### PR TITLE
Refactor mcms entrypoint fns to deserialize with ownercap

### DIFF
--- a/bindings/generated/ccip/ccip_token_pools/managed_token_pool/managed_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/managed_token_pool/managed_token_pool.go
@@ -62,7 +62,6 @@ type IManagedTokenPool interface {
 	McmsSetChainRateLimiterConfig(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object, clock bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DestroyTokenPool(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, ownerCap bind.Object) (*models.SuiTransactionBlockResponse, error)
 	McmsTransferOwnership(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
-	McmsMcmsAcceptOwnership(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	McmsExecuteOwnershipTransfer(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error)
 	DevInspect() IManagedTokenPoolDevInspect
 	Encoder() ManagedTokenPoolEncoder
@@ -173,8 +172,6 @@ type ManagedTokenPoolEncoder interface {
 	DestroyTokenPoolWithArgs(typeArgs []string, args ...any) (*bind.EncodedCall, error)
 	McmsTransferOwnership(typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*bind.EncodedCall, error)
 	McmsTransferOwnershipWithArgs(typeArgs []string, args ...any) (*bind.EncodedCall, error)
-	McmsMcmsAcceptOwnership(typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*bind.EncodedCall, error)
-	McmsMcmsAcceptOwnershipWithArgs(typeArgs []string, args ...any) (*bind.EncodedCall, error)
 	McmsExecuteOwnershipTransfer(typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*bind.EncodedCall, error)
 	McmsExecuteOwnershipTransferWithArgs(typeArgs []string, args ...any) (*bind.EncodedCall, error)
 }
@@ -671,16 +668,6 @@ func (c *ManagedTokenPoolContract) DestroyTokenPool(ctx context.Context, opts *b
 // McmsTransferOwnership executes the mcms_transfer_ownership Move function.
 func (c *ManagedTokenPoolContract) McmsTransferOwnership(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error) {
 	encoded, err := c.managedTokenPoolEncoder.McmsTransferOwnership(typeArgs, state, registry, params)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode function call: %w", err)
-	}
-
-	return c.ExecuteTransaction(ctx, opts, encoded)
-}
-
-// McmsMcmsAcceptOwnership executes the mcms_mcms_accept_ownership Move function.
-func (c *ManagedTokenPoolContract) McmsMcmsAcceptOwnership(ctx context.Context, opts *bind.CallOpts, typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*models.SuiTransactionBlockResponse, error) {
-	encoded, err := c.managedTokenPoolEncoder.McmsMcmsAcceptOwnership(typeArgs, state, registry, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode function call: %w", err)
 	}
@@ -2627,42 +2614,6 @@ func (c managedTokenPoolEncoder) McmsTransferOwnershipWithArgs(typeArgs []string
 		"T",
 	}
 	return c.EncodeCallArgsWithGenerics("mcms_transfer_ownership", typeArgsList, typeParamsList, expectedParams, args, nil)
-}
-
-// McmsMcmsAcceptOwnership encodes a call to the mcms_mcms_accept_ownership Move function.
-func (c managedTokenPoolEncoder) McmsMcmsAcceptOwnership(typeArgs []string, state bind.Object, registry bind.Object, params bind.Object) (*bind.EncodedCall, error) {
-	typeArgsList := typeArgs
-	typeParamsList := []string{
-		"T",
-	}
-	return c.EncodeCallArgsWithGenerics("mcms_mcms_accept_ownership", typeArgsList, typeParamsList, []string{
-		"&mut ManagedTokenPoolState<T>",
-		"&mut Registry",
-		"ExecutingCallbackParams",
-	}, []any{
-		state,
-		registry,
-		params,
-	}, nil)
-}
-
-// McmsMcmsAcceptOwnershipWithArgs encodes a call to the mcms_mcms_accept_ownership Move function using arbitrary arguments.
-// This method allows passing both regular values and transaction.Argument values for PTB chaining.
-func (c managedTokenPoolEncoder) McmsMcmsAcceptOwnershipWithArgs(typeArgs []string, args ...any) (*bind.EncodedCall, error) {
-	expectedParams := []string{
-		"&mut ManagedTokenPoolState<T>",
-		"&mut Registry",
-		"ExecutingCallbackParams",
-	}
-
-	if len(args) != len(expectedParams) {
-		return nil, fmt.Errorf("expected %d arguments, got %d", len(expectedParams), len(args))
-	}
-	typeArgsList := typeArgs
-	typeParamsList := []string{
-		"T",
-	}
-	return c.EncodeCallArgsWithGenerics("mcms_mcms_accept_ownership", typeArgsList, typeParamsList, expectedParams, args, nil)
 }
 
 // McmsExecuteOwnershipTransfer encodes a call to the mcms_execute_ownership_transfer Move function.

--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -1614,7 +1614,7 @@ public fun mcms_apply_fee_token_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1646,7 +1646,7 @@ public fun mcms_apply_dest_chain_config_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1714,7 +1714,7 @@ public fun mcms_apply_token_transfer_fee_config_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1785,7 +1785,7 @@ public fun mcms_update_prices_with_owner_cap(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry), object::id_address(clock)],
+        vector[object::id_address(ref), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
 
@@ -1837,7 +1837,7 @@ public fun mcms_apply_premium_multiplier_wei_per_eth_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip/sources/rmn_remote.move
+++ b/contracts/ccip/ccip/sources/rmn_remote.move
@@ -488,7 +488,7 @@ public fun mcms_set_config(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -528,7 +528,7 @@ public fun mcms_curse(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -552,7 +552,7 @@ public fun mcms_curse_multiple(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -579,7 +579,7 @@ public fun mcms_uncurse(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -606,7 +606,7 @@ public fun mcms_uncurse_multiple(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip/sources/state_object.move
+++ b/contracts/ccip/ccip/sources/state_object.move
@@ -192,7 +192,7 @@ public fun mcms_transfer_ownership(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -217,7 +217,7 @@ public fun mcms_execute_ownership_transfer(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref), object::id_address(_owner_cap)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip/sources/token_admin_registry.move
+++ b/contracts/ccip/ccip/sources/token_admin_registry.move
@@ -594,7 +594,7 @@ public fun mcms_unregister_pool(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref)],
         &mut stream,
     );
 
@@ -619,7 +619,7 @@ public fun mcms_set_pool(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref)],
         &mut stream,
     );
 
@@ -666,7 +666,7 @@ public fun mcms_transfer_admin_role(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref)],
         &mut stream,
     );
 
@@ -697,7 +697,7 @@ public fun mcms_accept_admin_role(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(ref), object::id_address(registry)],
+        vector[object::id_address(ref)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip/tests/fee_quoter_mcms_test.move
+++ b/contracts/ccip/ccip/tests/fee_quoter_mcms_test.move
@@ -113,14 +113,15 @@ public fun test_mcms_apply_fee_token_updates() {
     let mut env = setup();
 
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
-    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     // Prepare data for mcms_apply_fee_token_updates
     let mut data = vector::empty<u8>();
     data.append(bcs::to_bytes(&object::id_address(&env.ref)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
     data.append(bcs::to_bytes(&vector<address>[])); // fee_tokens_to_remove
     data.append(bcs::to_bytes(&vector[TOKEN_1, TOKEN_2])); // fee_tokens_to_add
+
+    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip,
@@ -150,12 +151,11 @@ public fun test_mcms_apply_dest_chain_config_updates() {
     let mut env = setup();
 
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
-    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     // Prepare data for mcms_apply_dest_chain_config_updates
     let mut data = vector::empty<u8>();
     data.append(bcs::to_bytes(&object::id_address(&env.ref)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
     data.append(bcs::to_bytes(&DEST_CHAIN_SELECTOR_1)); // dest_chain_selector
     data.append(bcs::to_bytes(&true)); // is_enabled
     data.append(bcs::to_bytes(&(10 as u16))); // max_number_of_tokens_per_msg
@@ -176,6 +176,8 @@ public fun test_mcms_apply_dest_chain_config_updates() {
     data.append(bcs::to_bytes(&(1000000000000000000 as u64))); // gas_multiplier_wei_per_eth
     data.append(bcs::to_bytes(&(3600 as u32))); // gas_price_staleness_threshold
     data.append(bcs::to_bytes(&(100 as u32))); // network_fee_usd_cents
+
+    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip,
@@ -243,12 +245,11 @@ public fun test_mcms_apply_token_transfer_fee_config_updates() {
     let mut env = setup();
 
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
-    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     // Prepare data for mcms_apply_token_transfer_fee_config_updates
     let mut data = vector::empty<u8>();
     data.append(bcs::to_bytes(&object::id_address(&env.ref)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
     data.append(bcs::to_bytes(&DEST_CHAIN_SELECTOR_1)); // dest_chain_selector
     data.append(bcs::to_bytes(&vector[TOKEN_1, TOKEN_2])); // add_tokens
     data.append(bcs::to_bytes(&vector[25 as u32, 30 as u32])); // add_min_fee_usd_cents
@@ -258,6 +259,8 @@ public fun test_mcms_apply_token_transfer_fee_config_updates() {
     data.append(bcs::to_bytes(&vector[32 as u32, 64 as u32])); // add_dest_bytes_overhead
     data.append(bcs::to_bytes(&vector[true, true])); // add_is_enabled
     data.append(bcs::to_bytes(&vector<address>[])); // remove_tokens
+
+    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip,
@@ -324,14 +327,15 @@ public fun test_mcms_apply_premium_multiplier_wei_per_eth_updates() {
     let mut env = setup();
 
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
-    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     // Prepare data for mcms_apply_premium_multiplier_wei_per_eth_updates
     let mut data = vector::empty<u8>();
     data.append(bcs::to_bytes(&object::id_address(&env.ref)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
     data.append(bcs::to_bytes(&vector[TOKEN_1, TOKEN_2])); // tokens
     data.append(bcs::to_bytes(&vector[1100000000000000000 as u64, 1200000000000000000 as u64])); // premium_multiplier_wei_per_eth (110%, 120%)
+
+    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip,
@@ -362,7 +366,6 @@ public fun test_mcms_update_prices_with_owner_cap() {
     let mut env = setup();
 
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
-    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     // Set up clock with current timestamp for staleness validation
     let current_timestamp = 1000000000; // 1 billion ms
@@ -371,12 +374,14 @@ public fun test_mcms_update_prices_with_owner_cap() {
     // Prepare data for mcms_update_prices_with_owner_cap
     let mut data = vector::empty<u8>();
     data.append(bcs::to_bytes(&object::id_address(&env.ref)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
     data.append(bcs::to_bytes(&object::id_address(&env.clock)));
     data.append(bcs::to_bytes(&vector[TOKEN_1, TOKEN_2])); // source_tokens
     data.append(bcs::to_bytes(&vector[2000000000000000000 as u256, 500000000000000 as u256])); // source_usd_per_token (2 ETH, 0.0005 ETH in wei)
     data.append(bcs::to_bytes(&vector[DEST_CHAIN_SELECTOR_1])); // gas_dest_chain_selectors
     data.append(bcs::to_bytes(&vector[30000000 as u256])); // gas_usd_per_unit_gas (0.03 USD per gas unit)
+
+    transfer_ownership_to_mcms(&mut env, owner_cap);
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip,

--- a/contracts/ccip/ccip/tests/token_admin_registry_tests.move
+++ b/contracts/ccip/ccip/tests/token_admin_registry_tests.move
@@ -1264,7 +1264,6 @@ public fun test_mcms_accept_admin_role() {
         // Create MCMS callback params for accept (need to include object addresses first)
         let mut data = vector::empty<u8>();
         data.append(bcs::to_bytes(&object::id_address(&ref)));
-        data.append(bcs::to_bytes(&object::id_address(&registry)));
         data.append(bcs::to_bytes(&local_token));
 
         let params = mcms_registry::test_create_executing_callback_params(
@@ -1350,7 +1349,6 @@ public fun test_mcms_full_admin_transfer_flow() {
 
         let mut data = vector::empty<u8>();
         data.append(bcs::to_bytes(&object::id_address(&ref)));
-        data.append(bcs::to_bytes(&object::id_address(&registry)));
         data.append(bcs::to_bytes(&local_token));
 
         let params = mcms_registry::test_create_executing_callback_params(
@@ -1418,7 +1416,6 @@ public fun test_mcms_accept_admin_role_no_pending_transfer_fails() {
 
         let mut data = vector::empty<u8>();
         data.append(bcs::to_bytes(&object::id_address(&ref)));
-        data.append(bcs::to_bytes(&object::id_address(&registry)));
         data.append(bcs::to_bytes(&local_token));
 
         let params = mcms_registry::test_create_executing_callback_params(
@@ -1465,7 +1462,6 @@ public fun test_mcms_transfer_admin_role_token_not_registered_fails() {
 
         let mut data = vector::empty<u8>();
         data.append(bcs::to_bytes(&object::id_address(&ref)));
-        data.append(bcs::to_bytes(&object::id_address(&registry)));
         data.append(bcs::to_bytes(&@0x999)); // unregistered token
         data.append(bcs::to_bytes(&mcms));
 

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -1483,7 +1483,7 @@ public fun mcms_set_dynamic_config(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1509,7 +1509,7 @@ public fun mcms_apply_source_chain_config_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1558,7 +1558,7 @@ public fun mcms_set_ocr3_config(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1605,7 +1605,7 @@ public fun mcms_transfer_ownership(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1631,7 +1631,7 @@ public fun mcms_execute_ownership_transfer(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(_owner_cap), object::id_address(state)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip_onramp/sources/onramp.move
+++ b/contracts/ccip/ccip_onramp/sources/onramp.move
@@ -1146,7 +1146,7 @@ public fun mcms_set_dynamic_config(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1172,7 +1172,7 @@ public fun mcms_apply_dest_chain_config_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1216,7 +1216,7 @@ public fun mcms_apply_allowlist_updates(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1272,7 +1272,7 @@ public fun mcms_transfer_ownership(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1298,7 +1298,7 @@ public fun mcms_execute_ownership_transfer(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(_owner_cap), object::id_address(state)],
         &mut stream,
     );
 
@@ -1326,7 +1326,7 @@ public fun mcms_initialize(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -1378,7 +1378,7 @@ public fun mcms_withdraw_fee_tokens<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip_onramp/tests/onramp_mcms_test.move
+++ b/contracts/ccip/ccip_onramp/tests/onramp_mcms_test.move
@@ -142,6 +142,12 @@ public fun test_mcms_set_dynamic_config() {
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
     initialize_onramp(&mut env, &owner_cap, nonce_manager_cap, source_transfer_cap);
 
+    let mut data = vector::empty<u8>();
+    data.append(bcs::to_bytes(&object::id_address(&env.state)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
+    data.append(bcs::to_bytes(&@0x123));
+    data.append(bcs::to_bytes(&@0x456));
+
     // Initialize owner_cap with MCMS - 3 step transfer process
     transfer_to_mcms(
         &env.ref,
@@ -150,12 +156,6 @@ public fun test_mcms_set_dynamic_config() {
         owner_cap,
         env.scenario.ctx(),
     );
-
-    let mut data = vector::empty<u8>();
-    data.append(bcs::to_bytes(&object::id_address(&env.state)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
-    data.append(bcs::to_bytes(&@0x123));
-    data.append(bcs::to_bytes(&@0x456));
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip_onramp,
@@ -187,6 +187,14 @@ public fun test_mcms_apply_dest_chain_config_updates() {
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
     initialize_onramp(&mut env, &owner_cap, nonce_manager_cap, source_transfer_cap);
 
+    // Prepare data: state_address, registry_address, dest_chain_selectors, dest_chain_enabled, dest_chain_allowlist_enabled
+    let mut data = vector::empty<u8>();
+    data.append(bcs::to_bytes(&object::id_address(&env.state)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
+    data.append(bcs::to_bytes(&vector[DEST_CHAIN_SELECTOR_1, DEST_CHAIN_SELECTOR_2])); // dest_chain_selectors
+    data.append(bcs::to_bytes(&vector[true, false])); // dest_chain_enabled
+    data.append(bcs::to_bytes(&vector[false, true])); // dest_chain_allowlist_enabled
+
     // Initialize owner_cap with MCMS
     transfer_to_mcms(
         &env.ref,
@@ -195,14 +203,6 @@ public fun test_mcms_apply_dest_chain_config_updates() {
         owner_cap,
         env.scenario.ctx(),
     );
-
-    // Prepare data: state_address, registry_address, dest_chain_selectors, dest_chain_enabled, dest_chain_allowlist_enabled
-    let mut data = vector::empty<u8>();
-    data.append(bcs::to_bytes(&object::id_address(&env.state)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
-    data.append(bcs::to_bytes(&vector[DEST_CHAIN_SELECTOR_1, DEST_CHAIN_SELECTOR_2])); // dest_chain_selectors
-    data.append(bcs::to_bytes(&vector[true, false])); // dest_chain_enabled
-    data.append(bcs::to_bytes(&vector[false, true])); // dest_chain_allowlist_enabled
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip_onramp,
@@ -246,17 +246,9 @@ public fun test_mcms_apply_allowlist_updates() {
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
     initialize_onramp(&mut env, &owner_cap, nonce_manager_cap, source_transfer_cap);
 
-    transfer_to_mcms(
-        &env.ref,
-        &mut env.state,
-        &mut env.registry,
-        owner_cap,
-        env.scenario.ctx(),
-    );
-
     let mut data = vector::empty<u8>();
     data.append(bcs::to_bytes(&object::id_address(&env.state)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
     data.append(bcs::to_bytes(&vector[DEST_CHAIN_SELECTOR_1, DEST_CHAIN_SELECTOR_2])); // dest_chain_selectors
     data.append(bcs::to_bytes(&vector[true, true])); // dest_chain_allowlist_enabled
     data.append(
@@ -265,6 +257,14 @@ public fun test_mcms_apply_allowlist_updates() {
         ),
     ); // dest_chain_add_allowed_senders
     data.append(bcs::to_bytes(&vector[vector<address>[], vector<address>[]])); // dest_chain_remove_allowed_senders
+
+    transfer_to_mcms(
+        &env.ref,
+        &mut env.state,
+        &mut env.registry,
+        owner_cap,
+        env.scenario.ctx(),
+    );
 
     let params = mcms_registry::test_create_executing_callback_params(
         @ccip_onramp,
@@ -303,7 +303,14 @@ public fun test_mcms_transfer_ownership_e2e() {
     let (mut env, nonce_manager_cap, source_transfer_cap) = setup();
 
     let owner_cap = ts::take_from_sender<OwnerCap>(&env.scenario);
+    let owner_cap_address = object::id_address(&owner_cap);
     initialize_onramp(&mut env, &owner_cap, nonce_manager_cap, source_transfer_cap);
+
+    let new_owner = @0x999;
+    let mut data = vector::empty<u8>();
+    data.append(bcs::to_bytes(&object::id_address(&env.state)));
+    data.append(bcs::to_bytes(&object::id_address(&owner_cap)));
+    data.append(bcs::to_bytes(&new_owner));
 
     // Transfer ownership to MCMS first
     transfer_to_mcms(
@@ -313,12 +320,6 @@ public fun test_mcms_transfer_ownership_e2e() {
         owner_cap,
         env.scenario.ctx(),
     );
-
-    let new_owner = @0x999;
-    let mut data = vector::empty<u8>();
-    data.append(bcs::to_bytes(&object::id_address(&env.state)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
-    data.append(bcs::to_bytes(&new_owner));
 
     // Transfer ownership to `new_owner` via MCMS
     let params = mcms_registry::test_create_executing_callback_params(
@@ -340,10 +341,9 @@ public fun test_mcms_transfer_ownership_e2e() {
     env.scenario.next_tx(new_owner);
     onramp::accept_ownership(&env.ref, &mut env.state, env.scenario.ctx());
 
-    // Execute ownership transfer as MCMS to `new_owner`
     let mut data = vector::empty<u8>();
+    data.append(bcs::to_bytes(&owner_cap_address));
     data.append(bcs::to_bytes(&object::id_address(&env.state)));
-    data.append(bcs::to_bytes(&object::id_address(&env.registry)));
     data.append(bcs::to_bytes(&new_owner));
 
     let params = mcms_registry::test_create_executing_callback_params(

--- a/contracts/ccip/ccip_router/sources/router.move
+++ b/contracts/ccip/ccip_router/sources/router.move
@@ -273,7 +273,7 @@ public fun mcms_set_on_ramp_infos(
 
     let mut stream = bcs_stream::new(data);
     validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(owner_cap), object::id_address(state)],
         &mut stream,
     );
 
@@ -318,7 +318,7 @@ public fun mcms_transfer_ownership(
 
     let mut stream = bcs_stream::new(data);
     validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -343,7 +343,7 @@ public fun mcms_execute_ownership_transfer(
 
     let mut stream = bcs_stream::new(data);
     validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(_owner_cap), object::id_address(state)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -596,7 +596,7 @@ public fun mcms_set_allowlist_enabled<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
     let enabled = bcs_stream::deserialize_bool(&mut stream);
@@ -619,7 +619,7 @@ public fun mcms_apply_allowlist_updates<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -650,7 +650,7 @@ public fun mcms_apply_chain_updates<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -699,7 +699,7 @@ public fun mcms_add_remote_pool<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -723,7 +723,7 @@ public fun mcms_remove_remote_pool<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -737,7 +737,7 @@ public fun mcms_set_chain_rate_limiter_configs<T>(
     state: &mut BurnMintTokenPoolState<T>,
     registry: &mut Registry,
     params: ExecutingCallbackParams,
-    clock: &Clock,
+    clock: &Clock, // TODO: Clock param breaks the mcms_ function signatures
 ) {
     let (owner_cap, function, data) = mcms_registry::get_callback_params<McmsCallback<T>, OwnerCap>(
         registry,
@@ -748,7 +748,7 @@ public fun mcms_set_chain_rate_limiter_configs<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
 
@@ -811,7 +811,7 @@ public fun mcms_set_chain_rate_limiter_config<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -852,7 +852,7 @@ public fun mcms_transfer_ownership<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -880,7 +880,7 @@ public fun mcms_execute_ownership_transfer<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(_owner_cap), object::id_address(state)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/burn_mint_token_pool/sources/burn_mint_token_pool.move
@@ -737,7 +737,7 @@ public fun mcms_set_chain_rate_limiter_configs<T>(
     state: &mut BurnMintTokenPoolState<T>,
     registry: &mut Registry,
     params: ExecutingCallbackParams,
-    clock: &Clock, // TODO: Clock param breaks the mcms_ function signatures
+    clock: &Clock,
 ) {
     let (owner_cap, function, data) = mcms_registry::get_callback_params<McmsCallback<T>, OwnerCap>(
         registry,

--- a/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/lock_release_token_pool/sources/lock_release_token_pool.move
@@ -634,7 +634,7 @@ public fun mcms_set_rebalancer<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(owner_cap), object::id_address(state)],
         &mut stream,
     );
 
@@ -658,7 +658,7 @@ public fun mcms_set_allowlist_enabled<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -682,7 +682,7 @@ public fun mcms_apply_allowlist_updates<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -713,7 +713,7 @@ public fun mcms_apply_chain_updates<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -762,7 +762,7 @@ public fun mcms_add_remote_pool<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -786,7 +786,7 @@ public fun mcms_remove_remote_pool<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -811,7 +811,7 @@ public fun mcms_set_chain_rate_limiter_configs<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
 
@@ -874,7 +874,7 @@ public fun mcms_set_chain_rate_limiter_config<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -915,7 +915,7 @@ public fun mcms_transfer_ownership<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -943,7 +943,7 @@ public fun mcms_execute_ownership_transfer<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(_owner_cap), object::id_address(state)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -918,8 +918,7 @@ public fun mcms_transfer_ownership<T>(
     transfer_ownership(state, owner_cap, to, ctx);
 }
 
-// TODO: Should this be mcms_accept...?
-public fun mcms_mcms_accept_ownership<T>(
+public fun mcms_accept_ownership<T>(
     state: &mut ManagedTokenPoolState<T>,
     registry: &mut Registry,
     params: ExecutingCallbackParams,

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -621,7 +621,7 @@ public fun mcms_set_allowlist_enabled<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -645,7 +645,7 @@ public fun mcms_apply_allowlist_updates<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -676,7 +676,7 @@ public fun mcms_apply_chain_updates<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -725,7 +725,7 @@ public fun mcms_add_remote_pool<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -750,7 +750,7 @@ public fun mcms_remove_remote_pool<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
     let remote_chain_selector = bcs_stream::deserialize_u64(&mut stream);
@@ -775,7 +775,7 @@ public fun mcms_set_chain_rate_limiter_configs<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
 
@@ -838,7 +838,7 @@ public fun mcms_set_chain_rate_limiter_config<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap), object::id_address(clock)],
         &mut stream,
     );
 
@@ -908,7 +908,7 @@ public fun mcms_transfer_ownership<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -918,6 +918,7 @@ public fun mcms_transfer_ownership<T>(
     transfer_ownership(state, owner_cap, to, ctx);
 }
 
+// TODO: Should this be mcms_accept...?
 public fun mcms_mcms_accept_ownership<T>(
     state: &mut ManagedTokenPoolState<T>,
     registry: &mut Registry,
@@ -936,7 +937,7 @@ public fun mcms_mcms_accept_ownership<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(state)],
         &mut stream,
     );
 
@@ -964,7 +965,7 @@ public fun mcms_execute_ownership_transfer<T>(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state), object::id_address(registry)],
+        vector[object::id_address(_owner_cap), object::id_address(state)],
         &mut stream,
     );
 

--- a/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
+++ b/contracts/ccip/ccip_token_pools/managed_token_pool/sources/managed_token_pool.move
@@ -918,34 +918,6 @@ public fun mcms_transfer_ownership<T>(
     transfer_ownership(state, owner_cap, to, ctx);
 }
 
-public fun mcms_accept_ownership<T>(
-    state: &mut ManagedTokenPoolState<T>,
-    registry: &mut Registry,
-    params: ExecutingCallbackParams,
-    ctx: &mut TxContext,
-) {
-    let (_owner_cap, function, data) = mcms_registry::get_callback_params<
-        McmsCallback<T>,
-        OwnerCap,
-    >(
-        registry,
-        McmsCallback<T> {},
-        params,
-    );
-    assert!(function == string::utf8(b"mcms_accept_ownership"), EInvalidFunction);
-
-    let mut stream = bcs_stream::new(data);
-    bcs_stream::validate_obj_addrs(
-        vector[object::id_address(state)],
-        &mut stream,
-    );
-
-    let mcms = bcs_stream::deserialize_address(&mut stream);
-    bcs_stream::assert_is_consumed(&stream);
-
-    ownable::mcms_accept_ownership(&mut state.ownable_state, mcms, ctx);
-}
-
 public fun mcms_execute_ownership_transfer<T>(
     state: &mut ManagedTokenPoolState<T>,
     registry: &mut Registry,

--- a/contracts/mcms/mcms_test/sources/mcms_user.move
+++ b/contracts/mcms/mcms_test/sources/mcms_user.move
@@ -121,7 +121,7 @@ public fun mcms_function_one(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(user_data), object::id_address(registry)],
+        vector[object::id_address(user_data), object::id_address(owner_cap)],
         &mut stream,
     );
 
@@ -150,7 +150,7 @@ public fun mcms_function_two(
 
     let mut stream = bcs_stream::new(data);
     bcs_stream::validate_obj_addrs(
-        vector[object::id_address(user_data), object::id_address(registry)],
+        vector[object::id_address(user_data), object::id_address(owner_cap)],
         &mut stream,
     );
 


### PR DESCRIPTION
- Changes data stream in the mcms like functions to match the arguments in the destination function. Mostly changing `registry` for `owner_cap` and some minor changes