### PR TITLE
MCMS entrypoints args encoder

### DIFF
--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -1,9 +1,11 @@
 package mcmsencoder
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
 	"github.com/block-vision/sui-go-sdk/sui"
 	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
@@ -18,6 +20,8 @@ import (
 	module_managed_token "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/managed_token/managed_token"
 )
 
+var SuiAddressLength = 32
+
 type CCIPEntrypointArgEncoder struct {
 	registryObjID string
 	client        sui.ISuiAPI
@@ -25,6 +29,15 @@ type CCIPEntrypointArgEncoder struct {
 
 func NewCCIPEntrypointArgEncoder() *CCIPEntrypointArgEncoder {
 	return &CCIPEntrypointArgEncoder{}
+}
+
+func deserializeFirst32Bytes(data []byte) []byte {
+	deserializer := bcs.NewDeserializer(data)
+	return deserializer.ReadFixedBytes(SuiAddressLength)
+}
+
+func toHexString(data []byte) string {
+	return fmt.Sprintf("0x%s", strings.ToLower(hex.EncodeToString(data)))
 }
 
 // MCMS SDK will call this to encode the entrypoint call
@@ -35,8 +48,10 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 	registryObj := bind.Object{Id: e.registryObjID}
 
 	encodeWithCCIPObjectRefAndState := func() (*bind.EncodedCall, error) {
-		// TODO: These should come from decoded data
-		ccipRef := bind.Object{Id: "0x123"}
+		// Deserialize the ccip object ref (always the first 32 bytes)
+		ccipRefBytes := deserializeFirst32Bytes(data)
+		ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
+
 		offramp, err := module_offramp.NewOfframp(target, e.client)
 		if err != nil {
 			return nil, err
@@ -98,7 +113,12 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		}
 		switch function {
 		case "update_prices_with_owner_cap":
-			return feeQuoter.Encoder().McmsUpdatePricesWithOwnerCapWithArgs(stateObj, registryObj, clock, executingCallbackParams)
+			ccipRefBytes := deserializeFirst32Bytes(data)
+			ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
+			if ccipRef.Id != stateObj.Id {
+				return nil, fmt.Errorf("ccip ref (%s) does not match state object (%s)", ccipRef.Id, stateObj.Id)
+			}
+			return feeQuoter.Encoder().McmsUpdatePricesWithOwnerCapWithArgs(ccipRef, registryObj, clock, executingCallbackParams)
 		}
 
 	// OFFRAMP
@@ -128,14 +148,32 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		case "execute_ownership_transfer":
 			return encodeWithCCIPObjectRefAndState()
 		case "initialize":
-			// TODO: These should come from decoded data
-			nonceManagerCap := bind.Object{Id: "0x456"}
-			sourceTransferCap := bind.Object{Id: "0x789"}
-			return onramp.Encoder().McmsInitializeWithArgs(stateObj, registryObj, nonceManagerCap, sourceTransferCap, executingCallbackParams)
+			deserializer := bcs.NewDeserializer(data)
+			state := deserializer.ReadFixedBytes(SuiAddressLength)
+			deserializer.ReadFixedBytes(SuiAddressLength) // skip owner cap, we don't need it
+			nonceManagerCap := deserializer.ReadFixedBytes(SuiAddressLength)
+			sourceTransferCap := deserializer.ReadFixedBytes(SuiAddressLength)
+
+			nonceManagerCapObj := bind.Object{Id: toHexString(nonceManagerCap)}
+			sourceTransferCapObj := bind.Object{Id: toHexString(sourceTransferCap)}
+
+			if toHexString(state) != stateObj.Id {
+				return nil, fmt.Errorf("state (%s) does not match state object (%s)", toHexString(state), stateObj.Id)
+			}
+			return onramp.Encoder().McmsInitializeWithArgs(stateObj, registryObj, nonceManagerCapObj, sourceTransferCapObj, executingCallbackParams)
 		case "withdraw_fee_tokens":
-			// TODO: These should come from decoded data
-			coinMetadata := bind.Object{Id: "0xabc"}
-			ccipRef := bind.Object{Id: "0x123"}
+			deserializer := bcs.NewDeserializer(data)
+			ccipRefBytes := deserializer.ReadFixedBytes(SuiAddressLength)
+			state := deserializer.ReadFixedBytes(SuiAddressLength)
+			deserializer.ReadFixedBytes(SuiAddressLength) // skip owner cap, we don't need it
+			feeTokenMetadata := deserializer.ReadFixedBytes(SuiAddressLength)
+
+			coinMetadata := bind.Object{Id: toHexString(feeTokenMetadata)}
+			ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
+
+			if toHexString(state) != stateObj.Id {
+				return nil, fmt.Errorf("state (%s) does not match state object (%s)", toHexString(state), stateObj.Id)
+			}
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
 			return onramp.Encoder().McmsWithdrawFeeTokensWithArgs(typeArgs, ccipRef, stateObj, registryObj, coinMetadata, executingCallbackParams)
@@ -264,37 +302,33 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		case "configure_new_minter":
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
-			// TODO: This doesn't exist
-			denyList := bind.Object{Id: "0xdef"}
-			return managedToken.Encoder().McmsConfigureNewMinterWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+			return managedToken.Encoder().McmsConfigureNewMinterWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
 		case "increment_mint_allowance":
-			// TODO: Find correct type args
-			typeArgs := []string{"0x1::sui::SUI"}
-			denyList := bind.Object{Id: "0xdef"}
-			return managedToken.Encoder().McmsIncrementMintAllowanceWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
 		case "set_unlimited_mint_allowances":
-			// TODO: Find correct type args
-			typeArgs := []string{"0x1::sui::SUI"}
-			denyList := bind.Object{Id: "0xdef"}
-			return managedToken.Encoder().McmsSetUnlimitedMintAllowancesWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
 		case "blocklist":
-			// TODO: Find correct type args
-			typeArgs := []string{"0x1::sui::SUI"}
-			denyList := bind.Object{Id: "0xdef"}
-			return managedToken.Encoder().McmsBlocklistWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
 		case "unblocklist":
-			// TODO: Find correct type args
-			typeArgs := []string{"0x1::sui::SUI"}
-			denyList := bind.Object{Id: "0xdef"}
-			return managedToken.Encoder().McmsUnblocklistWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
 		case "pause":
-			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
-			denyList := bind.Object{Id: "0xdef"}
-			return managedToken.Encoder().McmsPauseWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
-		}
+			deserializer := bcs.NewDeserializer(data)
+			state := deserializer.ReadFixedBytes(SuiAddressLength)
+			deserializer.ReadFixedBytes(SuiAddressLength) // skip owner cap, we don't need it
+			denyList := deserializer.ReadFixedBytes(SuiAddressLength)
 
-		// END OF MODULE SWITCH
+			denyListObj := bind.Object{Id: toHexString(denyList)}
+
+			if toHexString(state) != stateObj.Id {
+				return nil, fmt.Errorf("state (%s) does not match state object (%s)", toHexString(state), stateObj.Id)
+			}
+			entrypointCall, err := managedToken.Encoder().McmsIncrementMintAllowanceWithArgs(typeArgs, stateObj, registryObj, denyListObj, executingCallbackParams)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create mcms_entrypoint call: %w", err)
+			}
+			// Override the module info with the actual target
+			entrypointCall.Module.ModuleName = module
+			// mcms entrypoint like functions are the target function prefixed with `mcms_`
+			entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
+			return entrypointCall, nil
+		}
 	}
 
 	// FALLBACK CASE: Use Fee Quoter as it has the most common function signatures

