### PR TITLE
simplify rmn remote and offramp

### DIFF
--- a/bindings/generated/ccip/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/generated/ccip/ccip/rmn_remote/rmn_remote.go
@@ -23,7 +23,6 @@ type IRmnRemote interface {
 	TypeAndVersion(ctx context.Context, opts *bind.CallOpts) (*models.SuiTransactionBlockResponse, error)
 	GetArm(ctx context.Context, opts *bind.CallOpts) (*models.SuiTransactionBlockResponse, error)
 	Initialize(ctx context.Context, opts *bind.CallOpts, ref bind.Object, ownerCap bind.Object, localChainSelector uint64) (*models.SuiTransactionBlockResponse, error)
-	Verify(ctx context.Context, opts *bind.CallOpts, ref bind.Object, offRampStateAddress string, merkleRootSourceChainSelectors []uint64, merkleRootOnRampAddresses [][]byte, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (*models.SuiTransactionBlockResponse, error)
 	SetConfig(ctx context.Context, opts *bind.CallOpts, ref bind.Object, param bind.Object, rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (*models.SuiTransactionBlockResponse, error)
 	GetVersionedConfig(ctx context.Context, opts *bind.CallOpts, ref bind.Object) (*models.SuiTransactionBlockResponse, error)
 	GetLocalChainSelector(ctx context.Context, opts *bind.CallOpts, ref bind.Object) (*models.SuiTransactionBlockResponse, error)
@@ -49,7 +48,6 @@ type IRmnRemote interface {
 type IRmnRemoteDevInspect interface {
 	TypeAndVersion(ctx context.Context, opts *bind.CallOpts) (string, error)
 	GetArm(ctx context.Context, opts *bind.CallOpts) (string, error)
-	Verify(ctx context.Context, opts *bind.CallOpts, ref bind.Object, offRampStateAddress string, merkleRootSourceChainSelectors []uint64, merkleRootOnRampAddresses [][]byte, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (bool, error)
 	GetVersionedConfig(ctx context.Context, opts *bind.CallOpts, ref bind.Object) ([]any, error)
 	GetLocalChainSelector(ctx context.Context, opts *bind.CallOpts, ref bind.Object) (uint64, error)
 	GetReportDigestHeader(ctx context.Context, opts *bind.CallOpts) ([]byte, error)
@@ -66,8 +64,6 @@ type RmnRemoteEncoder interface {
 	GetArmWithArgs(args ...any) (*bind.EncodedCall, error)
 	Initialize(ref bind.Object, ownerCap bind.Object, localChainSelector uint64) (*bind.EncodedCall, error)
 	InitializeWithArgs(args ...any) (*bind.EncodedCall, error)
-	Verify(ref bind.Object, offRampStateAddress string, merkleRootSourceChainSelectors []uint64, merkleRootOnRampAddresses [][]byte, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (*bind.EncodedCall, error)
-	VerifyWithArgs(args ...any) (*bind.EncodedCall, error)
 	SetConfig(ref bind.Object, param bind.Object, rmnHomeContractConfigDigest []byte, signerOnchainPublicKeys [][]byte, nodeIndexes []uint64, fSign uint64) (*bind.EncodedCall, error)
 	SetConfigWithArgs(args ...any) (*bind.EncodedCall, error)
 	GetVersionedConfig(ref bind.Object) (*bind.EncodedCall, error)
@@ -163,22 +159,6 @@ type Signer struct {
 	NodeIndex        uint64 `move:"u64"`
 }
 
-type Report struct {
-	DestChainSelector           uint64       `move:"u64"`
-	RmnRemoteContractAddress    string       `move:"address"`
-	OffRampAddress              string       `move:"address"`
-	RmnHomeContractConfigDigest []byte       `move:"vector<u8>"`
-	MerkleRoots                 []MerkleRoot `move:"vector<MerkleRoot>"`
-}
-
-type MerkleRoot struct {
-	SourceChainSelector uint64 `move:"u64"`
-	OnRampAddress       []byte `move:"vector<u8>"`
-	MinSeqNr            uint64 `move:"u64"`
-	MaxSeqNr            uint64 `move:"u64"`
-	MerkleRoot          []byte `move:"vector<u8>"`
-}
-
 type ConfigSet struct {
 	Version uint32 `move:"u32"`
 	Config  Config `move:"Config"`
@@ -193,25 +173,6 @@ type Uncursed struct {
 }
 
 type McmsCallback struct {
-}
-
-type bcsReport struct {
-	DestChainSelector           uint64
-	RmnRemoteContractAddress    [32]byte
-	OffRampAddress              [32]byte
-	RmnHomeContractConfigDigest []byte
-	MerkleRoots                 []MerkleRoot
-}
-
-func convertReportFromBCS(bcs bcsReport) (Report, error) {
-
-	return Report{
-		DestChainSelector:           bcs.DestChainSelector,
-		RmnRemoteContractAddress:    fmt.Sprintf("0x%x", bcs.RmnRemoteContractAddress),
-		OffRampAddress:              fmt.Sprintf("0x%x", bcs.OffRampAddress),
-		RmnHomeContractConfigDigest: bcs.RmnHomeContractConfigDigest,
-		MerkleRoots:                 bcs.MerkleRoots,
-	}, nil
 }
 
 func init() {
@@ -233,27 +194,6 @@ func init() {
 	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::Signer", func(data []byte) (interface{}, error) {
 		var result Signer
-		_, err := mystenbcs.Unmarshal(data, &result)
-		if err != nil {
-			return nil, err
-		}
-		return result, nil
-	})
-	bind.RegisterStructDecoder("ccip::rmn_remote::Report", func(data []byte) (interface{}, error) {
-		var temp bcsReport
-		_, err := mystenbcs.Unmarshal(data, &temp)
-		if err != nil {
-			return nil, err
-		}
-
-		result, err := convertReportFromBCS(temp)
-		if err != nil {
-			return nil, err
-		}
-		return result, nil
-	})
-	bind.RegisterStructDecoder("ccip::rmn_remote::MerkleRoot", func(data []byte) (interface{}, error) {
-		var result MerkleRoot
 		_, err := mystenbcs.Unmarshal(data, &result)
 		if err != nil {
 			return nil, err
@@ -317,16 +257,6 @@ func (c *RmnRemoteContract) GetArm(ctx context.Context, opts *bind.CallOpts) (*m
 // Initialize executes the initialize Move function.
 func (c *RmnRemoteContract) Initialize(ctx context.Context, opts *bind.CallOpts, ref bind.Object, ownerCap bind.Object, localChainSelector uint64) (*models.SuiTransactionBlockResponse, error) {
 	encoded, err := c.rmnRemoteEncoder.Initialize(ref, ownerCap, localChainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode function call: %w", err)
-	}
-
-	return c.ExecuteTransaction(ctx, opts, encoded)
-}
-
-// Verify executes the verify Move function.
-func (c *RmnRemoteContract) Verify(ctx context.Context, opts *bind.CallOpts, ref bind.Object, offRampStateAddress string, merkleRootSourceChainSelectors []uint64, merkleRootOnRampAddresses [][]byte, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (*models.SuiTransactionBlockResponse, error) {
-	encoded, err := c.rmnRemoteEncoder.Verify(ref, offRampStateAddress, merkleRootSourceChainSelectors, merkleRootOnRampAddresses, merkleRootMinSeqNrs, merkleRootMaxSeqNrs, merkleRootValues, signatures)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode function call: %w", err)
 	}
@@ -544,28 +474,6 @@ func (d *RmnRemoteDevInspect) GetArm(ctx context.Context, opts *bind.CallOpts) (
 	result, ok := results[0].(string)
 	if !ok {
 		return "", fmt.Errorf("unexpected return type: expected string, got %T", results[0])
-	}
-	return result, nil
-}
-
-// Verify executes the verify Move function using DevInspect to get return values.
-//
-// Returns: bool
-func (d *RmnRemoteDevInspect) Verify(ctx context.Context, opts *bind.CallOpts, ref bind.Object, offRampStateAddress string, merkleRootSourceChainSelectors []uint64, merkleRootOnRampAddresses [][]byte, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (bool, error) {
-	encoded, err := d.contract.rmnRemoteEncoder.Verify(ref, offRampStateAddress, merkleRootSourceChainSelectors, merkleRootOnRampAddresses, merkleRootMinSeqNrs, merkleRootMaxSeqNrs, merkleRootValues, signatures)
-	if err != nil {
-		return false, fmt.Errorf("failed to encode function call: %w", err)
-	}
-	results, err := d.contract.Call(ctx, opts, encoded)
-	if err != nil {
-		return false, err
-	}
-	if len(results) == 0 {
-		return false, fmt.Errorf("no return value")
-	}
-	result, ok := results[0].(bool)
-	if !ok {
-		return false, fmt.Errorf("unexpected return type: expected bool, got %T", results[0])
 	}
 	return result, nil
 }
@@ -798,57 +706,6 @@ func (c rmnRemoteEncoder) InitializeWithArgs(args ...any) (*bind.EncodedCall, er
 	typeArgsList := []string{}
 	typeParamsList := []string{}
 	return c.EncodeCallArgsWithGenerics("initialize", typeArgsList, typeParamsList, expectedParams, args, nil)
-}
-
-// Verify encodes a call to the verify Move function.
-func (c rmnRemoteEncoder) Verify(ref bind.Object, offRampStateAddress string, merkleRootSourceChainSelectors []uint64, merkleRootOnRampAddresses [][]byte, merkleRootMinSeqNrs []uint64, merkleRootMaxSeqNrs []uint64, merkleRootValues [][]byte, signatures [][]byte) (*bind.EncodedCall, error) {
-	typeArgsList := []string{}
-	typeParamsList := []string{}
-	return c.EncodeCallArgsWithGenerics("verify", typeArgsList, typeParamsList, []string{
-		"&CCIPObjectRef",
-		"address",
-		"vector<u64>",
-		"vector<vector<u8>>",
-		"vector<u64>",
-		"vector<u64>",
-		"vector<vector<u8>>",
-		"vector<vector<u8>>",
-	}, []any{
-		ref,
-		offRampStateAddress,
-		merkleRootSourceChainSelectors,
-		merkleRootOnRampAddresses,
-		merkleRootMinSeqNrs,
-		merkleRootMaxSeqNrs,
-		merkleRootValues,
-		signatures,
-	}, []string{
-		"bool",
-	})
-}
-
-// VerifyWithArgs encodes a call to the verify Move function using arbitrary arguments.
-// This method allows passing both regular values and transaction.Argument values for PTB chaining.
-func (c rmnRemoteEncoder) VerifyWithArgs(args ...any) (*bind.EncodedCall, error) {
-	expectedParams := []string{
-		"&CCIPObjectRef",
-		"address",
-		"vector<u64>",
-		"vector<vector<u8>>",
-		"vector<u64>",
-		"vector<u64>",
-		"vector<vector<u8>>",
-		"vector<vector<u8>>",
-	}
-
-	if len(args) != len(expectedParams) {
-		return nil, fmt.Errorf("expected %d arguments, got %d", len(expectedParams), len(args))
-	}
-	typeArgsList := []string{}
-	typeParamsList := []string{}
-	return c.EncodeCallArgsWithGenerics("verify", typeArgsList, typeParamsList, expectedParams, args, []string{
-		"bool",
-	})
 }
 
 // SetConfig encodes a call to the set_config Move function.

--- a/contracts/ccip/ccip/sources/rmn_remote.move
+++ b/contracts/ccip/ccip/sources/rmn_remote.move
@@ -1,7 +1,6 @@
 module ccip::rmn_remote;
 
 use ccip::eth_abi;
-use ccip::merkle_proof;
 use ccip::ownable::OwnerCap;
 use ccip::state_object::{Self, CCIPObjectRef};
 use ccip::upgrade_registry::verify_function_allowed;
@@ -11,12 +10,10 @@ use std::bcs;
 use std::string::{Self, String};
 use std::type_name;
 use sui::address;
-use sui::ecdsa_k1;
 use sui::event;
 use sui::hash;
 use sui::vec_map::{Self, VecMap};
 
-const SIGNATURE_NUM_BYTES: u64 = 64;
 const GLOBAL_CURSE_SUBJECT: vector<u8> = x"01000000000000000000000000000001";
 
 public struct RMNRemoteState has key, store {
@@ -40,23 +37,6 @@ public struct Signer has copy, drop, store {
     node_index: u64,
 }
 
-// TODO: figure out what to do with chain_id. Cannot get it from Sui library.
-public struct Report has drop {
-    dest_chain_selector: u64,
-    rmn_remote_contract_address: address,
-    off_ramp_address: address,
-    rmn_home_contract_config_digest: vector<u8>,
-    merkle_roots: vector<MerkleRoot>,
-}
-
-public struct MerkleRoot has drop {
-    source_chain_selector: u64,
-    on_ramp_address: vector<u8>,
-    min_seq_nr: u64,
-    max_seq_nr: u64,
-    merkle_root: vector<u8>,
-}
-
 public struct ConfigSet has copy, drop {
     version: u32,
     config: Config,
@@ -72,22 +52,16 @@ public struct Uncursed has copy, drop {
 
 const EAlreadyInitialized: u64 = 1;
 const EAlreadyCursed: u64 = 2;
-const EConfigNotSet: u64 = 3;
-const EDuplicateSigner: u64 = 4;
-const EInvalidSignature: u64 = 5;
-const EInvalidSignerOrder: u64 = 6;
-const ENotEnoughSigners: u64 = 7;
-const ENotCursed: u64 = 8;
-const EOutOfOrderSignatures: u64 = 9;
-const EThresholdNotMet: u64 = 10;
-const EUnexpectedSigner: u64 = 11;
-const EZeroValueNotAllowed: u64 = 12;
-const EMerkleRootLengthMismatch: u64 = 13;
-const EInvalidDigestLength: u64 = 14;
-const ESignersMismatch: u64 = 15;
-const EInvalidSubjectLength: u64 = 16;
-const EInvalidPublicKeyLength: u64 = 17;
-const EInvalidFunction: u64 = 18;
+const EDuplicateSigner: u64 = 3;
+const EInvalidSignerOrder: u64 = 4;
+const ENotEnoughSigners: u64 = 5;
+const ENotCursed: u64 = 6;
+const EZeroValueNotAllowed: u64 = 7;
+const EInvalidDigestLength: u64 = 8;
+const ESignersMismatch: u64 = 9;
+const EInvalidSubjectLength: u64 = 10;
+const EInvalidPublicKeyLength: u64 = 11;
+const EInvalidFunction: u64 = 12;
 
 const VERSION: u8 = 1;
 
@@ -127,109 +101,6 @@ public fun initialize(
     };
 
     state_object::add(ref, owner_cap, state, ctx);
-}
-
-fun calculate_report(report: &Report): vector<u8> {
-    let mut digest = vector[];
-    eth_abi::encode_right_padded_bytes32(&mut digest, get_report_digest_header());
-    eth_abi::encode_u64(&mut digest, report.dest_chain_selector);
-    eth_abi::encode_address(&mut digest, report.rmn_remote_contract_address);
-    eth_abi::encode_address(&mut digest, report.off_ramp_address);
-    eth_abi::encode_right_padded_bytes32(&mut digest, report.rmn_home_contract_config_digest);
-    report.merkle_roots.do_ref!(|merkle_root| {
-        let merkle_root: &MerkleRoot = merkle_root;
-        eth_abi::encode_u64(&mut digest, merkle_root.source_chain_selector);
-        eth_abi::encode_bytes(&mut digest, merkle_root.on_ramp_address);
-        eth_abi::encode_u64(&mut digest, merkle_root.min_seq_nr);
-        eth_abi::encode_u64(&mut digest, merkle_root.max_seq_nr);
-        eth_abi::encode_right_padded_bytes32(&mut digest, merkle_root.merkle_root);
-    });
-    digest
-}
-
-public fun verify(
-    ref: &CCIPObjectRef,
-    off_ramp_state_address: address,
-    merkle_root_source_chain_selectors: vector<u64>,
-    merkle_root_on_ramp_addresses: vector<vector<u8>>,
-    merkle_root_min_seq_nrs: vector<u64>,
-    merkle_root_max_seq_nrs: vector<u64>,
-    merkle_root_values: vector<vector<u8>>,
-    signatures: vector<vector<u8>>,
-): bool {
-    verify_function_allowed(
-        ref,
-        string::utf8(b"rmn_remote"),
-        string::utf8(b"verify"),
-        VERSION,
-    );
-
-    let state = state_object::borrow<RMNRemoteState>(ref);
-
-    assert!(state.config_count > 0, EConfigNotSet);
-
-    let signatures_len = signatures.length();
-    assert!(signatures_len >= (state.config.f_sign + 1), EThresholdNotMet);
-
-    let merkle_root_len = merkle_root_source_chain_selectors.length();
-    assert!(merkle_root_len == merkle_root_on_ramp_addresses.length(), EMerkleRootLengthMismatch);
-    assert!(merkle_root_len == merkle_root_min_seq_nrs.length(), EMerkleRootLengthMismatch);
-    assert!(merkle_root_len == merkle_root_max_seq_nrs.length(), EMerkleRootLengthMismatch);
-    assert!(merkle_root_len == merkle_root_values.length(), EMerkleRootLengthMismatch);
-
-    // Since we cannot pass public structs, we need to reconpublic struct it from the individual components.
-    let mut merkle_roots = vector[];
-    let mut i = 0;
-    while (i < merkle_root_len) {
-        let source_chain_selector = merkle_root_source_chain_selectors[i];
-        let on_ramp_address = merkle_root_on_ramp_addresses[i];
-        let min_seq_nr = merkle_root_min_seq_nrs[i];
-        let max_seq_nr = merkle_root_max_seq_nrs[i];
-        let merkle_root = merkle_root_values[i];
-        merkle_roots.push_back(MerkleRoot {
-            source_chain_selector,
-            on_ramp_address,
-            min_seq_nr,
-            max_seq_nr,
-            merkle_root,
-        });
-        i = i + 1;
-    };
-
-    // TODO: verify this.
-    // currently we use the CCIP state object id as rmn_remote_contract_address and offramp state address as off_ramp_address.
-    let report = Report {
-        dest_chain_selector: state.local_chain_selector,
-        rmn_remote_contract_address: object::id_to_address(&object::id(ref)),
-        off_ramp_address: off_ramp_state_address,
-        rmn_home_contract_config_digest: state.config.rmn_home_contract_config_digest,
-        merkle_roots,
-    };
-
-    let digest = calculate_report(&report);
-
-    let mut previous_eth_address = vector[];
-    let mut i = 0;
-    while (i < signatures_len) {
-        let signature_bytes = signatures[i];
-
-        assert!(signature_bytes.length() == SIGNATURE_NUM_BYTES, EInvalidSignature);
-
-        let eth_address = ecrecover_to_eth_address(signature_bytes, digest);
-
-        assert!(state.signers.contains(&eth_address), EUnexpectedSigner);
-        if (i > 0) {
-            assert!(
-                merkle_proof::vector_u8_gt(&eth_address, &previous_eth_address),
-                EOutOfOrderSignatures,
-            );
-        };
-        previous_eth_address = eth_address;
-
-        i = i + 1;
-    };
-
-    true
 }
 
 public fun set_config(
@@ -434,37 +305,6 @@ public fun is_cursed_u128(ref: &CCIPObjectRef, subject_value: u128): bool {
     let mut subject = bcs::to_bytes(&subject_value);
     subject.reverse();
     is_cursed(ref, subject)
-}
-
-/// Recover the Ethereum address using the signature and message, assuming the signature was
-/// produced over the Keccak256 hash of the message.
-/// this implementation is based on the SUI example: https://github.com/MystenLabs/sui/blob/main/examples/move/crypto/ecdsa_k1/sources/example.move#L62
-fun ecrecover_to_eth_address(mut signature: vector<u8>, msg: vector<u8>): vector<u8> {
-    // no normalization is done bc the signature only includes 64 bytes.
-    // add a 0 byte to the end of the signature to make it 65 bytes.
-    signature.push_back(0);
-    // Ethereum signature is produced with Keccak256 hash of the message, so the last param is
-    // 0.
-    let pubkey = ecdsa_k1::secp256k1_ecrecover(&signature, &msg, 0);
-    let uncompressed = ecdsa_k1::decompress_pubkey(&pubkey);
-
-    // Take the last 64 bytes of the uncompressed pubkey.
-    let mut uncompressed_64 = vector[];
-    let mut i = 1;
-    while (i < 65) {
-        uncompressed_64.push_back(uncompressed[i]);
-        i = i + 1;
-    };
-
-    // Take the last 20 bytes of the hash of the 64-bytes uncompressed pubkey.
-    let hashed = sui::hash::keccak256(&uncompressed_64);
-    let mut addr = vector[];
-    let mut i = 12;
-    while (i < 32) {
-        addr.push_back(hashed[i]);
-        i = i + 1;
-    };
-    addr
 }
 
 // ================================================================

--- a/contracts/ccip/ccip/tests/rmn_remote_tests.move
+++ b/contracts/ccip/ccip/tests/rmn_remote_tests.move
@@ -12,7 +12,6 @@ use sui::test_scenario::{Self, Scenario};
 
 // Test addresses and identifiers
 const ADMIN_ADDRESS: address = @0x1;
-const OFFRAMP_STATE_ADDRESS: address = @0x123;
 const TEST_CHAIN_SELECTOR: u64 = 1;
 
 // Test data constants
@@ -24,8 +23,6 @@ const INVALID_SHORT_DIGEST: vector<u8> = b"000000000000000000000000000000";
 const SIGNER_PUBKEY_1: vector<u8> = b"00000000000000000002";
 const SIGNER_PUBKEY_2: vector<u8> = b"00000000000000000003";
 const SIGNER_PUBKEY_3: vector<u8> = b"00000000000000000004";
-const SIGNER_PUBKEY_4: vector<u8> = b"00000000000000000005";
-const SIGNER_PUBKEY_5: vector<u8> = b"00000000000000000006";
 const INVALID_SHORT_PUBKEY: vector<u8> = b"000000000000000000"; // 18 bytes
 
 // Subject identifiers (16 bytes each)
@@ -35,28 +32,10 @@ const SUBJECT_U128: vector<u8> = x"00000000000000000000000000000100"; // hex(256
 const GLOBAL_CURSE_SUBJECT: vector<u8> = x"01000000000000000000000000000001";
 const INVALID_SHORT_SUBJECT: vector<u8> = b"00003";
 
-// Merkle root test data
-const MERKLE_ROOT_VALUE_1: vector<u8> = b"merkle_root_value_32_bytes_long";
-const MERKLE_ROOT_VALUE_2: vector<u8> = b"merkle_root_value_32_bytes_lon2";
-const ONRAMP_ADDRESS: vector<u8> = b"onramp_addr";
-
-// Signature test data (64 bytes each)
-const VALID_SIGNATURE_1: vector<u8> =
-    b"signature_64_bytes_long_signature_64_bytes_long_signature_64_by";
-const VALID_SIGNATURE_2: vector<u8> =
-    b"signature_64_bytes_long_signature_64_bytes_long_signature_64_b2";
-const INVALID_SHORT_SIGNATURE: vector<u8> = b"invalid_signature_too_short"; // 28 bytes
-
 // Numerical constants
 const F_SIGN_VALUE: u64 = 1;
 const F_SIGN_HIGH_VALUE: u64 = 2;
 const VERSION_1: u32 = 1;
-const CHAIN_SELECTOR_100: u64 = 100;
-const CHAIN_SELECTOR_200: u64 = 200;
-const SEQ_NR_1: u64 = 1;
-const SEQ_NR_2: u64 = 2;
-const SEQ_NR_10: u64 = 10;
-const SEQ_NR_20: u64 = 20;
 const U128_VALUE_256: u128 = 256;
 const U128_VALUE_100: u128 = 100;
 
@@ -108,37 +87,6 @@ fun setup_basic_config(ref: &mut CCIPObjectRef, owner_cap: &OwnerCap) {
         vector[0, 1, 2],
         F_SIGN_VALUE,
     );
-}
-
-fun setup_high_threshold_config(ref: &mut CCIPObjectRef, owner_cap: &OwnerCap) {
-    rmn_remote::set_config(
-        ref,
-        owner_cap,
-        VALID_DIGEST,
-        vector[SIGNER_PUBKEY_1, SIGNER_PUBKEY_2, SIGNER_PUBKEY_3, SIGNER_PUBKEY_4, SIGNER_PUBKEY_5],
-        vector[0, 1, 2, 3, 4],
-        F_SIGN_HIGH_VALUE, // f_sign = 2, requires at least 3 signatures
-    );
-}
-
-fun create_basic_verify_params(): (
-    address, // off_ramp_state_address
-    vector<u64>, // merkle_root_source_chain_selectors
-    vector<vector<u8>>, // merkle_root_on_ramp_addresses
-    vector<u64>, // merkle_root_min_seq_nrs
-    vector<u64>, // merkle_root_max_seq_nrs
-    vector<vector<u8>>, // merkle_root_values
-    vector<vector<u8>>, // signatures
-) {
-    (
-        OFFRAMP_STATE_ADDRESS,
-        vector[CHAIN_SELECTOR_100],
-        vector[ONRAMP_ADDRESS],
-        vector[SEQ_NR_1],
-        vector[SEQ_NR_10],
-        vector[MERKLE_ROOT_VALUE_1],
-        vector[VALID_SIGNATURE_1, VALID_SIGNATURE_2],
-    )
 }
 
 // === Basic Initialization Tests ===
@@ -563,111 +511,6 @@ public fun test_uncurse_multiple_not_cursed() {
         &mut ref,
         &owner_cap,
         vector[SUBJECT_1, SUBJECT_2], // not cursed
-    );
-
-    tear_down_test(scenario, owner_cap, ref);
-}
-
-#[test]
-#[expected_failure(abort_code = rmn_remote::EConfigNotSet)]
-public fun test_verify_config_not_set() {
-    let (mut scenario, owner_cap, mut ref) = set_up_test();
-    let ctx = scenario.ctx();
-
-    initialize_rmn_remote(&mut ref, &owner_cap, TEST_CHAIN_SELECTOR, ctx);
-
-    // Try to verify without setting config first
-    let (
-        off_ramp_state_address,
-        merkle_root_source_chain_selectors,
-        merkle_root_on_ramp_addresses,
-        merkle_root_min_seq_nrs,
-        merkle_root_max_seq_nrs,
-        merkle_root_values,
-        signatures,
-    ) = create_basic_verify_params();
-
-    let _result = rmn_remote::verify(
-        &ref,
-        off_ramp_state_address,
-        merkle_root_source_chain_selectors,
-        merkle_root_on_ramp_addresses,
-        merkle_root_min_seq_nrs,
-        merkle_root_max_seq_nrs,
-        merkle_root_values,
-        signatures,
-    );
-
-    tear_down_test(scenario, owner_cap, ref);
-}
-
-#[test]
-#[expected_failure(abort_code = rmn_remote::EThresholdNotMet)]
-public fun test_verify_threshold_not_met() {
-    let (mut scenario, owner_cap, mut ref) = set_up_test();
-    let ctx = scenario.ctx();
-
-    initialize_rmn_remote(&mut ref, &owner_cap, TEST_CHAIN_SELECTOR, ctx);
-    setup_high_threshold_config(&mut ref, &owner_cap);
-
-    // Try to verify with only 2 signatures (less than f_sign + 1)
-    let _result = rmn_remote::verify(
-        &ref,
-        OFFRAMP_STATE_ADDRESS,
-        vector[CHAIN_SELECTOR_100],
-        vector[ONRAMP_ADDRESS],
-        vector[SEQ_NR_1],
-        vector[SEQ_NR_10],
-        vector[MERKLE_ROOT_VALUE_1],
-        vector[VALID_SIGNATURE_1, VALID_SIGNATURE_2], // only 2 signatures
-    );
-
-    tear_down_test(scenario, owner_cap, ref);
-}
-
-#[test]
-#[expected_failure(abort_code = rmn_remote::EMerkleRootLengthMismatch)]
-public fun test_verify_merkle_root_length_mismatch() {
-    let (mut scenario, owner_cap, mut ref) = set_up_test();
-    let ctx = scenario.ctx();
-
-    initialize_rmn_remote(&mut ref, &owner_cap, TEST_CHAIN_SELECTOR, ctx);
-    setup_basic_config(&mut ref, &owner_cap);
-
-    // Mismatched array lengths for merkle root components
-    let _result = rmn_remote::verify(
-        &ref,
-        OFFRAMP_STATE_ADDRESS,
-        vector[CHAIN_SELECTOR_100, CHAIN_SELECTOR_200], // 2 elements
-        vector[ONRAMP_ADDRESS], // 1 element - mismatch!
-        vector[SEQ_NR_1, SEQ_NR_2], // 2 elements
-        vector[SEQ_NR_10, SEQ_NR_20], // 2 elements
-        vector[MERKLE_ROOT_VALUE_1, MERKLE_ROOT_VALUE_2], // 2 elements
-        vector[VALID_SIGNATURE_1, VALID_SIGNATURE_2],
-    );
-
-    tear_down_test(scenario, owner_cap, ref);
-}
-
-#[test]
-#[expected_failure(abort_code = rmn_remote::EInvalidSignature)]
-public fun test_verify_invalid_signature_length() {
-    let (mut scenario, owner_cap, mut ref) = set_up_test();
-    let ctx = scenario.ctx();
-
-    initialize_rmn_remote(&mut ref, &owner_cap, TEST_CHAIN_SELECTOR, ctx);
-    setup_basic_config(&mut ref, &owner_cap);
-
-    // Try to verify with invalid signature length (not 64 bytes)
-    let _result = rmn_remote::verify(
-        &ref,
-        OFFRAMP_STATE_ADDRESS,
-        vector[CHAIN_SELECTOR_100],
-        vector[ONRAMP_ADDRESS],
-        vector[SEQ_NR_1],
-        vector[SEQ_NR_10],
-        vector[MERKLE_ROOT_VALUE_1],
-        vector[INVALID_SHORT_SIGNATURE, VALID_SIGNATURE_2], // only 28 bytes, should be 64
     );
 
     tear_down_test(scenario, owner_cap, ref);

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -193,9 +193,6 @@ const EXECUTION_STATE_UNTOUCHED: u8 = 0;
 const EXECUTION_STATE_SUCCESS: u8 = 2;
 // const EXECUTION_STATE_FAILURE: u8 = 3;
 
-const ZERO_MERKLE_ROOT: vector<u8> = vector[
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
 const ESourceChainSelectorsMismatch: u64 = 1;
 const EZeroChainSelector: u64 = 2;
 const EUnknownSourceChainSelector: u64 = 3;
@@ -206,26 +203,22 @@ const ETokenDataMismatch: u64 = 7;
 const ERootNotCommitted: u64 = 8;
 const EManualExecutionNotYetEnabled: u64 = 9;
 const ESourceChainNotEnabled: u64 = 10;
-const ECommitOnRampMismatch: u64 = 11;
-const EInvalidInterval: u64 = 12;
-const EInvalidRoot: u64 = 13;
-const ERootAlreadyCommitted: u64 = 14;
-const EStaleCommitReport: u64 = 15;
-const ECursedByRmn: u64 = 16;
-const ESignatureVerificationRequiredInCommitPlugin: u64 = 17;
-const ESignatureVerificationNotAllowedInExecutionPlugin: u64 = 18;
-const EFeeQuoterCapExists: u64 = 19;
-const ETokenAmountOverflow: u64 = 20;
-const EDestTransferCapExists: u64 = 21;
-const ERmnBlessingMismatch: u64 = 22;
-const EUnsupportedToken: u64 = 23;
-const EInvalidOnRampUpdate: u64 = 24;
-const EDestTransferCapNotSet: u64 = 25;
-const ECalculateMessageHashInvalidArguments: u64 = 26;
-const EInvalidFunction: u64 = 27;
-const EInvalidTokenReceiver: u64 = 28;
-const ETokenTransferLimitExceeded: u64 = 29;
-const EPackageIdNotFound: u64 = 30;
+const EInvalidRoot: u64 = 11;
+const EStaleCommitReport: u64 = 12;
+const ECursedByRmn: u64 = 13;
+const ESignatureVerificationRequiredInCommitPlugin: u64 = 14;
+const ESignatureVerificationNotAllowedInExecutionPlugin: u64 = 15;
+const EFeeQuoterCapExists: u64 = 16;
+const ETokenAmountOverflow: u64 = 17;
+const EDestTransferCapExists: u64 = 18;
+const EUnsupportedToken: u64 = 19;
+const EInvalidOnRampUpdate: u64 = 20;
+const EDestTransferCapNotSet: u64 = 21;
+const ECalculateMessageHashInvalidArguments: u64 = 22;
+const EInvalidFunction: u64 = 23;
+const EInvalidTokenReceiver: u64 = 24;
+const ETokenTransferLimitExceeded: u64 = 25;
+const EPackageIdNotFound: u64 = 26;
 
 const VERSION: u8 = 1;
 
@@ -983,15 +976,6 @@ public fun commit(
     );
     let commit_report = deserialize_commit_report(report);
 
-    if (commit_report.blessed_merkle_roots.length() > 0) {
-        verify_blessed_roots(
-            ref,
-            object::uid_to_address(&state.id),
-            &commit_report.blessed_merkle_roots,
-            commit_report.rmn_signatures,
-        );
-    };
-
     if (
         commit_report.price_updates.token_price_updates.length() > 0
             || commit_report.price_updates.gas_price_updates.length() > 0
@@ -1026,21 +1010,9 @@ public fun commit(
                 ctx,
             );
         } else {
-            // If no non-stale valid price updates are present and the report contains no merkle roots,
-            // either blessed or unblesssed, the entire report is stale and should be rejected.
-            assert!(
-                commit_report.blessed_merkle_roots.length() > 0
-                        || commit_report.unblessed_merkle_roots.length() > 0,
-                EStaleCommitReport,
-            );
+            abort EStaleCommitReport
         };
     };
-
-    // Commit the roots that do require RMN blessing validation.
-    // The blessings are checked at the start of this function.
-    commit_merkle_roots(ref, state, clock, commit_report.blessed_merkle_roots, true);
-    // Commit the roots that do not require RMN blessing validation.
-    commit_merkle_roots(ref, state, clock, commit_report.unblessed_merkle_roots, false);
 
     event::emit(CommitReportAccepted {
         blessed_merkle_roots: commit_report.blessed_merkle_roots,
@@ -1057,78 +1029,6 @@ public fun commit(
         signatures,
         ctx,
     )
-}
-
-fun verify_blessed_roots(
-    ref: &CCIPObjectRef,
-    off_ramp_state_address: address,
-    blessed_merkle_roots: &vector<MerkleRoot>,
-    rmn_signatures: vector<vector<u8>>,
-) {
-    let mut merkle_root_source_chains_selector = vector[];
-    let mut merkle_root_on_ramp_addresses = vector[];
-    let mut merkle_root_min_seq_nrs = vector[];
-    let mut merkle_root_max_seq_nrs = vector[];
-    let mut merkle_root_values = vector[];
-    vector::do_ref!(blessed_merkle_roots, |merkle_root| {
-        let merkle_root: &MerkleRoot = merkle_root;
-        merkle_root_source_chains_selector.push_back(merkle_root.source_chain_selector);
-        merkle_root_on_ramp_addresses.push_back(merkle_root.on_ramp_address);
-        merkle_root_max_seq_nrs.push_back(merkle_root.max_seq_nr);
-        merkle_root_min_seq_nrs.push_back(merkle_root.min_seq_nr);
-        merkle_root_values.push_back(merkle_root.merkle_root);
-    });
-    rmn_remote::verify(
-        ref,
-        off_ramp_state_address,
-        merkle_root_source_chains_selector,
-        merkle_root_on_ramp_addresses,
-        merkle_root_min_seq_nrs,
-        merkle_root_max_seq_nrs,
-        merkle_root_values,
-        rmn_signatures,
-    );
-}
-
-fun commit_merkle_roots(
-    ref: &CCIPObjectRef,
-    state: &mut OffRampState,
-    clock: &clock::Clock,
-    merkle_roots: vector<MerkleRoot>,
-    is_blessed: bool,
-) {
-    merkle_roots.do_ref!(|root| {
-        let root: &MerkleRoot = root;
-        let source_chain_selector = root.source_chain_selector;
-
-        assert!(!rmn_remote::is_cursed_u128(ref, source_chain_selector as u128), ECursedByRmn);
-
-        assert_source_chain_enabled(state, source_chain_selector);
-
-        let source_chain_config = state.source_chain_configs.get_mut(&source_chain_selector);
-
-        // If the root is blessed but RMN blessing is disabled for the source chain, or if the root is not
-        // blessed but RMN blessing is enabled, we revert.
-        assert!(
-            is_blessed != source_chain_config.is_rmn_verification_disabled,
-            ERmnBlessingMismatch,
-        );
-
-        assert!(source_chain_config.on_ramp == root.on_ramp_address, ECommitOnRampMismatch);
-        assert!(
-            source_chain_config.min_seq_nr == root.min_seq_nr
-                    && root.min_seq_nr <= root.max_seq_nr,
-            EInvalidInterval,
-        );
-
-        let merkle_root = root.merkle_root;
-        assert!(merkle_root.length() == 32 && merkle_root != ZERO_MERKLE_ROOT, EInvalidRoot);
-
-        assert!(!state.roots.contains(merkle_root), ERootAlreadyCommitted);
-
-        source_chain_config.min_seq_nr = root.max_seq_nr + 1;
-        state.roots.add(merkle_root, clock.timestamp_ms() / 1000);
-    })
 }
 
 public fun get_latest_price_sequence_number(state: &OffRampState): u64 {

--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -192,6 +192,9 @@ const EXECUTION_STATE_UNTOUCHED: u8 = 0;
 // const EXECUTION_STATE_IN_PROGRESS: u8 = 1;
 const EXECUTION_STATE_SUCCESS: u8 = 2;
 // const EXECUTION_STATE_FAILURE: u8 = 3;
+const ZERO_MERKLE_ROOT: vector<u8> = vector[
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
 
 const ESourceChainSelectorsMismatch: u64 = 1;
 const EZeroChainSelector: u64 = 2;
@@ -203,22 +206,26 @@ const ETokenDataMismatch: u64 = 7;
 const ERootNotCommitted: u64 = 8;
 const EManualExecutionNotYetEnabled: u64 = 9;
 const ESourceChainNotEnabled: u64 = 10;
-const EInvalidRoot: u64 = 11;
-const EStaleCommitReport: u64 = 12;
-const ECursedByRmn: u64 = 13;
-const ESignatureVerificationRequiredInCommitPlugin: u64 = 14;
-const ESignatureVerificationNotAllowedInExecutionPlugin: u64 = 15;
-const EFeeQuoterCapExists: u64 = 16;
-const ETokenAmountOverflow: u64 = 17;
-const EDestTransferCapExists: u64 = 18;
-const EUnsupportedToken: u64 = 19;
-const EInvalidOnRampUpdate: u64 = 20;
-const EDestTransferCapNotSet: u64 = 21;
-const ECalculateMessageHashInvalidArguments: u64 = 22;
-const EInvalidFunction: u64 = 23;
-const EInvalidTokenReceiver: u64 = 24;
-const ETokenTransferLimitExceeded: u64 = 25;
-const EPackageIdNotFound: u64 = 26;
+const ECommitOnRampMismatch: u64 = 11;
+const EInvalidInterval: u64 = 12;
+const EInvalidRoot: u64 = 13;
+const ERootAlreadyCommitted: u64 = 14;
+const EStaleCommitReport: u64 = 15;
+const ECursedByRmn: u64 = 16;
+const ESignatureVerificationRequiredInCommitPlugin: u64 = 17;
+const ESignatureVerificationNotAllowedInExecutionPlugin: u64 = 18;
+const EFeeQuoterCapExists: u64 = 19;
+const ETokenAmountOverflow: u64 = 20;
+const EDestTransferCapExists: u64 = 21;
+const ERmnBlessingMismatch: u64 = 22;
+const EUnsupportedToken: u64 = 23;
+const EInvalidOnRampUpdate: u64 = 24;
+const EDestTransferCapNotSet: u64 = 25;
+const ECalculateMessageHashInvalidArguments: u64 = 26;
+const EInvalidFunction: u64 = 27;
+const EInvalidTokenReceiver: u64 = 28;
+const ETokenTransferLimitExceeded: u64 = 29;
+const EPackageIdNotFound: u64 = 30;
 
 const VERSION: u8 = 1;
 
@@ -976,6 +983,16 @@ public fun commit(
     );
     let commit_report = deserialize_commit_report(report);
 
+    // // there will be no blessed merkle roots
+    // if (commit_report.blessed_merkle_roots.length() > 0) {
+    //     verify_blessed_roots(
+    //         ref,
+    //         object::uid_to_address(&state.id),
+    //         &commit_report.blessed_merkle_roots,
+    //         commit_report.rmn_signatures,
+    //     );
+    // };
+
     if (
         commit_report.price_updates.token_price_updates.length() > 0
             || commit_report.price_updates.gas_price_updates.length() > 0
@@ -1010,9 +1027,17 @@ public fun commit(
                 ctx,
             );
         } else {
-            abort EStaleCommitReport
+            // If no non-stale valid price updates are present and the report contains no unblessed merkle roots,
+            // report is stale and should be rejected. there will be no blessed merkle roots
+            assert!(commit_report.unblessed_merkle_roots.length() > 0, EStaleCommitReport);
         };
     };
+
+    // // Commit the roots that do require RMN blessing validation.
+    // // The blessings are checked at the start of this function.
+    // commit_merkle_roots(ref, state, clock, commit_report.blessed_merkle_roots, true);
+    // Commit the roots that do not require RMN blessing validation.
+    commit_merkle_roots(ref, state, clock, commit_report.unblessed_merkle_roots, false);
 
     event::emit(CommitReportAccepted {
         blessed_merkle_roots: commit_report.blessed_merkle_roots,
@@ -1029,6 +1054,47 @@ public fun commit(
         signatures,
         ctx,
     )
+}
+
+fun commit_merkle_roots(
+    ref: &CCIPObjectRef,
+    state: &mut OffRampState,
+    clock: &clock::Clock,
+    merkle_roots: vector<MerkleRoot>,
+    is_blessed: bool,
+) {
+    merkle_roots.do_ref!(|root| {
+        let root: &MerkleRoot = root;
+        let source_chain_selector = root.source_chain_selector;
+
+        assert!(!rmn_remote::is_cursed_u128(ref, source_chain_selector as u128), ECursedByRmn);
+
+        assert_source_chain_enabled(state, source_chain_selector);
+
+        let source_chain_config = state.source_chain_configs.get_mut(&source_chain_selector);
+
+        // If the root is blessed but RMN blessing is disabled for the source chain, or if the root is not
+        // blessed but RMN blessing is enabled, we revert.
+        assert!(
+            is_blessed != source_chain_config.is_rmn_verification_disabled,
+            ERmnBlessingMismatch,
+        );
+
+        assert!(source_chain_config.on_ramp == root.on_ramp_address, ECommitOnRampMismatch);
+        assert!(
+            source_chain_config.min_seq_nr == root.min_seq_nr
+                    && root.min_seq_nr <= root.max_seq_nr,
+            EInvalidInterval,
+        );
+
+        let merkle_root = root.merkle_root;
+        assert!(merkle_root.length() == 32 && merkle_root != ZERO_MERKLE_ROOT, EInvalidRoot);
+
+        assert!(!state.roots.contains(merkle_root), ERootAlreadyCommitted);
+
+        source_chain_config.min_seq_nr = root.max_seq_nr + 1;
+        state.roots.add(merkle_root, clock.timestamp_ms() / 1000);
+    })
 }
 
 public fun get_latest_price_sequence_number(state: &OffRampState): u64 {


### PR DESCRIPTION
there will be no more `blessed_merkle_roots` from rmn. hence, removing related logic. but keeping the event sig the same for compatibility for offchain and o11y