### PR TITLE
feat(decoder): deserializer for bcs data

### DIFF
--- a/bindings/bind/bcs_decoder.go
+++ b/bindings/bind/bcs_decoder.go
@@ -1,9 +1,12 @@
 package bind
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
+	"strings"
 
 	"github.com/block-vision/sui-go-sdk/mystenbcs"
 )
@@ -277,4 +280,57 @@ func DecodeU128Value(bcsBytes [16]byte) (*big.Int, error) {
 	result := new(big.Int)
 	result.SetBytes(reverseBytes(bcsBytes[:]))
 	return result, nil
+}
+
+// DeserializeBCS consumes a slice of bytes containing multiple BCS-encoded values
+// and decodes them according to the provided Move types.
+// TODO: this function should also serve extractBCSBytes, but currently
+// getElementType handles objects as their ID (32-byte address)
+func DeserializeBCS(data []byte, moveTypes []string) ([]any, error) {
+	deserializer := mystenbcs.NewDecoder(bytes.NewReader(data))
+	ret := make([]any, 0, len(moveTypes))
+	for _, moveType := range moveTypes {
+		decoded, err := decodeType(deserializer, moveType)
+		if err != nil {
+			return ret, err
+		}
+		ret = append(ret, decoded)
+	}
+	return ret, nil
+}
+
+func decodeType(deserializer *mystenbcs.Decoder, moveType string) (any, error) {
+	refType := getElementType(moveType)
+	res := reflect.New(refType)
+	_, err := deserializer.Decode(res.Interface())
+	return res.Elem().Interface(), err
+}
+
+// TODO: treat big.int since it's a structure with unexported fields
+// encoder doesn't work. So does decoder. To return as a proper big.Int
+// we'll need to handle it in DeserializeBCS
+func getElementType(moveType string) reflect.Type {
+	switch {
+	case moveType == "bool":
+		return reflect.TypeOf(false)
+	case moveType == "u8":
+		return reflect.TypeOf(uint8(0))
+	case moveType == "u16":
+		return reflect.TypeOf(uint16(0))
+	case moveType == "u32":
+		return reflect.TypeOf(uint32(0))
+	case moveType == "u64":
+		return reflect.TypeOf(uint64(0))
+	case moveType == "0x1::string::String":
+		return reflect.TypeOf("")
+	case strings.HasPrefix(moveType, "vector"):
+		// Extract the inner type from "vector<innerType>"
+		innerType := moveType[7 : len(moveType)-1]
+		return reflect.SliceOf(getElementType(innerType))
+	case moveType == "address":
+		return reflect.TypeOf([32]byte{})
+	default:
+		// Custom move structs are deserialized as their ID (32-byte address)
+		return reflect.TypeOf([32]byte{})
+	}
 }

--- a/bindings/bind/bcs_decoder.go
+++ b/bindings/bind/bcs_decoder.go
@@ -300,10 +300,45 @@ func DeserializeBCS(data []byte, moveTypes []string) ([]any, error) {
 }
 
 func decodeType(deserializer *mystenbcs.Decoder, moveType string) (any, error) {
+	// Handle special cases first
+	switch moveType {
+	case "u128":
+		return decodeBigInt(deserializer, moveType, 16)
+	case "u256":
+		return decodeBigInt(deserializer, moveType, 32)
+	default:
+		// Handle regular types with reflection
+		return decodeRegularType(deserializer, moveType)
+	}
+}
+
+func decodeBigInt(deserializer *mystenbcs.Decoder, moveType string, size int) (*big.Int, error) {
+	// Direct decoding based on size
+	switch size {
+	case 16:
+		var bytes [16]byte
+		if _, err := deserializer.Decode(&bytes); err != nil {
+			return nil, fmt.Errorf("failed to decode %s: %w", moveType, err)
+		}
+		return DecodeU128Value(bytes)
+	case 32:
+		var bytes [32]byte
+		if _, err := deserializer.Decode(&bytes); err != nil {
+			return nil, fmt.Errorf("failed to decode %s: %w", moveType, err)
+		}
+		return DecodeU256Value(bytes)
+	default:
+		return nil, fmt.Errorf("unsupported big int size %d for type %s", size, moveType)
+	}
+}
+
+func decodeRegularType(deserializer *mystenbcs.Decoder, moveType string) (any, error) {
 	refType := getElementType(moveType)
 	res := reflect.New(refType)
-	_, err := deserializer.Decode(res.Interface())
-	return res.Elem().Interface(), err
+	if _, err := deserializer.Decode(res.Interface()); err != nil {
+		return nil, fmt.Errorf("failed to decode type %s: %w", moveType, err)
+	}
+	return res.Elem().Interface(), nil
 }
 
 // TODO: treat big.int since it's a structure with unexported fields

--- a/bindings/bind/bcs_decoder.go
+++ b/bindings/bind/bcs_decoder.go
@@ -341,9 +341,6 @@ func decodeRegularType(deserializer *mystenbcs.Decoder, moveType string) (any, e
 	return res.Elem().Interface(), nil
 }
 