--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/aptos-labs/aptos-go-sdk/bcs"
-	"github.com/block-vision/sui-go-sdk/sui"
 	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	module_fee_quoter "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/fee_quoter"
@@ -24,7 +23,6 @@ var SuiAddressLength = 32
 
 type CCIPEntrypointArgEncoder struct {
 	registryObjID string
-	client        sui.ISuiAPI
 }
 
 func NewCCIPEntrypointArgEncoder() *CCIPEntrypointArgEncoder {
@@ -40,6 +38,12 @@ func toHexString(data []byte) string {
 	return fmt.Sprintf("0x%s", strings.ToLower(hex.EncodeToString(data)))
 }
 
+func overrideCall(call *bind.EncodedCall, module, function string) *bind.EncodedCall {
+	call.Module.ModuleName = module
+	call.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
+	return call
+}
+
 // MCMS SDK will call this to encode the entrypoint call
 // Data is the raw BCS encoded bytes of the final function call
 func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *transaction.Argument, target, module, function, stateObjID string, data []byte) (*bind.EncodedCall, error) {
@@ -52,7 +56,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		ccipRefBytes := deserializeFirst32Bytes(data)
 		ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
 
-		offramp, err := module_offramp.NewOfframp(target, e.client)
+		offramp, err := module_offramp.NewOfframp(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -61,15 +65,12 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		if err != nil {
 			return nil, err
 		}
-		// Override the module info with the actual target
-		entrypointCall.Module.ModuleName = module
-		// mcms entrypoint like functions are the target function prefixed with `mcms_`
-		entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
-		return entrypointCall, nil
+
+		return overrideCall(entrypointCall, module, function), nil
 	}
 
 	encodeDefaultWithTypeArgsAndClock := func() (*bind.EncodedCall, error) {
-		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, e.client)
+		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -79,15 +80,12 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		if err != nil {
 			return nil, err
 		}
-		// Override the module info with the actual target
-		entrypointCall.Module.ModuleName = module
-		// mcms entrypoint like functions are the target function prefixed with `mcms_`
-		entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
-		return entrypointCall, nil
+
+		return overrideCall(entrypointCall, module, function), nil
 	}
 
 	encodeDefaultWithTypeArgs := func() (*bind.EncodedCall, error) {
-		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, e.client)
+		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -97,17 +95,14 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		if err != nil {
 			return nil, err
 		}
-		// Override the module info with the actual target
-		entrypointCall.Module.ModuleName = module
-		// mcms entrypoint like functions are the target function prefixed with `mcms_`
-		entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
-		return entrypointCall, nil
+
+		return overrideCall(entrypointCall, module, function), nil
 	}
 
 	switch module {
 	// FEE QUOTER
 	case "fee_quoter":
-		feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, e.client)
+		feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -124,28 +119,28 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 	// OFFRAMP
 	case "offramp":
 		switch function {
-		case "accept_ownership":
-		case "set_dynamic_config":
-		case "apply_source_chain_config_updates":
-		case "set_ocr3_config":
-		case "transfer_ownership":
-		case "execute_ownership_transfer":
+		case "accept_ownership",
+			"set_dynamic_config",
+			"apply_source_chain_config_updates",
+			"set_ocr3_config",
+			"transfer_ownership",
+			"execute_ownership_transfer":
 			return encodeWithCCIPObjectRefAndState()
 		}
 
 	// ONRAMP
 	case "onramp":
-		onramp, err := module_onramp.NewOnramp(target, e.client)
+		onramp, err := module_onramp.NewOnramp(target, nil)
 		if err != nil {
 			return nil, err
 		}
 		switch function {
-		case "accept_ownership":
-		case "set_dynamic_config":
-		case "apply_dest_chain_config_updates":
-		case "apply_allowlist_updates":
-		case "transfer_ownership":
-		case "execute_ownership_transfer":
+		case "accept_ownership",
+			"set_dynamic_config",
+			"apply_dest_chain_config_updates",
+			"apply_allowlist_updates",
+			"transfer_ownership",
+			"execute_ownership_transfer":
 			return encodeWithCCIPObjectRefAndState()
 		case "initialize":
 			deserializer := bcs.NewDeserializer(data)
@@ -181,7 +176,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 
 	// ROUTER
 	case "router":
-		router, err := module_router.NewRouter(target, e.client)
+		router, err := module_router.NewRouter(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -192,7 +187,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 
 	// BURN MINT TOKEN POOL
 	case "burn_mint_token_pool":
-		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, e.client)
+		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -201,22 +196,22 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
 			return burnMintTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
-		case "set_allowlist_enabled":
-		case "apply_allowlist_updates":
-		case "apply_chain_updates":
-		case "add_remote_pool":
-		case "remove_remote_pool":
-		case "transfer_ownership":
-		case "execute_ownership_transfer":
+		case "set_allowlist_enabled",
+			"apply_allowlist_updates",
+			"apply_chain_updates",
+			"add_remote_pool",
+			"remove_remote_pool",
+			"transfer_ownership",
+			"execute_ownership_transfer":
 			return encodeDefaultWithTypeArgs()
-		case "set_chain_rate_limiter_configs":
-		case "set_chain_rate_limiter_config":
-			return encodeDefaultWithTypeArgs()
+		case "set_chain_rate_limiter_configs",
+			"set_chain_rate_limiter_config":
+			return encodeDefaultWithTypeArgsAndClock()
 		}
 
 	// LOCK RELEASE TOKEN POOL
 	case "lock_release_token_pool":
