### PR TITLE
Change ret type of binding constructor to interface

### DIFF
--- a/bindgen/template/go.tmpl
+++ b/bindgen/template/go.tmpl
@@ -30,6 +30,7 @@ type I{{toUpperCamel .Module}} interface {
 {{- end}}
   DevInspect() I{{toUpperCamel .Module}}DevInspect
   Encoder() {{toUpperCamel .Module}}Encoder
+	Bound() bind.IBoundContract
 }
 
 type I{{toUpperCamel .Module}}DevInspect interface {
@@ -64,7 +65,7 @@ type {{toUpperCamel .Module}}DevInspect struct {
 var _ I{{toUpperCamel .Module}} = (*{{toUpperCamel .Module}}Contract)(nil)
 var _ I{{toUpperCamel .Module}}DevInspect = (*{{toUpperCamel .Module}}DevInspect)(nil)
 
-func New{{toUpperCamel .Module}}(packageID string, client sui.ISuiAPI) (*{{toUpperCamel .Module}}Contract, error) {
+func New{{toUpperCamel .Module}}(packageID string, client sui.ISuiAPI) (I{{toUpperCamel .Module}}, error) {
 	contract, err := bind.NewBoundContract(packageID, "{{.Package}}", "{{.Module}}", client)
 	if err != nil {
 		return nil, err
@@ -76,6 +77,10 @@ func New{{toUpperCamel .Module}}(packageID string, client sui.ISuiAPI) (*{{toUpp
 	}
 	c.devInspect = &{{toUpperCamel .Module}}DevInspect{contract: c}
 	return c, nil
+}
+
+func (c *{{toUpperCamel .Module}}Contract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *{{toUpperCamel .Module}}Contract) Encoder() {{toUpperCamel .Module}}Encoder {

--- a/bindings/bind/call.go
+++ b/bindings/bind/call.go
@@ -18,6 +18,17 @@ const (
 	DefaultGasBudget uint64 = 10_000_000
 )
 
+type IBoundContract interface {
+	GetPackageID() string
+	GetPackageName() string
+	GetModuleName() string
+	AppendPTB(ctx context.Context, opts *CallOpts, ptb *transaction.Transaction, encoded *EncodedCall) (*transaction.Argument, error)
+	Call(ctx context.Context, opts *CallOpts, encoded *EncodedCall) ([]any, error)
+	ExecuteTransaction(ctx context.Context, opts *CallOpts, encoded *EncodedCall) (*models.SuiTransactionBlockResponse, error)
+}
+
+var _ IBoundContract = (*BoundContract)(nil)
+
 type BoundContract struct {
 	packageID   string
 	packageName string

--- a/bindings/generated/ccip/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/generated/ccip/ccip/fee_quoter/fee_quoter.go
@@ -47,6 +47,7 @@ type IFeeQuoter interface {
 	McmsEntrypoint(ctx context.Context, opts *bind.CallOpts, ref bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IFeeQuoterDevInspect
 	Encoder() FeeQuoterEncoder
+	Bound() bind.IBoundContract
 }
 
 type IFeeQuoterDevInspect interface {
@@ -136,7 +137,7 @@ type FeeQuoterDevInspect struct {
 var _ IFeeQuoter = (*FeeQuoterContract)(nil)
 var _ IFeeQuoterDevInspect = (*FeeQuoterDevInspect)(nil)
 
-func NewFeeQuoter(packageID string, client sui.ISuiAPI) (*FeeQuoterContract, error) {
+func NewFeeQuoter(packageID string, client sui.ISuiAPI) (IFeeQuoter, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip", "fee_quoter", client)
 	if err != nil {
 		return nil, err
@@ -148,6 +149,10 @@ func NewFeeQuoter(packageID string, client sui.ISuiAPI) (*FeeQuoterContract, err
 	}
 	c.devInspect = &FeeQuoterDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *FeeQuoterContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *FeeQuoterContract) Encoder() FeeQuoterEncoder {

--- a/bindings/generated/ccip/ccip/nonce_manager/nonce_manager.go
+++ b/bindings/generated/ccip/ccip/nonce_manager/nonce_manager.go
@@ -26,6 +26,7 @@ type INonceManager interface {
 	GetIncrementedOutboundNonce(ctx context.Context, opts *bind.CallOpts, ref bind.Object, param bind.Object, destChainSelector uint64, sender string) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() INonceManagerDevInspect
 	Encoder() NonceManagerEncoder
+	Bound() bind.IBoundContract
 }
 
 type INonceManagerDevInspect interface {
@@ -58,7 +59,7 @@ type NonceManagerDevInspect struct {
 var _ INonceManager = (*NonceManagerContract)(nil)
 var _ INonceManagerDevInspect = (*NonceManagerDevInspect)(nil)
 
-func NewNonceManager(packageID string, client sui.ISuiAPI) (*NonceManagerContract, error) {
+func NewNonceManager(packageID string, client sui.ISuiAPI) (INonceManager, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip", "nonce_manager", client)
 	if err != nil {
 		return nil, err
@@ -70,6 +71,10 @@ func NewNonceManager(packageID string, client sui.ISuiAPI) (*NonceManagerContrac
 	}
 	c.devInspect = &NonceManagerDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *NonceManagerContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *NonceManagerContract) Encoder() NonceManagerEncoder {

--- a/bindings/generated/ccip/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/generated/ccip/ccip/receiver_registry/receiver_registry.go
@@ -30,6 +30,7 @@ type IReceiverRegistry interface {
 	GetReceiverInfo(ctx context.Context, opts *bind.CallOpts, ref bind.Object, receiverPackageId string) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IReceiverRegistryDevInspect
 	Encoder() ReceiverRegistryEncoder
+	Bound() bind.IBoundContract
 }
 
 type IReceiverRegistryDevInspect interface {
@@ -72,7 +73,7 @@ type ReceiverRegistryDevInspect struct {
 var _ IReceiverRegistry = (*ReceiverRegistryContract)(nil)
 var _ IReceiverRegistryDevInspect = (*ReceiverRegistryDevInspect)(nil)
 
-func NewReceiverRegistry(packageID string, client sui.ISuiAPI) (*ReceiverRegistryContract, error) {
+func NewReceiverRegistry(packageID string, client sui.ISuiAPI) (IReceiverRegistry, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip", "receiver_registry", client)
 	if err != nil {
 		return nil, err
@@ -84,6 +85,10 @@ func NewReceiverRegistry(packageID string, client sui.ISuiAPI) (*ReceiverRegistr
 	}
 	c.devInspect = &ReceiverRegistryDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *ReceiverRegistryContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *ReceiverRegistryContract) Encoder() ReceiverRegistryEncoder {

--- a/bindings/generated/ccip/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/generated/ccip/ccip/rmn_remote/rmn_remote.go
@@ -38,6 +38,7 @@ type IRmnRemote interface {
 	IsCursedU128(ctx context.Context, opts *bind.CallOpts, ref bind.Object, subjectValue *big.Int) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IRmnRemoteDevInspect
 	Encoder() RmnRemoteEncoder
+	Bound() bind.IBoundContract
 }
 
 type IRmnRemoteDevInspect interface {
@@ -101,7 +102,7 @@ type RmnRemoteDevInspect struct {
 var _ IRmnRemote = (*RmnRemoteContract)(nil)
 var _ IRmnRemoteDevInspect = (*RmnRemoteDevInspect)(nil)
 
-func NewRmnRemote(packageID string, client sui.ISuiAPI) (*RmnRemoteContract, error) {
+func NewRmnRemote(packageID string, client sui.ISuiAPI) (IRmnRemote, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip", "rmn_remote", client)
 	if err != nil {
 		return nil, err
@@ -113,6 +114,10 @@ func NewRmnRemote(packageID string, client sui.ISuiAPI) (*RmnRemoteContract, err
 	}
 	c.devInspect = &RmnRemoteDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *RmnRemoteContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *RmnRemoteContract) Encoder() RmnRemoteEncoder {

--- a/bindings/generated/ccip/ccip/state_object/state_object.go
+++ b/bindings/generated/ccip/ccip/state_object/state_object.go
@@ -39,6 +39,7 @@ type IStateObject interface {
 	McmsProofEntrypoint(ctx context.Context, opts *bind.CallOpts, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IStateObjectDevInspect
 	Encoder() StateObjectEncoder
+	Bound() bind.IBoundContract
 }
 
 type IStateObjectDevInspect interface {
@@ -105,7 +106,7 @@ type StateObjectDevInspect struct {
 var _ IStateObject = (*StateObjectContract)(nil)
 var _ IStateObjectDevInspect = (*StateObjectDevInspect)(nil)
 
-func NewStateObject(packageID string, client sui.ISuiAPI) (*StateObjectContract, error) {
+func NewStateObject(packageID string, client sui.ISuiAPI) (IStateObject, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip", "state_object", client)
 	if err != nil {
 		return nil, err
@@ -117,6 +118,10 @@ func NewStateObject(packageID string, client sui.ISuiAPI) (*StateObjectContract,
 	}
 	c.devInspect = &StateObjectDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *StateObjectContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *StateObjectContract) Encoder() StateObjectEncoder {

--- a/bindings/generated/ccip/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/generated/ccip/ccip/token_admin_registry/token_admin_registry.go
@@ -37,6 +37,7 @@ type ITokenAdminRegistry interface {
 	IsAdministrator(ctx context.Context, opts *bind.CallOpts, ref bind.Object, coinMetadataAddress string, administrator string) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() ITokenAdminRegistryDevInspect
 	Encoder() TokenAdminRegistryEncoder
+	Bound() bind.IBoundContract
 }
 
 type ITokenAdminRegistryDevInspect interface {
@@ -96,7 +97,7 @@ type TokenAdminRegistryDevInspect struct {
 var _ ITokenAdminRegistry = (*TokenAdminRegistryContract)(nil)
 var _ ITokenAdminRegistryDevInspect = (*TokenAdminRegistryDevInspect)(nil)
 
-func NewTokenAdminRegistry(packageID string, client sui.ISuiAPI) (*TokenAdminRegistryContract, error) {
+func NewTokenAdminRegistry(packageID string, client sui.ISuiAPI) (ITokenAdminRegistry, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip", "token_admin_registry", client)
 	if err != nil {
 		return nil, err
@@ -108,6 +109,10 @@ func NewTokenAdminRegistry(packageID string, client sui.ISuiAPI) (*TokenAdminReg
 	}
 	c.devInspect = &TokenAdminRegistryDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *TokenAdminRegistryContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *TokenAdminRegistryContract) Encoder() TokenAdminRegistryEncoder {

--- a/bindings/generated/ccip/ccip_dummy_receiver/ccip_dummy_receiver/dummy_receiver.go
+++ b/bindings/generated/ccip/ccip_dummy_receiver/ccip_dummy_receiver/dummy_receiver.go
@@ -33,6 +33,7 @@ type IDummyReceiver interface {
 	CcipReceive(ctx context.Context, opts *bind.CallOpts, expectedMessageId []byte, ref bind.Object, message bind.Object, param bind.Object, state bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IDummyReceiverDevInspect
 	Encoder() DummyReceiverEncoder
+	Bound() bind.IBoundContract
 }
 
 type IDummyReceiverDevInspect interface {
@@ -83,7 +84,7 @@ type DummyReceiverDevInspect struct {
 var _ IDummyReceiver = (*DummyReceiverContract)(nil)
 var _ IDummyReceiverDevInspect = (*DummyReceiverDevInspect)(nil)
 
-func NewDummyReceiver(packageID string, client sui.ISuiAPI) (*DummyReceiverContract, error) {
+func NewDummyReceiver(packageID string, client sui.ISuiAPI) (IDummyReceiver, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip_dummy_receiver", "dummy_receiver", client)
 	if err != nil {
 		return nil, err
@@ -95,6 +96,10 @@ func NewDummyReceiver(packageID string, client sui.ISuiAPI) (*DummyReceiverContr
 	}
 	c.devInspect = &DummyReceiverDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *DummyReceiverContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *DummyReceiverContract) Encoder() DummyReceiverEncoder {

--- a/bindings/generated/ccip/ccip_offramp/offramp/offramp.go
+++ b/bindings/generated/ccip/ccip_offramp/offramp/offramp.go
@@ -59,6 +59,7 @@ type IOfframp interface {
 	McmsEntrypoint(ctx context.Context, opts *bind.CallOpts, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IOfframpDevInspect
 	Encoder() OfframpEncoder
+	Bound() bind.IBoundContract
 }
 
 type IOfframpDevInspect interface {
@@ -177,7 +178,7 @@ type OfframpDevInspect struct {
 var _ IOfframp = (*OfframpContract)(nil)
 var _ IOfframpDevInspect = (*OfframpDevInspect)(nil)
 
-func NewOfframp(packageID string, client sui.ISuiAPI) (*OfframpContract, error) {
+func NewOfframp(packageID string, client sui.ISuiAPI) (IOfframp, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip_offramp", "offramp", client)
 	if err != nil {
 		return nil, err
@@ -189,6 +190,10 @@ func NewOfframp(packageID string, client sui.ISuiAPI) (*OfframpContract, error) 
 	}
 	c.devInspect = &OfframpDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *OfframpContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *OfframpContract) Encoder() OfframpEncoder {

--- a/bindings/generated/ccip/ccip_onramp/onramp/onramp.go
+++ b/bindings/generated/ccip/ccip_onramp/onramp/onramp.go
@@ -56,6 +56,7 @@ type IOnramp interface {
 	McmsEntrypoint(ctx context.Context, opts *bind.CallOpts, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IOnrampDevInspect
 	Encoder() OnrampEncoder
+	Bound() bind.IBoundContract
 }
 
 type IOnrampDevInspect interface {
@@ -165,7 +166,7 @@ type OnrampDevInspect struct {
 var _ IOnramp = (*OnrampContract)(nil)
 var _ IOnrampDevInspect = (*OnrampDevInspect)(nil)
 
-func NewOnramp(packageID string, client sui.ISuiAPI) (*OnrampContract, error) {
+func NewOnramp(packageID string, client sui.ISuiAPI) (IOnramp, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip_onramp", "onramp", client)
 	if err != nil {
 		return nil, err
@@ -177,6 +178,10 @@ func NewOnramp(packageID string, client sui.ISuiAPI) (*OnrampContract, error) {
 	}
 	c.devInspect = &OnrampDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *OnrampContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *OnrampContract) Encoder() OnrampEncoder {

--- a/bindings/generated/ccip/ccip_router/router.go
+++ b/bindings/generated/ccip/ccip_router/router.go
@@ -42,6 +42,7 @@ type IRouter interface {
 	McmsEntrypoint(ctx context.Context, opts *bind.CallOpts, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IRouterDevInspect
 	Encoder() RouterEncoder
+	Bound() bind.IBoundContract
 }
 
 type IRouterDevInspect interface {
@@ -114,7 +115,7 @@ type RouterDevInspect struct {
 var _ IRouter = (*RouterContract)(nil)
 var _ IRouterDevInspect = (*RouterDevInspect)(nil)
 
-func NewRouter(packageID string, client sui.ISuiAPI) (*RouterContract, error) {
+func NewRouter(packageID string, client sui.ISuiAPI) (IRouter, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip_router", "router", client)
 	if err != nil {
 		return nil, err
@@ -126,6 +127,10 @@ func NewRouter(packageID string, client sui.ISuiAPI) (*RouterContract, error) {
 	}
 	c.devInspect = &RouterDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *RouterContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *RouterContract) Encoder() RouterEncoder {

--- a/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool.go
@@ -57,6 +57,7 @@ type IBurnMintTokenPool interface {
 	McmsEntrypoint(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IBurnMintTokenPoolDevInspect
 	Encoder() BurnMintTokenPoolEncoder
+	Bound() bind.IBoundContract
 }
 
 type IBurnMintTokenPoolDevInspect interface {
@@ -164,7 +165,7 @@ type BurnMintTokenPoolDevInspect struct {
 var _ IBurnMintTokenPool = (*BurnMintTokenPoolContract)(nil)
 var _ IBurnMintTokenPoolDevInspect = (*BurnMintTokenPoolDevInspect)(nil)
 
-func NewBurnMintTokenPool(packageID string, client sui.ISuiAPI) (*BurnMintTokenPoolContract, error) {
+func NewBurnMintTokenPool(packageID string, client sui.ISuiAPI) (IBurnMintTokenPool, error) {
 	contract, err := bind.NewBoundContract(packageID, "burn_mint_token_pool", "burn_mint_token_pool", client)
 	if err != nil {
 		return nil, err
@@ -176,6 +177,10 @@ func NewBurnMintTokenPool(packageID string, client sui.ISuiAPI) (*BurnMintTokenP
 	}
 	c.devInspect = &BurnMintTokenPoolDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *BurnMintTokenPoolContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *BurnMintTokenPoolContract) Encoder() BurnMintTokenPoolEncoder {

--- a/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool/lock_release_token_pool.go
@@ -62,6 +62,7 @@ type ILockReleaseTokenPool interface {
 	DestroyTokenPool(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, ownerCap bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() ILockReleaseTokenPoolDevInspect
 	Encoder() LockReleaseTokenPoolEncoder
+	Bound() bind.IBoundContract
 }
 
 type ILockReleaseTokenPoolDevInspect interface {
@@ -182,7 +183,7 @@ type LockReleaseTokenPoolDevInspect struct {
 var _ ILockReleaseTokenPool = (*LockReleaseTokenPoolContract)(nil)
 var _ ILockReleaseTokenPoolDevInspect = (*LockReleaseTokenPoolDevInspect)(nil)
 
-func NewLockReleaseTokenPool(packageID string, client sui.ISuiAPI) (*LockReleaseTokenPoolContract, error) {
+func NewLockReleaseTokenPool(packageID string, client sui.ISuiAPI) (ILockReleaseTokenPool, error) {
 	contract, err := bind.NewBoundContract(packageID, "lock_release_token_pool", "lock_release_token_pool", client)
 	if err != nil {
 		return nil, err
@@ -194,6 +195,10 @@ func NewLockReleaseTokenPool(packageID string, client sui.ISuiAPI) (*LockRelease
 	}
 	c.devInspect = &LockReleaseTokenPoolDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *LockReleaseTokenPoolContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *LockReleaseTokenPoolContract) Encoder() LockReleaseTokenPoolEncoder {

--- a/bindings/generated/ccip/ccip_token_pools/managed_token_pool/managed_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/managed_token_pool/managed_token_pool.go
@@ -57,6 +57,7 @@ type IManagedTokenPool interface {
 	DestroyTokenPool(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, ownerCap bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IManagedTokenPoolDevInspect
 	Encoder() ManagedTokenPoolEncoder
+	Bound() bind.IBoundContract
 }
 
 type IManagedTokenPoolDevInspect interface {
@@ -164,7 +165,7 @@ type ManagedTokenPoolDevInspect struct {
 var _ IManagedTokenPool = (*ManagedTokenPoolContract)(nil)
 var _ IManagedTokenPoolDevInspect = (*ManagedTokenPoolDevInspect)(nil)
 
-func NewManagedTokenPool(packageID string, client sui.ISuiAPI) (*ManagedTokenPoolContract, error) {
+func NewManagedTokenPool(packageID string, client sui.ISuiAPI) (IManagedTokenPool, error) {
 	contract, err := bind.NewBoundContract(packageID, "managed_token_pool", "managed_token_pool", client)
 	if err != nil {
 		return nil, err
@@ -176,6 +177,10 @@ func NewManagedTokenPool(packageID string, client sui.ISuiAPI) (*ManagedTokenPoo
 	}
 	c.devInspect = &ManagedTokenPoolDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *ManagedTokenPoolContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *ManagedTokenPoolContract) Encoder() ManagedTokenPoolEncoder {

--- a/bindings/generated/ccip/ccip_token_pools/token_pool/token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/token_pool/token_pool.go
@@ -51,6 +51,7 @@ type ITokenPool interface {
 	DestroyTokenPool(ctx context.Context, opts *bind.CallOpts, state TokenPoolState) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() ITokenPoolDevInspect
 	Encoder() TokenPoolEncoder
+	Bound() bind.IBoundContract
 }
 
 type ITokenPoolDevInspect interface {
@@ -146,7 +147,7 @@ type TokenPoolDevInspect struct {
 var _ ITokenPool = (*TokenPoolContract)(nil)
 var _ ITokenPoolDevInspect = (*TokenPoolDevInspect)(nil)
 
-func NewTokenPool(packageID string, client sui.ISuiAPI) (*TokenPoolContract, error) {
+func NewTokenPool(packageID string, client sui.ISuiAPI) (ITokenPool, error) {
 	contract, err := bind.NewBoundContract(packageID, "ccip_token_pool", "token_pool", client)
 	if err != nil {
 		return nil, err
@@ -158,6 +159,10 @@ func NewTokenPool(packageID string, client sui.ISuiAPI) (*TokenPoolContract, err
 	}
 	c.devInspect = &TokenPoolDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *TokenPoolContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *TokenPoolContract) Encoder() TokenPoolEncoder {

--- a/bindings/generated/ccip/managed_token/managed_token/managed_token.go
+++ b/bindings/generated/ccip/managed_token/managed_token/managed_token.go
@@ -54,6 +54,7 @@ type IManagedToken interface {
 	McmsEntrypoint(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, denyList bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IManagedTokenDevInspect
 	Encoder() ManagedTokenEncoder
+	Bound() bind.IBoundContract
 }
 
 type IManagedTokenDevInspect interface {
@@ -152,7 +153,7 @@ type ManagedTokenDevInspect struct {
 var _ IManagedToken = (*ManagedTokenContract)(nil)
 var _ IManagedTokenDevInspect = (*ManagedTokenDevInspect)(nil)
 
-func NewManagedToken(packageID string, client sui.ISuiAPI) (*ManagedTokenContract, error) {
+func NewManagedToken(packageID string, client sui.ISuiAPI) (IManagedToken, error) {
 	contract, err := bind.NewBoundContract(packageID, "managed_token", "managed_token", client)
 	if err != nil {
 		return nil, err
@@ -164,6 +165,10 @@ func NewManagedToken(packageID string, client sui.ISuiAPI) (*ManagedTokenContrac
 	}
 	c.devInspect = &ManagedTokenDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *ManagedTokenContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *ManagedTokenContract) Encoder() ManagedTokenEncoder {

--- a/bindings/generated/ccip/mock_eth_token/mock_eth_token/mock_eth_token.go
+++ b/bindings/generated/ccip/mock_eth_token/mock_eth_token/mock_eth_token.go
@@ -24,6 +24,7 @@ type IMockEthToken interface {
 	Mint(ctx context.Context, opts *bind.CallOpts, treasuryCap bind.Object, amount uint64) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMockEthTokenDevInspect
 	Encoder() MockEthTokenEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMockEthTokenDevInspect interface {
@@ -49,7 +50,7 @@ type MockEthTokenDevInspect struct {
 var _ IMockEthToken = (*MockEthTokenContract)(nil)
 var _ IMockEthTokenDevInspect = (*MockEthTokenDevInspect)(nil)
 
-func NewMockEthToken(packageID string, client sui.ISuiAPI) (*MockEthTokenContract, error) {
+func NewMockEthToken(packageID string, client sui.ISuiAPI) (IMockEthToken, error) {
 	contract, err := bind.NewBoundContract(packageID, "mock_eth_token", "mock_eth_token", client)
 	if err != nil {
 		return nil, err
@@ -61,6 +62,10 @@ func NewMockEthToken(packageID string, client sui.ISuiAPI) (*MockEthTokenContrac
 	}
 	c.devInspect = &MockEthTokenDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *MockEthTokenContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *MockEthTokenContract) Encoder() MockEthTokenEncoder {

--- a/bindings/generated/ccip/mock_link_token/mock_link_token/mock_link_token.go
+++ b/bindings/generated/ccip/mock_link_token/mock_link_token/mock_link_token.go
@@ -24,6 +24,7 @@ type IMockLinkToken interface {
 	Mint(ctx context.Context, opts *bind.CallOpts, treasuryCap bind.Object, amount uint64) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMockLinkTokenDevInspect
 	Encoder() MockLinkTokenEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMockLinkTokenDevInspect interface {
@@ -49,7 +50,7 @@ type MockLinkTokenDevInspect struct {
 var _ IMockLinkToken = (*MockLinkTokenContract)(nil)
 var _ IMockLinkTokenDevInspect = (*MockLinkTokenDevInspect)(nil)
 
-func NewMockLinkToken(packageID string, client sui.ISuiAPI) (*MockLinkTokenContract, error) {
+func NewMockLinkToken(packageID string, client sui.ISuiAPI) (IMockLinkToken, error) {
 	contract, err := bind.NewBoundContract(packageID, "mock_link_token", "mock_link_token", client)
 	if err != nil {
 		return nil, err
@@ -61,6 +62,10 @@ func NewMockLinkToken(packageID string, client sui.ISuiAPI) (*MockLinkTokenContr
 	}
 	c.devInspect = &MockLinkTokenDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *MockLinkTokenContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *MockLinkTokenContract) Encoder() MockLinkTokenEncoder {

--- a/bindings/generated/link/link/link.go
+++ b/bindings/generated/link/link/link.go
@@ -24,6 +24,7 @@ type ILink interface {
 	Mint(ctx context.Context, opts *bind.CallOpts, treasuryCap bind.Object, amount uint64) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() ILinkDevInspect
 	Encoder() LinkEncoder
+	Bound() bind.IBoundContract
 }
 
 type ILinkDevInspect interface {
@@ -50,7 +51,7 @@ type LinkDevInspect struct {
 var _ ILink = (*LinkContract)(nil)
 var _ ILinkDevInspect = (*LinkDevInspect)(nil)
 
-func NewLink(packageID string, client sui.ISuiAPI) (*LinkContract, error) {
+func NewLink(packageID string, client sui.ISuiAPI) (ILink, error) {
 	contract, err := bind.NewBoundContract(packageID, "link", "link", client)
 	if err != nil {
 		return nil, err
@@ -62,6 +63,10 @@ func NewLink(packageID string, client sui.ISuiAPI) (*LinkContract, error) {
 	}
 	c.devInspect = &LinkDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *LinkContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *LinkContract) Encoder() LinkEncoder {

--- a/bindings/generated/mcms/mcms/mcms.go
+++ b/bindings/generated/mcms/mcms/mcms.go
@@ -86,6 +86,7 @@ type IMcms interface {
 	Data(ctx context.Context, opts *bind.CallOpts, call Call) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMcmsDevInspect
 	Encoder() McmsEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMcmsDevInspect interface {
@@ -285,7 +286,7 @@ type McmsDevInspect struct {
 var _ IMcms = (*McmsContract)(nil)
 var _ IMcmsDevInspect = (*McmsDevInspect)(nil)
 
-func NewMcms(packageID string, client sui.ISuiAPI) (*McmsContract, error) {
+func NewMcms(packageID string, client sui.ISuiAPI) (IMcms, error) {
 	contract, err := bind.NewBoundContract(packageID, "mcms", "mcms", client)
 	if err != nil {
 		return nil, err
@@ -297,6 +298,10 @@ func NewMcms(packageID string, client sui.ISuiAPI) (*McmsContract, error) {
 	}
 	c.devInspect = &McmsDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *McmsContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *McmsContract) Encoder() McmsEncoder {

--- a/bindings/generated/mcms/mcms_account/mcms_account.go
+++ b/bindings/generated/mcms/mcms_account/mcms_account.go
@@ -31,6 +31,7 @@ type IMcmsAccount interface {
 	PendingTransferAccepted(ctx context.Context, opts *bind.CallOpts, state bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMcmsAccountDevInspect
 	Encoder() McmsAccountEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMcmsAccountDevInspect interface {
@@ -73,7 +74,7 @@ type McmsAccountDevInspect struct {
 var _ IMcmsAccount = (*McmsAccountContract)(nil)
 var _ IMcmsAccountDevInspect = (*McmsAccountDevInspect)(nil)
 
-func NewMcmsAccount(packageID string, client sui.ISuiAPI) (*McmsAccountContract, error) {
+func NewMcmsAccount(packageID string, client sui.ISuiAPI) (IMcmsAccount, error) {
 	contract, err := bind.NewBoundContract(packageID, "mcms", "mcms_account", client)
 	if err != nil {
 		return nil, err
@@ -85,6 +86,10 @@ func NewMcmsAccount(packageID string, client sui.ISuiAPI) (*McmsAccountContract,
 	}
 	c.devInspect = &McmsAccountDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *McmsAccountContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *McmsAccountContract) Encoder() McmsAccountEncoder {

--- a/bindings/generated/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/generated/mcms/mcms_deployer/mcms_deployer.go
@@ -25,6 +25,7 @@ type IMcmsDeployer interface {
 	CommitUpgrade(ctx context.Context, opts *bind.CallOpts, state bind.Object, receipt bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMcmsDeployerDevInspect
 	Encoder() McmsDeployerEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMcmsDeployerDevInspect interface {
@@ -53,7 +54,7 @@ type McmsDeployerDevInspect struct {
 var _ IMcmsDeployer = (*McmsDeployerContract)(nil)
 var _ IMcmsDeployerDevInspect = (*McmsDeployerDevInspect)(nil)
 
-func NewMcmsDeployer(packageID string, client sui.ISuiAPI) (*McmsDeployerContract, error) {
+func NewMcmsDeployer(packageID string, client sui.ISuiAPI) (IMcmsDeployer, error) {
 	contract, err := bind.NewBoundContract(packageID, "mcms", "mcms_deployer", client)
 	if err != nil {
 		return nil, err
@@ -65,6 +66,10 @@ func NewMcmsDeployer(packageID string, client sui.ISuiAPI) (*McmsDeployerContrac
 	}
 	c.devInspect = &McmsDeployerDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *McmsDeployerContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *McmsDeployerContract) Encoder() McmsDeployerEncoder {

--- a/bindings/generated/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/generated/mcms/mcms_registry/mcms_registry.go
@@ -36,6 +36,7 @@ type IMcmsRegistry interface {
 	CreateMcmsProof(ctx context.Context, opts *bind.CallOpts) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMcmsRegistryDevInspect
 	Encoder() McmsRegistryEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMcmsRegistryDevInspect interface {
@@ -98,7 +99,7 @@ type McmsRegistryDevInspect struct {
 var _ IMcmsRegistry = (*McmsRegistryContract)(nil)
 var _ IMcmsRegistryDevInspect = (*McmsRegistryDevInspect)(nil)
 
-func NewMcmsRegistry(packageID string, client sui.ISuiAPI) (*McmsRegistryContract, error) {
+func NewMcmsRegistry(packageID string, client sui.ISuiAPI) (IMcmsRegistry, error) {
 	contract, err := bind.NewBoundContract(packageID, "mcms", "mcms_registry", client)
 	if err != nil {
 		return nil, err
@@ -110,6 +111,10 @@ func NewMcmsRegistry(packageID string, client sui.ISuiAPI) (*McmsRegistryContrac
 	}
 	c.devInspect = &McmsRegistryDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *McmsRegistryContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *McmsRegistryContract) Encoder() McmsRegistryEncoder {

--- a/bindings/generated/mcms/mcms_user/mcms_user.go
+++ b/bindings/generated/mcms/mcms_user/mcms_user.go
@@ -33,6 +33,7 @@ type IMcmsUser interface {
 	GetFieldD(ctx context.Context, opts *bind.CallOpts, userData bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IMcmsUserDevInspect
 	Encoder() McmsUserEncoder
+	Bound() bind.IBoundContract
 }
 
 type IMcmsUserDevInspect interface {
@@ -82,7 +83,7 @@ type McmsUserDevInspect struct {
 var _ IMcmsUser = (*McmsUserContract)(nil)
 var _ IMcmsUserDevInspect = (*McmsUserDevInspect)(nil)
 
-func NewMcmsUser(packageID string, client sui.ISuiAPI) (*McmsUserContract, error) {
+func NewMcmsUser(packageID string, client sui.ISuiAPI) (IMcmsUser, error) {
 	contract, err := bind.NewBoundContract(packageID, "mcms_test", "mcms_user", client)
 	if err != nil {
 		return nil, err
@@ -94,6 +95,10 @@ func NewMcmsUser(packageID string, client sui.ISuiAPI) (*McmsUserContract, error
 	}
 	c.devInspect = &McmsUserDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *McmsUserContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *McmsUserContract) Encoder() McmsUserEncoder {

--- a/bindings/generated/test/complex/complex.go
+++ b/bindings/generated/test/complex/complex.go
@@ -32,6 +32,7 @@ type IComplex interface {
 	FlattenString(ctx context.Context, opts *bind.CallOpts, input [][]string) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IComplexDevInspect
 	Encoder() ComplexEncoder
+	Bound() bind.IBoundContract
 }
 
 type IComplexDevInspect interface {
@@ -82,7 +83,7 @@ type ComplexDevInspect struct {
 var _ IComplex = (*ComplexContract)(nil)
 var _ IComplexDevInspect = (*ComplexDevInspect)(nil)
 
-func NewComplex(packageID string, client sui.ISuiAPI) (*ComplexContract, error) {
+func NewComplex(packageID string, client sui.ISuiAPI) (IComplex, error) {
 	contract, err := bind.NewBoundContract(packageID, "test", "complex", client)
 	if err != nil {
 		return nil, err
@@ -94,6 +95,10 @@ func NewComplex(packageID string, client sui.ISuiAPI) (*ComplexContract, error) 
 	}
 	c.devInspect = &ComplexDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *ComplexContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *ComplexContract) Encoder() ComplexEncoder {

--- a/bindings/generated/test/counter/counter.go
+++ b/bindings/generated/test/counter/counter.go
@@ -48,6 +48,7 @@ type ICounter interface {
 	GetVectorOfVectorsOfU8(ctx context.Context, opts *bind.CallOpts) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() ICounterDevInspect
 	Encoder() CounterEncoder
+	Bound() bind.IBoundContract
 }
 
 type ICounterDevInspect interface {
@@ -139,7 +140,7 @@ type CounterDevInspect struct {
 var _ ICounter = (*CounterContract)(nil)
 var _ ICounterDevInspect = (*CounterDevInspect)(nil)
 
-func NewCounter(packageID string, client sui.ISuiAPI) (*CounterContract, error) {
+func NewCounter(packageID string, client sui.ISuiAPI) (ICounter, error) {
 	contract, err := bind.NewBoundContract(packageID, "test", "counter", client)
 	if err != nil {
 		return nil, err
@@ -151,6 +152,10 @@ func NewCounter(packageID string, client sui.ISuiAPI) (*CounterContract, error) 
 	}
 	c.devInspect = &CounterDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *CounterContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *CounterContract) Encoder() CounterEncoder {

--- a/bindings/generated/test/generics/generics.go
+++ b/bindings/generated/test/generics/generics.go
@@ -31,6 +31,7 @@ type IGenerics interface {
 	CreateAndTransferBox(ctx context.Context, opts *bind.CallOpts, typeArgs []string, value bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IGenericsDevInspect
 	Encoder() GenericsEncoder
+	Bound() bind.IBoundContract
 }
 
 type IGenericsDevInspect interface {
@@ -75,7 +76,7 @@ type GenericsDevInspect struct {
 var _ IGenerics = (*GenericsContract)(nil)
 var _ IGenericsDevInspect = (*GenericsDevInspect)(nil)
 
-func NewGenerics(packageID string, client sui.ISuiAPI) (*GenericsContract, error) {
+func NewGenerics(packageID string, client sui.ISuiAPI) (IGenerics, error) {
 	contract, err := bind.NewBoundContract(packageID, "test", "generics", client)
 	if err != nil {
 		return nil, err
@@ -87,6 +88,10 @@ func NewGenerics(packageID string, client sui.ISuiAPI) (*GenericsContract, error
 	}
 	c.devInspect = &GenericsDevInspect{contract: c}
 	return c, nil
+}
+
+func (c *GenericsContract) Bound() bind.IBoundContract {
+	return c.BoundContract
 }
 
 func (c *GenericsContract) Encoder() GenericsEncoder {


### PR DESCRIPTION
### What
- Constructing contract bindings return an Interface instead of the contract struct

### Why
Gives more flexibility on using and testing bindings
 