-// TODO: treat big.int since it's a structure with unexported fields
-// encoder doesn't work. So does decoder. To return as a proper big.Int
-// we'll need to handle it in DeserializeBCS
 func getElementType(moveType string) reflect.Type {
 	switch {
 	case moveType == "bool":

--- a/bindings/bind/bcs_decoder_test.go
+++ b/bindings/bind/bcs_decoder_test.go
@@ -1,10 +1,13 @@
 package bind
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
+	"github.com/block-vision/sui-go-sdk/models"
 	"github.com/block-vision/sui-go-sdk/mystenbcs"
+	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -255,4 +258,54 @@ func TestSpecificDecodeFunctions(t *testing.T) {
 		assert.Equal(t, 0, result128.Cmp(result256), "u128 and u256 decoding should give same result for same value")
 		assert.Equal(t, 0, result128.Cmp(testValue), "Decoded value should match original")
 	})
+}
+
+func TestDeserializer(t *testing.T) {
+	mockAddr := "0x8bc59c2842f436c1221691a359dc42941c1f25eca13f4bad79f7b00e8df4b968"
+	addr, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(mockAddr))
+	require.NoError(t, err)
+
+	// Encode BCS
+	bcsEncodedMsg := bytes.Buffer{}
+	encoder := mystenbcs.NewEncoder(&bcsEncodedMsg)
+	encoder.Encode(true)
+	encoder.Encode([][]*models.SuiAddressBytes{{addr, addr}, {addr}})
+	encoder.Encode(uint8(7))
+	encoder.Encode("hello sui")
+	encoder.Encode(uint16(7))
+	encoder.Encode([]uint8{0, 1, 2, 3, 4, 5, 6})
+	encoder.Encode(^uint32(0))
+	encoder.Encode([][]string{{"hello", "hi"}, {"world", "sui"}})
+	encoder.Encode(^uint64(0))
+
+	// Deserialize BCS
+	bcsMsg := bcsEncodedMsg.Bytes()
+	des, err := DeserializeBCS(
+		bcsMsg,
+		[]string{
+			"bool",
+			"vector<vector<address>>",
+			"u8",
+			"0x1::string::String",
+			"u16",
+			"vector\u003cu8\u003e",
+			"u32",
+			"vector<vector<0x1::string::String>>",
+			"u64",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]any{
+			true,
+			[][][32]byte{{*addr, *addr}, {*addr}},
+			uint8(7),
+			"hello sui",
+			uint16(7),
+			[]uint8{0, 1, 2, 3, 4, 5, 6},
+			^uint32(0),
+			[][]string{{"hello", "hi"}, {"world", "sui"}},
+			^uint64(0)},
+		des,
+	)
 }

--- a/bindings/bind/bcs_decoder_test.go
+++ b/bindings/bind/bcs_decoder_test.go
@@ -261,9 +261,15 @@ func TestSpecificDecodeFunctions(t *testing.T) {
 }
 
 func TestDeserializer(t *testing.T) {
+	// Address values
 	mockAddr := "0x8bc59c2842f436c1221691a359dc42941c1f25eca13f4bad79f7b00e8df4b968"
 	addr, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(mockAddr))
 	require.NoError(t, err)
+	// u128 and u256 values
+	u128 := new(big.Int)
+	u128.SetString("12345678901234567890", 10)
+	u256 := new(big.Int)
+	u256.SetString("1234567890123456789012345678901234567890", 10)
 
 	// Encode BCS
 	bcsEncodedMsg := bytes.Buffer{}
@@ -277,9 +283,15 @@ func TestDeserializer(t *testing.T) {
 	encoder.Encode(^uint32(0))
 	encoder.Encode([][]string{{"hello", "hi"}, {"world", "sui"}})
 	encoder.Encode(^uint64(0))
+	bcsMsg := bcsEncodedMsg.Bytes()
+	// mystenbcs encoder treats [n]byte as a regular slice and encodes the length, so we cannot use it directly.
+	// we'll append the encoded u128 and u256 bytes manually
+	u128AsByte := [16]byte{0xd2, 0xa, 0x1f, 0xeb, 0x8c, 0xa9, 0x54, 0xab}
+	u256AsByte := [32]byte{0xd2, 0xa, 0x3f, 0xce, 0x96, 0x5f, 0xbc, 0xac, 0xb8, 0xf3, 0xdb, 0xc0, 0x75, 0x20, 0xc9, 0xa0, 0x3}
+	bcsMsg = append(bcsMsg, u128AsByte[:]...)
+	bcsMsg = append(bcsMsg, u256AsByte[:]...)
 
 	// Deserialize BCS
-	bcsMsg := bcsEncodedMsg.Bytes()
 	des, err := DeserializeBCS(
 		bcsMsg,
 		[]string{
@@ -292,6 +304,8 @@ func TestDeserializer(t *testing.T) {
 			"u32",
 			"vector<vector<0x1::string::String>>",
 			"u64",
+			"u128",
+			"u256",
 		},
 	)
 	require.NoError(t, err)
@@ -305,7 +319,10 @@ func TestDeserializer(t *testing.T) {
 			[]uint8{0, 1, 2, 3, 4, 5, 6},
 			^uint32(0),
 			[][]string{{"hello", "hi"}, {"world", "sui"}},
-			^uint64(0)},
+			^uint64(0),
+			u128,
+			u256,
+		},
 		des,
 	)
 }


### PR DESCRIPTION
# Summary
Add a method to deserialize transaction data into a slice of arguments.
`DeserializeBCS` will take data containing multiple encoded arguments and deserializes them based on a provided list of move types.

# Testing
Unit tests using `sui-sdk` encoder.