-		lockReleaseTokenPool, err := module_lock_release_token_pool.NewLockReleaseTokenPool(target, e.client)
+		lockReleaseTokenPool, err := module_lock_release_token_pool.NewLockReleaseTokenPool(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -225,24 +220,24 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
 			return lockReleaseTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
-		case "set_rebalancer":
-		case "set_allowlist_enabled":
-		case "apply_allowlist_updates":
-		case "apply_chain_updates":
-		case "add_remote_pool":
-		case "remove_remote_pool":
-		case "transfer_ownership":
-		case "execute_ownership_transfer":
+		case "set_rebalancer",
+			"set_allowlist_enabled",
+			"apply_allowlist_updates",
+			"apply_chain_updates",
+			"add_remote_pool",
+			"remove_remote_pool",
+			"transfer_ownership",
+			"execute_ownership_transfer":
 			return encodeDefaultWithTypeArgs()
-		case "set_chain_rate_limiter_configs":
-		case "set_chain_rate_limiter_config":
+		case "set_chain_rate_limiter_configs",
+			"set_chain_rate_limiter_config":
 			return encodeDefaultWithTypeArgsAndClock()
 
 		}
 
 	// MANAGED TOKEN POOL
 	case "managed_token_pool":
-		managedTokenPool, err := module_managed_token_pool.NewManagedTokenPool(target, e.client)
+		managedTokenPool, err := module_managed_token_pool.NewManagedTokenPool(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -251,22 +246,22 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
 			return managedTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
-		case "set_allowlist_enabled":
-		case "apply_allowlist_updates":
-		case "apply_chain_updates":
-		case "add_remote_pool":
-		case "remove_remote_pool":
-		case "transfer_ownership":
-		case "execute_ownership_transfer":
+		case "set_allowlist_enabled",
+			"apply_allowlist_updates",
+			"apply_chain_updates",
+			"add_remote_pool",
+			"remove_remote_pool",
+			"transfer_ownership",
+			"execute_ownership_transfer":
 			return encodeDefaultWithTypeArgs()
-		case "set_chain_rate_limiter_configs":
-		case "set_chain_rate_limiter_config":
+		case "set_chain_rate_limiter_configs",
+			"set_chain_rate_limiter_config":
 			return encodeDefaultWithTypeArgsAndClock()
 		}
 
 	// USDC TOKEN POOL
 	case "usdc_token_pool":
-		usdcTokenPool, err := module_usdc_token_pool.NewUsdcTokenPool(target, e.client)
+		usdcTokenPool, err := module_usdc_token_pool.NewUsdcTokenPool(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -275,22 +270,21 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
 			return usdcTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
-		case "set_allowlist_enabled":
-		case "apply_allowlist_updates":
-		case "apply_chain_updates":
-		case "add_remote_pool":
-		case "remove_remote_pool":
-		case "transfer_ownership":
-		case "execute_ownership_transfer":
+		case "set_allowlist_enabled",
+			"apply_allowlist_updates",
+			"apply_chain_updates",
+			"add_remote_pool",
+			"remove_remote_pool",
+			"transfer_ownership",
+			"execute_ownership_transfer":
 			return encodeDefaultWithTypeArgs()
-		case "set_chain_rate_limiter_configs":
-		case "set_chain_rate_limiter_config":
+		case "set_chain_rate_limiter_configs", "set_chain_rate_limiter_config":
 			return encodeDefaultWithTypeArgsAndClock()
 		}
 
 	// MANAGED TOKEN
 	case "managed_token":
-		managedToken, err := module_managed_token.NewManagedToken(target, e.client)
+		managedToken, err := module_managed_token.NewManagedToken(target, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -303,11 +297,11 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			// TODO: Find correct type args
 			typeArgs := []string{"0x1::sui::SUI"}
 			return managedToken.Encoder().McmsConfigureNewMinterWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
-		case "increment_mint_allowance":
-		case "set_unlimited_mint_allowances":
-		case "blocklist":
-		case "unblocklist":
-		case "pause":
+		case "increment_mint_allowance",
+			"set_unlimited_mint_allowances",
+			"blocklist",
+			"unblocklist",
+			"pause":
 			typeArgs := []string{"0x1::sui::SUI"}
 			deserializer := bcs.NewDeserializer(data)
 			state := deserializer.ReadFixedBytes(SuiAddressLength)
@@ -323,20 +317,19 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			if err != nil {
 				return nil, fmt.Errorf("failed to create mcms_entrypoint call: %w", err)
 			}
-			// Override the module info with the actual target
-			entrypointCall.Module.ModuleName = module
-			// mcms entrypoint like functions are the target function prefixed with `mcms_`
-			entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
-			return entrypointCall, nil
+
+			return overrideCall(entrypointCall, module, function), nil
 		}
 	}
+
+	fmt.Println("MODULE AND FUNCTION", module, function)
 
 	// FALLBACK CASE: Use Fee Quoter as it has the most common function signatures
 	// Fallback to fee quoter for any unhandled module/function
 	// This works because most mcms functions have the same signature
 	// state: &State, registry: &Registry, executing_callback_params: &ExecutingCallbackParams
 	// If a function has a different signature, it should be handled explicitly above
-	feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, e.client)
+	feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -349,10 +342,6 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mcms_entrypoint call: %w", err)
 	}
-	// Override the module info with the actual target
-	entryPointCall.Module.ModuleName = module
-	// mcms entrypoint like functions are the target function prefixed with `mcms_`
-	entryPointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
 
-	return entryPointCall, nil
+	return overrideCall(entryPointCall, module, function), nil
 }

--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -27,19 +27,6 @@ func NewCCIPEntrypointArgEncoder() *CCIPEntrypointArgEncoder {
 	return &CCIPEntrypointArgEncoder{}
 }
 
-// package-level constructor variables so tests can inject fakes
-var (
-	newFeeQuoter            = module_fee_quoter.NewFeeQuoter
-	newOfframp              = module_offramp.NewOfframp
-	newOnramp               = module_onramp.NewOnramp
-	newRouter               = module_router.NewRouter
-	newBurnMintTokenPool    = module_burn_mint_token_pool.NewBurnMintTokenPool
-	newLockReleaseTokenPool = module_lock_release_token_pool.NewLockReleaseTokenPool
-	newManagedTokenPool     = module_managed_token_pool.NewManagedTokenPool
-	newUsdcTokenPool        = module_usdc_token_pool.NewUsdcTokenPool
-	newManagedToken         = module_managed_token.NewManagedToken
-)
-
 // MCMS SDK will call this to encode the entrypoint call
 // Data is the raw BCS encoded bytes of the final function call
 func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *transaction.Argument, target, module, function, stateObjID string, data []byte) (*bind.EncodedCall, error) {

--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -1,0 +1,337 @@
+package mcmsencoder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/block-vision/sui-go-sdk/sui"
+	"github.com/block-vision/sui-go-sdk/transaction"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_fee_quoter "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/fee_quoter"
+	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
+	module_onramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/onramp"
+	module_router "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_router"
+	module_burn_mint_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool"
+	module_lock_release_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool"
+	module_managed_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/managed_token_pool"
+	module_usdc_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/usdc_token_pool"
+	module_managed_token "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/managed_token/managed_token"
+)
+
+type CCIPEntrypointArgEncoder struct {
+	registryObjID string
+	client        sui.ISuiAPI
+}
+
+func NewCCIPEntrypointArgEncoder() *CCIPEntrypointArgEncoder {
+	return &CCIPEntrypointArgEncoder{}
+}
+
+// package-level constructor variables so tests can inject fakes
+var (
+	newFeeQuoter            = module_fee_quoter.NewFeeQuoter
+	newOfframp              = module_offramp.NewOfframp
+	newOnramp               = module_onramp.NewOnramp
+	newRouter               = module_router.NewRouter
+	newBurnMintTokenPool    = module_burn_mint_token_pool.NewBurnMintTokenPool
+	newLockReleaseTokenPool = module_lock_release_token_pool.NewLockReleaseTokenPool
+	newManagedTokenPool     = module_managed_token_pool.NewManagedTokenPool
+	newUsdcTokenPool        = module_usdc_token_pool.NewUsdcTokenPool
+	newManagedToken         = module_managed_token.NewManagedToken
+)
+
+// MCMS SDK will call this to encode the entrypoint call
+// Data is the raw BCS encoded bytes of the final function call
+func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *transaction.Argument, target, module, function, stateObjID string, data []byte) (*bind.EncodedCall, error) {
+	clock := bind.Object{Id: "0x6"}
+	stateObj := bind.Object{Id: stateObjID}
+	registryObj := bind.Object{Id: e.registryObjID}
+
+	encodeWithCCIPObjectRefAndState := func() (*bind.EncodedCall, error) {
+		// TODO: These should come from decoded data
+		ccipRef := bind.Object{Id: "0x123"}
+		offramp, err := module_offramp.NewOfframp(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		// The function signature is the same for all ccip entrypoints that require the ccip object ref, so we can use any of them to encode
+		entrypointCall, err := offramp.Encoder().McmsSetDynamicConfigWithArgs(ccipRef, stateObj, registryObj, executingCallbackParams)
+		if err != nil {
+			return nil, err
+		}
+		// Override the module info with the actual target
+		entrypointCall.Module.ModuleName = module
+		// mcms entrypoint like functions are the target function prefixed with `mcms_`
+		entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
+		return entrypointCall, nil
+	}
+
+	encodeDefaultWithTypeArgsAndClock := func() (*bind.EncodedCall, error) {
+		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: Find correct type args
+		typeArgs := []string{"0x1::sui::SUI"}
+		entrypointCall, err := burnMintTokenPool.Encoder().McmsSetChainRateLimiterConfigsWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams, clock)
+		if err != nil {
+			return nil, err
+		}
+		// Override the module info with the actual target
+		entrypointCall.Module.ModuleName = module
+		// mcms entrypoint like functions are the target function prefixed with `mcms_`
+		entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
+		return entrypointCall, nil
+	}
+
+	encodeDefaultWithTypeArgs := func() (*bind.EncodedCall, error) {
+		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: Find correct type args
+		typeArgs := []string{"0x1::sui::SUI"}
+		entrypointCall, err := burnMintTokenPool.Encoder().McmsExecuteOwnershipTransferWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
+		if err != nil {
+			return nil, err
+		}
+		// Override the module info with the actual target
+		entrypointCall.Module.ModuleName = module
+		// mcms entrypoint like functions are the target function prefixed with `mcms_`
+		entrypointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
+		return entrypointCall, nil
+	}
+
+	switch module {
+	// FEE QUOTER
+	case "fee_quoter":
+		feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "update_prices_with_owner_cap":
+			return feeQuoter.Encoder().McmsUpdatePricesWithOwnerCapWithArgs(stateObj, registryObj, clock, executingCallbackParams)
+		}
+
+	// OFFRAMP
+	case "offramp":
+		switch function {
+		case "accept_ownership":
+		case "set_dynamic_config":
+		case "apply_source_chain_config_updates":
+		case "set_ocr3_config":
+		case "transfer_ownership":
+		case "execute_ownership_transfer":
+			return encodeWithCCIPObjectRefAndState()
+		}
+
+	// ONRAMP
+	case "onramp":
+		onramp, err := module_onramp.NewOnramp(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+		case "set_dynamic_config":
+		case "apply_dest_chain_config_updates":
+		case "apply_allowlist_updates":
+		case "transfer_ownership":
+		case "execute_ownership_transfer":
+			return encodeWithCCIPObjectRefAndState()
+		case "initialize":
+			// TODO: These should come from decoded data
+			nonceManagerCap := bind.Object{Id: "0x456"}
+			sourceTransferCap := bind.Object{Id: "0x789"}
+			return onramp.Encoder().McmsInitializeWithArgs(stateObj, registryObj, nonceManagerCap, sourceTransferCap, executingCallbackParams)
+		case "withdraw_fee_tokens":
+			// TODO: These should come from decoded data
+			coinMetadata := bind.Object{Id: "0xabc"}
+			ccipRef := bind.Object{Id: "0x123"}
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			return onramp.Encoder().McmsWithdrawFeeTokensWithArgs(typeArgs, ccipRef, stateObj, registryObj, coinMetadata, executingCallbackParams)
+		}
+
+	// ROUTER
+	case "router":
+		router, err := module_router.NewRouter(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+			return router.Encoder().McmsAcceptOwnershipWithArgs(stateObj, executingCallbackParams)
+		}
+
+	// BURN MINT TOKEN POOL
+	case "burn_mint_token_pool":
+		burnMintTokenPool, err := module_burn_mint_token_pool.NewBurnMintTokenPool(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			return burnMintTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
+		case "set_allowlist_enabled":
+		case "apply_allowlist_updates":
+		case "apply_chain_updates":
+		case "add_remote_pool":
+		case "remove_remote_pool":
+		case "transfer_ownership":
+		case "execute_ownership_transfer":
+			return encodeDefaultWithTypeArgs()
+		case "set_chain_rate_limiter_configs":
+		case "set_chain_rate_limiter_config":
+			return encodeDefaultWithTypeArgs()
+		}
+
+	// LOCK RELEASE TOKEN POOL
+	case "lock_release_token_pool":
+		lockReleaseTokenPool, err := module_lock_release_token_pool.NewLockReleaseTokenPool(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			return lockReleaseTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
+		case "set_rebalancer":
+		case "set_allowlist_enabled":
+		case "apply_allowlist_updates":
+		case "apply_chain_updates":
+		case "add_remote_pool":
+		case "remove_remote_pool":
+		case "transfer_ownership":
+		case "execute_ownership_transfer":
+			return encodeDefaultWithTypeArgs()
+		case "set_chain_rate_limiter_configs":
+		case "set_chain_rate_limiter_config":
+			return encodeDefaultWithTypeArgsAndClock()
+
+		}
+
+	// MANAGED TOKEN POOL
+	case "managed_token_pool":
+		managedTokenPool, err := module_managed_token_pool.NewManagedTokenPool(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			return managedTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
+		case "set_allowlist_enabled":
+		case "apply_allowlist_updates":
+		case "apply_chain_updates":
+		case "add_remote_pool":
+		case "remove_remote_pool":
+		case "transfer_ownership":
+		case "execute_ownership_transfer":
+			return encodeDefaultWithTypeArgs()
+		case "set_chain_rate_limiter_configs":
+		case "set_chain_rate_limiter_config":
+			return encodeDefaultWithTypeArgsAndClock()
+		}
+
+	// USDC TOKEN POOL
+	case "usdc_token_pool":
+		usdcTokenPool, err := module_usdc_token_pool.NewUsdcTokenPool(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			return usdcTokenPool.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
+		case "set_allowlist_enabled":
+		case "apply_allowlist_updates":
+		case "apply_chain_updates":
+		case "add_remote_pool":
+		case "remove_remote_pool":
+		case "transfer_ownership":
+		case "execute_ownership_transfer":
+			return encodeDefaultWithTypeArgs()
+		case "set_chain_rate_limiter_configs":
+		case "set_chain_rate_limiter_config":
+			return encodeDefaultWithTypeArgsAndClock()
+		}
+
+	// MANAGED TOKEN
+	case "managed_token":
+		managedToken, err := module_managed_token.NewManagedToken(target, e.client)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "accept_ownership":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			return managedToken.Encoder().McmsAcceptOwnershipWithArgs(typeArgs, stateObj, executingCallbackParams)
+		case "configure_new_minter":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			// TODO: This doesn't exist
+			denyList := bind.Object{Id: "0xdef"}
+			return managedToken.Encoder().McmsConfigureNewMinterWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+		case "increment_mint_allowance":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			denyList := bind.Object{Id: "0xdef"}
+			return managedToken.Encoder().McmsIncrementMintAllowanceWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+		case "set_unlimited_mint_allowances":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			denyList := bind.Object{Id: "0xdef"}
+			return managedToken.Encoder().McmsSetUnlimitedMintAllowancesWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+		case "blocklist":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			denyList := bind.Object{Id: "0xdef"}
+			return managedToken.Encoder().McmsBlocklistWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+		case "unblocklist":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			denyList := bind.Object{Id: "0xdef"}
+			return managedToken.Encoder().McmsUnblocklistWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+		case "pause":
+			// TODO: Find correct type args
+			typeArgs := []string{"0x1::sui::SUI"}
+			denyList := bind.Object{Id: "0xdef"}
+			return managedToken.Encoder().McmsPauseWithArgs(typeArgs, stateObj, registryObj, denyList, executingCallbackParams)
+		}
+
+		// END OF MODULE SWITCH
+	}
+
+	// FALLBACK CASE: Use Fee Quoter as it has the most common function signatures
+	// Fallback to fee quoter for any unhandled module/function
+	// This works because most mcms functions have the same signature
+	// state: &State, registry: &Registry, executing_callback_params: &ExecutingCallbackParams
+	// If a function has a different signature, it should be handled explicitly above
+	feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, e.client)
+	if err != nil {
+		return nil, err
+	}
+
+	entryPointCall, err := feeQuoter.Encoder().McmsApplyFeeTokenUpdatesWithArgs(
+		stateObj,
+		registryObj,
+		executingCallbackParams,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mcms_entrypoint call: %w", err)
+	}
+	// Override the module info with the actual target
+	entryPointCall.Module.ModuleName = module
+	// mcms entrypoint like functions are the target function prefixed with `mcms_`
+	entryPointCall.Function = fmt.Sprintf("mcms_%s", strings.TrimPrefix(function, "mcms_"))
+
+	return entryPointCall, nil
+}

--- a/bindings/mcms_encoder_test.go
+++ b/bindings/mcms_encoder_test.go
@@ -1,0 +1,1059 @@
+//go:build unit
+
+package mcmsencoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+	"github.com/block-vision/sui-go-sdk/transaction"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+)
+
+// Helper function to create a 32-byte address from a hex string
+func createAddress(addr string) []byte {
+	// Ensure address has "0x" prefix
+	if len(addr) < 2 || addr[:2] != "0x" {
+		addr = "0x" + addr
+	}
+	// Pad to 32 bytes (64 hex chars + 2 for "0x")
+	for len(addr) < 66 {
+		addr = "0x0" + addr[2:]
+	}
+
+	bytes := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		var b byte
+		for j := 0; j < 2; j++ {
+			c := addr[2+i*2+j]
+			if c >= '0' && c <= '9' {
+				b = b*16 + (c - '0')
+			} else if c >= 'a' && c <= 'f' {
+				b = b*16 + (c - 'a' + 10)
+			} else if c >= 'A' && c <= 'F' {
+				b = b*16 + (c - 'A' + 10)
+			}
+		}
+		bytes[i] = b
+	}
+	return bytes
+}
+
+// Helper function to serialize a single address for BCS
+func serializeAddress(addr string) []byte {
+	s := &bcs.Serializer{}
+	s.FixedBytes(createAddress(addr))
+	return s.ToBytes()
+}
+
+// Helper function to serialize multiple addresses for BCS
+func serializeAddresses(addrs ...string) []byte {
+	s := &bcs.Serializer{}
+	for _, addr := range addrs {
+		s.FixedBytes(createAddress(addr))
+	}
+	return s.ToBytes()
+}
+
+// Helper function to extract object ID from an EncodedCallArgument
+func extractObjectID(arg *bind.EncodedCallArgument) (string, error) {
+	if arg == nil {
+		return "", fmt.Errorf("nil argument")
+	}
+
+	if arg.CallArg == nil {
+		return "", fmt.Errorf("nil CallArg")
+	}
+
+	if arg.CallArg.UnresolvedObject != nil {
+		// Convert bytes to hex string
+		objBytes := arg.CallArg.UnresolvedObject.ObjectId
+		return toHexString(objBytes[:]), nil
+	}
+
+	if arg.CallArg.Object != nil {
+		if arg.CallArg.Object.ImmOrOwnedObject != nil {
+			return toHexString(arg.CallArg.Object.ImmOrOwnedObject.ObjectId[:]), nil
+		}
+		if arg.CallArg.Object.SharedObject != nil {
+			return toHexString(arg.CallArg.Object.SharedObject.ObjectId[:]), nil
+		}
+	}
+
+	return "", fmt.Errorf("no object ID found in argument")
+}
+
+func TestEncodeEntryPointArg_FeeQuoter(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("update_prices_with_owner_cap", func(t *testing.T) {
+		// For this function, ccipRef must match stateObjID
+		data := serializeAddress(stateObjID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"fee_quoter",
+			"update_prices_with_owner_cap",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "fee_quoter", result.Module.ModuleName)
+		assert.Equal(t, "mcms_update_prices_with_owner_cap", result.Function)
+
+		// Verify deserialization - the ccipRef should be extracted from data and match stateObjID
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ccipRef, registry, clock, executingCallbackParams")
+
+		// Verify the ccipRef was deserialized correctly and matches stateObjID
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, stateObjID, ccipRefFromResult, "CcipRef should match stateObjID (from BCS data)")
+	})
+
+	t.Run("fallback_case", func(t *testing.T) {
+		// Test an unhandled function that falls back to default encoding
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"fee_quoter",
+			"apply_fee_token_updates",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "fee_quoter", result.Module.ModuleName)
+		assert.Equal(t, "mcms_apply_fee_token_updates", result.Function)
+	})
+}
+
+func TestEncodeEntryPointArg_Offramp(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	ccipRefID := "0x8888888888888888888888888888888888888888888888888888888888888888"
+	executingCallbackParams := &transaction.Argument{}
+
+	testCases := []string{
+		"accept_ownership",
+		"set_dynamic_config",
+		"apply_source_chain_config_updates",
+		"set_ocr3_config",
+		"transfer_ownership",
+		"execute_ownership_transfer",
+	}
+
+	for _, fn := range testCases {
+		t.Run(fn, func(t *testing.T) {
+			data := serializeAddress(ccipRefID)
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"offramp",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "offramp", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			// Verify deserialization - the ccipRef should be extracted from data and match stateObjID
+			require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ccipRef, state, registry, executingCallbackParams")
+
+			// Verify the ccipRef was deserialized correctly and matches stateObjID
+			ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract ccipRef object ID")
+			assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_Onramp(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	ccipRefID := "0x8888888888888888888888888888888888888888888888888888888888888888"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("initialize", func(t *testing.T) {
+		ownerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		nonceManagerCapID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+		sourceTransferCapID := "0x5555555555555555555555555555555555555555555555555555555555555555"
+
+		data := serializeAddresses(stateObjID, ownerCapID, nonceManagerCapID, sourceTransferCapID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"onramp",
+			"initialize",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "onramp", result.Module.ModuleName)
+		assert.Equal(t, "mcms_initialize", result.Function)
+
+		// Verify deserialization - check that the encoder correctly deserialized BCS data
+		// and used the correct object IDs from the data
+		require.Len(t, result.CallArgs, 5, "Expected 5 arguments: state, registry, nonceManagerCap, sourceTransferCap, executingCallbackParams")
+
+		// Extract object IDs from the result to verify deserialization
+		stateObjIDFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateObjIDFromResult, "State object ID should match the one provided")
+
+		// Verify nonceManagerCap was deserialized correctly (3rd argument, index 2)
+		nonceManagerCapFromResult, err := extractObjectID(result.CallArgs[2])
+		require.NoError(t, err, "Failed to extract nonceManagerCap object ID")
+		assert.Equal(t, toHexString(createAddress(nonceManagerCapID)), nonceManagerCapFromResult, "NonceManagerCap should match deserialized value from data")
+
+		// Verify sourceTransferCap was deserialized correctly (4th argument, index 3)
+		sourceTransferCapFromResult, err := extractObjectID(result.CallArgs[3])
+		require.NoError(t, err, "Failed to extract sourceTransferCap object ID")
+		assert.Equal(t, toHexString(createAddress(sourceTransferCapID)), sourceTransferCapFromResult, "SourceTransferCap should match deserialized value from data")
+	})
+
+	t.Run("withdraw_fee_tokens", func(t *testing.T) {
+		ownerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		feeTokenMetadataID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+
+		data := serializeAddresses(ccipRefID, stateObjID, ownerCapID, feeTokenMetadataID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"onramp",
+			"withdraw_fee_tokens",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "onramp", result.Module.ModuleName)
+		assert.Equal(t, "mcms_withdraw_fee_tokens", result.Function)
+		assert.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+
+		// Verify deserialization - check that the encoder correctly deserialized BCS data
+		require.Len(t, result.CallArgs, 5, "Expected 5 arguments: ccipRef, state, registry, coinMetadata, executingCallbackParams")
+
+		// Verify ccipRef was deserialized correctly (1st argument)
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, toHexString(createAddress(ccipRefID)), ccipRefFromResult, "CcipRef should match deserialized value from data")
+
+		// Verify state object matches
+		stateFromResult, err := extractObjectID(result.CallArgs[1])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match the provided stateObjID")
+
+		// Verify coinMetadata was deserialized correctly (4th argument, index 3)
+		coinMetadataFromResult, err := extractObjectID(result.CallArgs[3])
+		require.NoError(t, err, "Failed to extract coinMetadata object ID")
+		assert.Equal(t, toHexString(createAddress(feeTokenMetadataID)), coinMetadataFromResult, "CoinMetadata should match deserialized value from data")
+	})
+
+	ccipTestCases := []string{
+		"accept_ownership",
+		"set_dynamic_config",
+		"apply_dest_chain_config_updates",
+		"apply_allowlist_updates",
+		"transfer_ownership",
+		"execute_ownership_transfer",
+	}
+
+	for _, fn := range ccipTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := serializeAddress(ccipRefID)
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"onramp",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "onramp", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			// Verify deserialization - the ccipRef should be extracted from data
+			require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ccipRef, state, registry, executingCallbackParams")
+
+			// Verify the ccipRef was deserialized correctly
+			ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract ccipRef object ID")
+			assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_Router(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("accept_ownership", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"router",
+			"accept_ownership",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "router", result.Module.ModuleName)
+		assert.Equal(t, "mcms_accept_ownership", result.Function)
+
+		// Verify deserialization - the state should be extracted from data
+		require.Len(t, result.CallArgs, 2, "Expected 2 arguments: state, executingCallbackParams")
+
+		// Verify the state was deserialized correctly
+		stateFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+	})
+}
+
+func TestEncodeEntryPointArg_BurnMintTokenPool(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("accept_ownership", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"burn_mint_token_pool",
+			"accept_ownership",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "burn_mint_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_accept_ownership", result.Function)
+	})
+
+	typeArgTestCases := []string{
+		"set_allowlist_enabled",
+		"apply_allowlist_updates",
+		"apply_chain_updates",
+		"add_remote_pool",
+		"remove_remote_pool",
+		"transfer_ownership",
+		"execute_ownership_transfer",
+	}
+
+	for _, fn := range typeArgTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"burn_mint_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "burn_mint_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+
+	rateLimiterTestCases := []string{
+		"set_chain_rate_limiter_configs",
+		"set_chain_rate_limiter_config",
+	}
+
+	for _, fn := range rateLimiterTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"burn_mint_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "burn_mint_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, clock, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_LockReleaseTokenPool(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("accept_ownership", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"lock_release_token_pool",
+			"accept_ownership",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_accept_ownership", result.Function)
+	})
+
+	typeArgTestCases := []string{
+		"set_rebalancer",
+		"set_allowlist_enabled",
+		"apply_allowlist_updates",
+		"apply_chain_updates",
+		"add_remote_pool",
+		"remove_remote_pool",
+		"transfer_ownership",
+		"execute_ownership_transfer",
+	}
+
+	for _, fn := range typeArgTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"lock_release_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+
+	rateLimiterTestCases := []string{
+		"set_chain_rate_limiter_configs",
+		"set_chain_rate_limiter_config",
+	}
+
+	for _, fn := range rateLimiterTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"lock_release_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, clock, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_ManagedTokenPool(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("accept_ownership", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"managed_token_pool",
+			"accept_ownership",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "managed_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_accept_ownership", result.Function)
+	})
+
+	typeArgTestCases := []string{
+		"set_allowlist_enabled",
+		"apply_allowlist_updates",
+		"apply_chain_updates",
+		"add_remote_pool",
+		"remove_remote_pool",
+		"transfer_ownership",
+		"execute_ownership_transfer",
+	}
+
+	for _, fn := range typeArgTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"managed_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "managed_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+
+	rateLimiterTestCases := []string{
+		"set_chain_rate_limiter_configs",
+		"set_chain_rate_limiter_config",
+	}
+
+	for _, fn := range rateLimiterTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"managed_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "managed_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, clock, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_UsdcTokenPool(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("accept_ownership", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"usdc_token_pool",
+			"accept_ownership",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "usdc_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_accept_ownership", result.Function)
+	})
+
+	typeArgTestCases := []string{
+		"set_allowlist_enabled",
+		"apply_allowlist_updates",
+		"apply_chain_updates",
+		"add_remote_pool",
+		"remove_remote_pool",
+		"transfer_ownership",
+		"execute_ownership_transfer",
+	}
+
+	for _, fn := range typeArgTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"usdc_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "usdc_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+
+	rateLimiterTestCases := []string{
+		"set_chain_rate_limiter_configs",
+		"set_chain_rate_limiter_config",
+	}
+
+	for _, fn := range rateLimiterTestCases {
+		t.Run(fn, func(t *testing.T) {
+			data := []byte{}
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"usdc_token_pool",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "usdc_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, clock, registry, executingCallbackParams")
+
+			// Verify the state was deserialized correctly
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_ManagedToken(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("accept_ownership", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"managed_token",
+			"accept_ownership",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "managed_token", result.Module.ModuleName)
+		assert.Equal(t, "mcms_accept_ownership", result.Function)
+
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 2, "Expected 2 arguments: state, executingCallbackParams")
+
+		// Verify the state was deserialized correctly
+		stateFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+	})
+
+	t.Run("configure_new_minter", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"managed_token",
+			"configure_new_minter",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "managed_token", result.Module.ModuleName)
+		assert.Equal(t, "mcms_configure_new_minter", result.Function)
+
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+		// Verify the state was deserialized correctly
+		stateFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+	})
+
+	denyListTestCases := []string{
+		"increment_mint_allowance",
+		"set_unlimited_mint_allowances",
+		"blocklist",
+		"unblocklist",
+		"pause",
+	}
+
+	for _, fn := range denyListTestCases {
+		t.Run(fn, func(t *testing.T) {
+			ownerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+			denyListID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+
+			data := serializeAddresses(stateObjID, ownerCapID, denyListID)
+
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"managed_token",
+				fn,
+				stateObjID,
+				data,
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "managed_token", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+
+			require.NotEmpty(t, result.CallArgs, "Expected call arguments to be populated")
+
+			denyListFromResult, err := extractObjectID(result.CallArgs[2])
+			require.NoError(t, err, "Failed to extract denyList object ID")
+			assert.Equal(t, toHexString(createAddress(denyListID)), denyListFromResult, "DenyList should match deserialized value from data")
+		})
+	}
+}
+
+func TestEncodeEntryPointArg_UnknownModule(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("fallback_to_default_encoder", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"unknown_module",
+			"unknown_function",
+			stateObjID,
+			data,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "unknown_module", result.Module.ModuleName)
+		assert.Equal(t, "mcms_unknown_function", result.Function)
+	})
+}
+
+func TestEncodeEntryPointArg_ErrorCases(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	wrongStateObjID := "0x8888888888888888888888888888888888888888888888888888888888888888"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("fee_quoter_update_prices_with_owner_cap_mismatch", func(t *testing.T) {
+		// ccipRef does not match stateObjID - should error
+		data := serializeAddress(wrongStateObjID)
+
+		_, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"fee_quoter",
+			"update_prices_with_owner_cap",
+			stateObjID,
+			data,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match state object")
+	})
+
+	t.Run("onramp_initialize_state_mismatch", func(t *testing.T) {
+		ownerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		nonceManagerCapID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+		sourceTransferCapID := "0x5555555555555555555555555555555555555555555555555555555555555555"
+
+		// First address is wrong state
+		data := serializeAddresses(wrongStateObjID, ownerCapID, nonceManagerCapID, sourceTransferCapID)
+
+		_, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"onramp",
+			"initialize",
+			stateObjID,
+			data,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match state object")
+	})
+
+	t.Run("onramp_withdraw_fee_tokens_state_mismatch", func(t *testing.T) {
+		ccipRefID := "0x8888888888888888888888888888888888888888888888888888888888888888"
+		ownerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		feeTokenMetadataID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+
+		// Second address is wrong state
+		data := serializeAddresses(ccipRefID, wrongStateObjID, ownerCapID, feeTokenMetadataID)
+
+		_, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"onramp",
+			"withdraw_fee_tokens",
+			stateObjID,
+			data,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match state object")
+	})
+
+	t.Run("managed_token_state_mismatch", func(t *testing.T) {
+		ownerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		denyListID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+
+		// First address is wrong state
+		data := serializeAddresses(wrongStateObjID, ownerCapID, denyListID)
+
+		_, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"managed_token",
+			"pause",
+			stateObjID,
+			data,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match state object")
+	})
+}
+
+func TestBCSDeserialization(t *testing.T) {
+	t.Run("deserialize_single_address", func(t *testing.T) {
+		expectedAddr := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+		data := serializeAddress(expectedAddr)
+
+		result := deserializeFirst32Bytes(data)
+
+		assert.Equal(t, 32, len(result))
+		assert.Equal(t, toHexString(result), toHexString(createAddress(expectedAddr)))
+	})
+
+	t.Run("deserialize_multiple_addresses", func(t *testing.T) {
+		addr1 := "0x1111111111111111111111111111111111111111111111111111111111111111"
+		addr2 := "0x2222222222222222222222222222222222222222222222222222222222222222"
+		addr3 := "0x3333333333333333333333333333333333333333333333333333333333333333"
+
+		data := serializeAddresses(addr1, addr2, addr3)
+
+		// Deserialize each address sequentially
+		deserializer := bcs.NewDeserializer(data)
+		result1 := deserializer.ReadFixedBytes(SuiAddressLength)
+		result2 := deserializer.ReadFixedBytes(SuiAddressLength)
+		result3 := deserializer.ReadFixedBytes(SuiAddressLength)
+
+		assert.Equal(t, toHexString(result1), toHexString(createAddress(addr1)))
+		assert.Equal(t, toHexString(result2), toHexString(createAddress(addr2)))
+		assert.Equal(t, toHexString(result3), toHexString(createAddress(addr3)))
+	})
+
+	t.Run("verify_address_format", func(t *testing.T) {
+		// Test that addresses are correctly padded and formatted
+		shortAddr := "0x123"
+		data := serializeAddress(shortAddr)
+
+		result := deserializeFirst32Bytes(data)
+		resultHex := toHexString(result)
+
+		// Should be 0x-prefixed with 64 hex chars (32 bytes)
+		assert.True(t, len(resultHex) == 66, "Address should be 0x + 64 hex chars")
+		assert.True(t, resultHex[:2] == "0x", "Address should start with 0x")
+		assert.Contains(t, resultHex, "123", "Address should contain the original value")
+	})
+}
+
+func TestOverrideCall(t *testing.T) {
+	call := &bind.EncodedCall{
+		Module: bind.ModuleInformation{
+			ModuleName: "original_module",
+		},
+		Function: "original_function",
+	}
+
+	result := overrideCall(call, "new_module", "some_function")
+
+	assert.Equal(t, "new_module", result.Module.ModuleName)
+	assert.Equal(t, "mcms_some_function", result.Function)
+
+	// Test with mcms_ prefix already present
+	result2 := overrideCall(call, "another_module", "mcms_prefixed_function")
+
+	assert.Equal(t, "another_module", result2.Module.ModuleName)
+	assert.Equal(t, "mcms_prefixed_function", result2.Function)
+}
+
+func TestHelperFunctions(t *testing.T) {
+	t.Run("deserializeFirst32Bytes", func(t *testing.T) {
+		addr := createAddress("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+		result := deserializeFirst32Bytes(addr)
+
+		assert.Equal(t, 32, len(result))
+		assert.Equal(t, addr, result)
+	})
+
+	t.Run("toHexString", func(t *testing.T) {
+		data := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
+		result := toHexString(data)
+
+		assert.Equal(t, "0x1234567890abcdef", result)
+	})
+}
+
+func TestNewCCIPEntrypointArgEncoder(t *testing.T) {
+	encoder := NewCCIPEntrypointArgEncoder()
+
+	assert.NotNil(t, encoder)
+	assert.Empty(t, encoder.registryObjID)
+}

--- a/contracts/ccip/ccip_onramp/sources/onramp.move
+++ b/contracts/ccip/ccip_onramp/sources/onramp.move
@@ -1375,7 +1375,6 @@ public fun mcms_initialize(
     assert!(function == string::utf8(b"initialize"), EInvalidFunction);
 
     let mut stream = bcs_stream::new(data);
-    // TODO: nonce_manager_cap and source_transfer_cap should also be validated here
     bcs_stream::validate_obj_addrs(
         vector[
             object::id_address(state),

--- a/contracts/ccip/ccip_onramp/sources/onramp.move
+++ b/contracts/ccip/ccip_onramp/sources/onramp.move
@@ -1375,6 +1375,7 @@ public fun mcms_initialize(
     assert!(function == string::utf8(b"initialize"), EInvalidFunction);
 
     let mut stream = bcs_stream::new(data);
+    // TODO: nonce_manager_cap and source_transfer_cap should also be validated here
     bcs_stream::validate_obj_addrs(
         vector[
             object::id_address(state),


### PR DESCRIPTION
### Why
MCMS library require every Sui implementation to include a helper to encode the `mcms_` entrypoint functions based on the proposal ([here](https://github.com/smartcontractkit/mcms/blob/main/sdk/sui/executing_callback.go#L24))

### What
- Adds encoder cases for every `mcms_` entrypoint function for every CCIP contract
- Unit tests