### PR TITLE
Chore: edit bindings template to include vector<Struct> decoder registrations

### DIFF
--- a/bindgen/template/go.tmpl
+++ b/bindgen/template/go.tmpl
@@ -182,6 +182,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for {{.Name}}
+	bind.RegisterStructDecoder("vector<{{$.Package}}::{{$.Module}}::{{.Name}}>", func(data []byte) (interface{}, error) {
+		var temps []bcs{{.Name}}
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]{{.Name}}, len(temps))
+		for i, temp := range temps {
+			result, err := convert{{.Name}}FromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	{{- else}}
 	bind.RegisterStructDecoder("{{$.Package}}::{{$.Module}}::{{.Name}}", func(data []byte) (interface{}, error) {
 		var result {{.Name}}
@@ -190,6 +208,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for {{.Name}}
+	bind.RegisterStructDecoder("vector<{{$.Package}}::{{$.Module}}::{{.Name}}>", func(data []byte) (interface{}, error) {
+		var results []{{.Name}}
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	{{- end}}
 {{- end}}

--- a/bindings/bind/bcs_decoder.go
+++ b/bindings/bind/bcs_decoder.go
@@ -201,6 +201,14 @@ func decodeBCSValue(data []byte, moveType string) (any, error) {
 
 		return result, nil
 
+	case "vector<u64>":
+		var result []uint64
+		if _, err := mystenbcs.Unmarshal(data, &result); err != nil {
+			return nil, err
+		}
+
+		return result, nil
+
 	case "vector<address>":
 		var result [][32]byte
 		if _, err := mystenbcs.Unmarshal(data, &result); err != nil {

--- a/bindings/generated/ccip/ccip/fee_quoter/fee_quoter.go
+++ b/bindings/generated/ccip/ccip/fee_quoter/fee_quoter.go
@@ -459,6 +459,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for FeeQuoterState
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::FeeQuoterState>", func(data []byte) (interface{}, error) {
+		var temps []bcsFeeQuoterState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]FeeQuoterState, len(temps))
+		for i, temp := range temps {
+			result, err := convertFeeQuoterStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::FeeQuoterCap", func(data []byte) (interface{}, error) {
 		var result FeeQuoterCap
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -466,6 +484,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for FeeQuoterCap
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::FeeQuoterCap>", func(data []byte) (interface{}, error) {
+		var results []FeeQuoterCap
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::DestChainConfig", func(data []byte) (interface{}, error) {
 		var result DestChainConfig
@@ -475,6 +502,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DestChainConfig
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::DestChainConfig>", func(data []byte) (interface{}, error) {
+		var results []DestChainConfig
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::TokenTransferFeeConfig", func(data []byte) (interface{}, error) {
 		var result TokenTransferFeeConfig
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -482,6 +518,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for TokenTransferFeeConfig
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::TokenTransferFeeConfig>", func(data []byte) (interface{}, error) {
+		var results []TokenTransferFeeConfig
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::TimestampedPrice", func(data []byte) (interface{}, error) {
 		var temp bcsTimestampedPrice
@@ -496,6 +541,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TimestampedPrice
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::TimestampedPrice>", func(data []byte) (interface{}, error) {
+		var temps []bcsTimestampedPrice
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TimestampedPrice, len(temps))
+		for i, temp := range temps {
+			result, err := convertTimestampedPriceFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::FeeTokenAdded", func(data []byte) (interface{}, error) {
 		var temp bcsFeeTokenAdded
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -508,6 +571,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for FeeTokenAdded
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::FeeTokenAdded>", func(data []byte) (interface{}, error) {
+		var temps []bcsFeeTokenAdded
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]FeeTokenAdded, len(temps))
+		for i, temp := range temps {
+			result, err := convertFeeTokenAddedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::FeeTokenRemoved", func(data []byte) (interface{}, error) {
 		var temp bcsFeeTokenRemoved
@@ -522,6 +603,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for FeeTokenRemoved
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::FeeTokenRemoved>", func(data []byte) (interface{}, error) {
+		var temps []bcsFeeTokenRemoved
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]FeeTokenRemoved, len(temps))
+		for i, temp := range temps {
+			result, err := convertFeeTokenRemovedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::TokenTransferFeeConfigAdded", func(data []byte) (interface{}, error) {
 		var temp bcsTokenTransferFeeConfigAdded
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -534,6 +633,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for TokenTransferFeeConfigAdded
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::TokenTransferFeeConfigAdded>", func(data []byte) (interface{}, error) {
+		var temps []bcsTokenTransferFeeConfigAdded
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TokenTransferFeeConfigAdded, len(temps))
+		for i, temp := range temps {
+			result, err := convertTokenTransferFeeConfigAddedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::TokenTransferFeeConfigRemoved", func(data []byte) (interface{}, error) {
 		var temp bcsTokenTransferFeeConfigRemoved
@@ -548,6 +665,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TokenTransferFeeConfigRemoved
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::TokenTransferFeeConfigRemoved>", func(data []byte) (interface{}, error) {
+		var temps []bcsTokenTransferFeeConfigRemoved
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TokenTransferFeeConfigRemoved, len(temps))
+		for i, temp := range temps {
+			result, err := convertTokenTransferFeeConfigRemovedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::UsdPerTokenUpdated", func(data []byte) (interface{}, error) {
 		var temp bcsUsdPerTokenUpdated
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -560,6 +695,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for UsdPerTokenUpdated
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::UsdPerTokenUpdated>", func(data []byte) (interface{}, error) {
+		var temps []bcsUsdPerTokenUpdated
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]UsdPerTokenUpdated, len(temps))
+		for i, temp := range temps {
+			result, err := convertUsdPerTokenUpdatedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::UsdPerUnitGasUpdated", func(data []byte) (interface{}, error) {
 		var temp bcsUsdPerUnitGasUpdated
@@ -574,6 +727,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for UsdPerUnitGasUpdated
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::UsdPerUnitGasUpdated>", func(data []byte) (interface{}, error) {
+		var temps []bcsUsdPerUnitGasUpdated
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]UsdPerUnitGasUpdated, len(temps))
+		for i, temp := range temps {
+			result, err := convertUsdPerUnitGasUpdatedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::DestChainAdded", func(data []byte) (interface{}, error) {
 		var result DestChainAdded
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -582,6 +753,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DestChainAdded
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::DestChainAdded>", func(data []byte) (interface{}, error) {
+		var results []DestChainAdded
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::DestChainConfigUpdated", func(data []byte) (interface{}, error) {
 		var result DestChainConfigUpdated
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -589,6 +769,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for DestChainConfigUpdated
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::DestChainConfigUpdated>", func(data []byte) (interface{}, error) {
+		var results []DestChainConfigUpdated
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::PremiumMultiplierWeiPerEthUpdated", func(data []byte) (interface{}, error) {
 		var temp bcsPremiumMultiplierWeiPerEthUpdated
@@ -603,6 +792,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for PremiumMultiplierWeiPerEthUpdated
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::PremiumMultiplierWeiPerEthUpdated>", func(data []byte) (interface{}, error) {
+		var temps []bcsPremiumMultiplierWeiPerEthUpdated
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]PremiumMultiplierWeiPerEthUpdated, len(temps))
+		for i, temp := range temps {
+			result, err := convertPremiumMultiplierWeiPerEthUpdatedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::CCIPAdminProof", func(data []byte) (interface{}, error) {
 		var result CCIPAdminProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -611,6 +818,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CCIPAdminProof
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::CCIPAdminProof>", func(data []byte) (interface{}, error) {
+		var results []CCIPAdminProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::fee_quoter::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -618,6 +834,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip::fee_quoter::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip/nonce_manager/nonce_manager.go
+++ b/bindings/generated/ccip/ccip/nonce_manager/nonce_manager.go
@@ -105,6 +105,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for NonceManagerCap
+	bind.RegisterStructDecoder("vector<ccip::nonce_manager::NonceManagerCap>", func(data []byte) (interface{}, error) {
+		var results []NonceManagerCap
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::nonce_manager::NonceManagerState", func(data []byte) (interface{}, error) {
 		var result NonceManagerState
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -112,6 +121,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for NonceManagerState
+	bind.RegisterStructDecoder("vector<ccip::nonce_manager::NonceManagerState>", func(data []byte) (interface{}, error) {
+		var results []NonceManagerState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip/receiver_registry/receiver_registry.go
+++ b/bindings/generated/ccip/ccip/receiver_registry/receiver_registry.go
@@ -156,6 +156,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ReceiverConfig
+	bind.RegisterStructDecoder("vector<ccip::receiver_registry::ReceiverConfig>", func(data []byte) (interface{}, error) {
+		var results []ReceiverConfig
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::receiver_registry::ReceiverRegistry", func(data []byte) (interface{}, error) {
 		var result ReceiverRegistry
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -163,6 +172,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ReceiverRegistry
+	bind.RegisterStructDecoder("vector<ccip::receiver_registry::ReceiverRegistry>", func(data []byte) (interface{}, error) {
+		var results []ReceiverRegistry
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::receiver_registry::ReceiverRegistered", func(data []byte) (interface{}, error) {
 		var temp bcsReceiverRegistered
@@ -177,6 +195,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ReceiverRegistered
+	bind.RegisterStructDecoder("vector<ccip::receiver_registry::ReceiverRegistered>", func(data []byte) (interface{}, error) {
+		var temps []bcsReceiverRegistered
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ReceiverRegistered, len(temps))
+		for i, temp := range temps {
+			result, err := convertReceiverRegisteredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::receiver_registry::ReceiverUnregistered", func(data []byte) (interface{}, error) {
 		var temp bcsReceiverUnregistered
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -189,6 +225,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ReceiverUnregistered
+	bind.RegisterStructDecoder("vector<ccip::receiver_registry::ReceiverUnregistered>", func(data []byte) (interface{}, error) {
+		var temps []bcsReceiverUnregistered
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ReceiverUnregistered, len(temps))
+		for i, temp := range temps {
+			result, err := convertReceiverUnregisteredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip/rmn_remote/rmn_remote.go
+++ b/bindings/generated/ccip/ccip/rmn_remote/rmn_remote.go
@@ -186,6 +186,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for RMNRemoteState
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::RMNRemoteState>", func(data []byte) (interface{}, error) {
+		var results []RMNRemoteState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::Config", func(data []byte) (interface{}, error) {
 		var result Config
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -193,6 +202,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Config
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::Config>", func(data []byte) (interface{}, error) {
+		var results []Config
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::Signer", func(data []byte) (interface{}, error) {
 		var result Signer
@@ -202,6 +220,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Signer
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::Signer>", func(data []byte) (interface{}, error) {
+		var results []Signer
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::ConfigSet", func(data []byte) (interface{}, error) {
 		var result ConfigSet
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -209,6 +236,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ConfigSet
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::ConfigSet>", func(data []byte) (interface{}, error) {
+		var results []ConfigSet
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::Cursed", func(data []byte) (interface{}, error) {
 		var result Cursed
@@ -218,6 +254,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Cursed
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::Cursed>", func(data []byte) (interface{}, error) {
+		var results []Cursed
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::Uncursed", func(data []byte) (interface{}, error) {
 		var result Uncursed
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -226,6 +271,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Uncursed
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::Uncursed>", func(data []byte) (interface{}, error) {
+		var results []Uncursed
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::rmn_remote::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -233,6 +287,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip::rmn_remote::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip/state_object/state_object.go
+++ b/bindings/generated/ccip/ccip/state_object/state_object.go
@@ -220,6 +220,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CCIPObjectRef
+	bind.RegisterStructDecoder("vector<ccip::state_object::CCIPObjectRef>", func(data []byte) (interface{}, error) {
+		var temps []bcsCCIPObjectRef
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]CCIPObjectRef, len(temps))
+		for i, temp := range temps {
+			result, err := convertCCIPObjectRefFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::state_object::CCIPObjectRefPointer", func(data []byte) (interface{}, error) {
 		var temp bcsCCIPObjectRefPointer
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -233,6 +251,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CCIPObjectRefPointer
+	bind.RegisterStructDecoder("vector<ccip::state_object::CCIPObjectRefPointer>", func(data []byte) (interface{}, error) {
+		var temps []bcsCCIPObjectRefPointer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]CCIPObjectRefPointer, len(temps))
+		for i, temp := range temps {
+			result, err := convertCCIPObjectRefPointerFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::state_object::STATE_OBJECT", func(data []byte) (interface{}, error) {
 		var result STATE_OBJECT
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -240,6 +276,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for STATE_OBJECT
+	bind.RegisterStructDecoder("vector<ccip::state_object::STATE_OBJECT>", func(data []byte) (interface{}, error) {
+		var results []STATE_OBJECT
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::state_object::CCIPAdminProof", func(data []byte) (interface{}, error) {
 		var result CCIPAdminProof
@@ -249,6 +294,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CCIPAdminProof
+	bind.RegisterStructDecoder("vector<ccip::state_object::CCIPAdminProof>", func(data []byte) (interface{}, error) {
+		var results []CCIPAdminProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::state_object::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -256,6 +310,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip::state_object::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip/token_admin_registry/token_admin_registry.go
+++ b/bindings/generated/ccip/ccip/token_admin_registry/token_admin_registry.go
@@ -325,6 +325,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TokenAdminRegistryState
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::TokenAdminRegistryState>", func(data []byte) (interface{}, error) {
+		var results []TokenAdminRegistryState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::TokenConfig", func(data []byte) (interface{}, error) {
 		var temp bcsTokenConfig
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -337,6 +346,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for TokenConfig
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::TokenConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsTokenConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TokenConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertTokenConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::PoolSet", func(data []byte) (interface{}, error) {
 		var temp bcsPoolSet
@@ -351,6 +378,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for PoolSet
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::PoolSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsPoolSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]PoolSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertPoolSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::PoolRegistered", func(data []byte) (interface{}, error) {
 		var temp bcsPoolRegistered
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -363,6 +408,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for PoolRegistered
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::PoolRegistered>", func(data []byte) (interface{}, error) {
+		var temps []bcsPoolRegistered
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]PoolRegistered, len(temps))
+		for i, temp := range temps {
+			result, err := convertPoolRegisteredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::PoolUnregistered", func(data []byte) (interface{}, error) {
 		var temp bcsPoolUnregistered
@@ -377,6 +440,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for PoolUnregistered
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::PoolUnregistered>", func(data []byte) (interface{}, error) {
+		var temps []bcsPoolUnregistered
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]PoolUnregistered, len(temps))
+		for i, temp := range temps {
+			result, err := convertPoolUnregisteredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::AdministratorTransferRequested", func(data []byte) (interface{}, error) {
 		var temp bcsAdministratorTransferRequested
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -389,6 +470,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for AdministratorTransferRequested
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::AdministratorTransferRequested>", func(data []byte) (interface{}, error) {
+		var temps []bcsAdministratorTransferRequested
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]AdministratorTransferRequested, len(temps))
+		for i, temp := range temps {
+			result, err := convertAdministratorTransferRequestedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::AdministratorTransferred", func(data []byte) (interface{}, error) {
 		var temp bcsAdministratorTransferred
@@ -403,6 +502,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for AdministratorTransferred
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::AdministratorTransferred>", func(data []byte) (interface{}, error) {
+		var temps []bcsAdministratorTransferred
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]AdministratorTransferred, len(temps))
+		for i, temp := range temps {
+			result, err := convertAdministratorTransferredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::token_admin_registry::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -410,6 +527,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip::token_admin_registry::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip/upgrade_registry/upgrade_registry.go
+++ b/bindings/generated/ccip/ccip/upgrade_registry/upgrade_registry.go
@@ -117,6 +117,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for VersionBlocked
+	bind.RegisterStructDecoder("vector<ccip::upgrade_registry::VersionBlocked>", func(data []byte) (interface{}, error) {
+		var results []VersionBlocked
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::upgrade_registry::FunctionBlocked", func(data []byte) (interface{}, error) {
 		var result FunctionBlocked
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -125,6 +134,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for FunctionBlocked
+	bind.RegisterStructDecoder("vector<ccip::upgrade_registry::FunctionBlocked>", func(data []byte) (interface{}, error) {
+		var results []FunctionBlocked
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip::upgrade_registry::UpgradeRegistry", func(data []byte) (interface{}, error) {
 		var result UpgradeRegistry
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -132,6 +150,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for UpgradeRegistry
+	bind.RegisterStructDecoder("vector<ccip::upgrade_registry::UpgradeRegistry>", func(data []byte) (interface{}, error) {
+		var results []UpgradeRegistry
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_dummy_receiver/ccip_dummy_receiver/dummy_receiver.go
+++ b/bindings/generated/ccip/ccip_dummy_receiver/ccip_dummy_receiver/dummy_receiver.go
@@ -185,6 +185,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OwnerCap
+	bind.RegisterStructDecoder("vector<ccip_dummy_receiver::dummy_receiver::OwnerCap>", func(data []byte) (interface{}, error) {
+		var temps []bcsOwnerCap
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OwnerCap, len(temps))
+		for i, temp := range temps {
+			result, err := convertOwnerCapFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_dummy_receiver::dummy_receiver::ReceivedMessage", func(data []byte) (interface{}, error) {
 		var result ReceivedMessage
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -192,6 +210,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ReceivedMessage
+	bind.RegisterStructDecoder("vector<ccip_dummy_receiver::dummy_receiver::ReceivedMessage>", func(data []byte) (interface{}, error) {
+		var results []ReceivedMessage
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_dummy_receiver::dummy_receiver::CCIPReceiverState", func(data []byte) (interface{}, error) {
 		var result CCIPReceiverState
@@ -201,6 +228,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CCIPReceiverState
+	bind.RegisterStructDecoder("vector<ccip_dummy_receiver::dummy_receiver::CCIPReceiverState>", func(data []byte) (interface{}, error) {
+		var results []CCIPReceiverState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_dummy_receiver::dummy_receiver::DummyReceiverProof", func(data []byte) (interface{}, error) {
 		var result DummyReceiverProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -208,6 +244,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for DummyReceiverProof
+	bind.RegisterStructDecoder("vector<ccip_dummy_receiver::dummy_receiver::DummyReceiverProof>", func(data []byte) (interface{}, error) {
+		var results []DummyReceiverProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_dummy_receiver::dummy_receiver::TokenAmount", func(data []byte) (interface{}, error) {
 		var temp bcsTokenAmount
@@ -221,6 +266,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for TokenAmount
+	bind.RegisterStructDecoder("vector<ccip_dummy_receiver::dummy_receiver::TokenAmount>", func(data []byte) (interface{}, error) {
+		var temps []bcsTokenAmount
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TokenAmount, len(temps))
+		for i, temp := range temps {
+			result, err := convertTokenAmountFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_offramp/offramp/offramp.go
+++ b/bindings/generated/ccip/ccip_offramp/offramp/offramp.go
@@ -627,6 +627,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OffRampState
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::OffRampState>", func(data []byte) (interface{}, error) {
+		var temps []bcsOffRampState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OffRampState, len(temps))
+		for i, temp := range temps {
+			result, err := convertOffRampStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::OffRampStatePointer", func(data []byte) (interface{}, error) {
 		var temp bcsOffRampStatePointer
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -639,6 +657,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for OffRampStatePointer
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::OffRampStatePointer>", func(data []byte) (interface{}, error) {
+		var temps []bcsOffRampStatePointer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OffRampStatePointer, len(temps))
+		for i, temp := range temps {
+			result, err := convertOffRampStatePointerFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::SourceChainConfig", func(data []byte) (interface{}, error) {
 		var temp bcsSourceChainConfig
@@ -653,6 +689,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for SourceChainConfig
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::SourceChainConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsSourceChainConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]SourceChainConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertSourceChainConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::RampMessageHeader", func(data []byte) (interface{}, error) {
 		var result RampMessageHeader
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -660,6 +714,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for RampMessageHeader
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::RampMessageHeader>", func(data []byte) (interface{}, error) {
+		var results []RampMessageHeader
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::Any2SuiRampMessage", func(data []byte) (interface{}, error) {
 		var temp bcsAny2SuiRampMessage
@@ -674,6 +737,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Any2SuiRampMessage
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::Any2SuiRampMessage>", func(data []byte) (interface{}, error) {
+		var temps []bcsAny2SuiRampMessage
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Any2SuiRampMessage, len(temps))
+		for i, temp := range temps {
+			result, err := convertAny2SuiRampMessageFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::Any2SuiTokenTransfer", func(data []byte) (interface{}, error) {
 		var temp bcsAny2SuiTokenTransfer
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -686,6 +767,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Any2SuiTokenTransfer
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::Any2SuiTokenTransfer>", func(data []byte) (interface{}, error) {
+		var temps []bcsAny2SuiTokenTransfer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Any2SuiTokenTransfer, len(temps))
+		for i, temp := range temps {
+			result, err := convertAny2SuiTokenTransferFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::ExecutionReport", func(data []byte) (interface{}, error) {
 		var temp bcsExecutionReport
@@ -700,6 +799,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ExecutionReport
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::ExecutionReport>", func(data []byte) (interface{}, error) {
+		var temps []bcsExecutionReport
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ExecutionReport, len(temps))
+		for i, temp := range temps {
+			result, err := convertExecutionReportFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::CommitReport", func(data []byte) (interface{}, error) {
 		var result CommitReport
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -708,6 +825,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CommitReport
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::CommitReport>", func(data []byte) (interface{}, error) {
+		var results []CommitReport
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::PriceUpdates", func(data []byte) (interface{}, error) {
 		var result PriceUpdates
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -715,6 +841,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for PriceUpdates
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::PriceUpdates>", func(data []byte) (interface{}, error) {
+		var results []PriceUpdates
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::TokenPriceUpdate", func(data []byte) (interface{}, error) {
 		var temp bcsTokenPriceUpdate
@@ -729,6 +864,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TokenPriceUpdate
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::TokenPriceUpdate>", func(data []byte) (interface{}, error) {
+		var temps []bcsTokenPriceUpdate
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TokenPriceUpdate, len(temps))
+		for i, temp := range temps {
+			result, err := convertTokenPriceUpdateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::GasPriceUpdate", func(data []byte) (interface{}, error) {
 		var temp bcsGasPriceUpdate
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -742,6 +895,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for GasPriceUpdate
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::GasPriceUpdate>", func(data []byte) (interface{}, error) {
+		var temps []bcsGasPriceUpdate
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]GasPriceUpdate, len(temps))
+		for i, temp := range temps {
+			result, err := convertGasPriceUpdateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::MerkleRoot", func(data []byte) (interface{}, error) {
 		var result MerkleRoot
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -749,6 +920,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for MerkleRoot
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::MerkleRoot>", func(data []byte) (interface{}, error) {
+		var results []MerkleRoot
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::StaticConfig", func(data []byte) (interface{}, error) {
 		var temp bcsStaticConfig
@@ -763,6 +943,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for StaticConfig
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::StaticConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsStaticConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]StaticConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertStaticConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::DynamicConfig", func(data []byte) (interface{}, error) {
 		var temp bcsDynamicConfig
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -776,6 +974,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DynamicConfig
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::DynamicConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsDynamicConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]DynamicConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertDynamicConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::StaticConfigSet", func(data []byte) (interface{}, error) {
 		var result StaticConfigSet
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -783,6 +999,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for StaticConfigSet
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::StaticConfigSet>", func(data []byte) (interface{}, error) {
+		var results []StaticConfigSet
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::DynamicConfigSet", func(data []byte) (interface{}, error) {
 		var temp bcsDynamicConfigSet
@@ -797,6 +1022,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DynamicConfigSet
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::DynamicConfigSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsDynamicConfigSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]DynamicConfigSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertDynamicConfigSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::SourceChainConfigSet", func(data []byte) (interface{}, error) {
 		var temp bcsSourceChainConfigSet
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -810,6 +1053,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for SourceChainConfigSet
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::SourceChainConfigSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsSourceChainConfigSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]SourceChainConfigSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertSourceChainConfigSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::SkippedAlreadyExecuted", func(data []byte) (interface{}, error) {
 		var result SkippedAlreadyExecuted
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -817,6 +1078,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for SkippedAlreadyExecuted
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::SkippedAlreadyExecuted>", func(data []byte) (interface{}, error) {
+		var results []SkippedAlreadyExecuted
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::ExecutionStateChanged", func(data []byte) (interface{}, error) {
 		var result ExecutionStateChanged
@@ -826,6 +1096,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ExecutionStateChanged
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::ExecutionStateChanged>", func(data []byte) (interface{}, error) {
+		var results []ExecutionStateChanged
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::CommitReportAccepted", func(data []byte) (interface{}, error) {
 		var result CommitReportAccepted
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -833,6 +1112,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for CommitReportAccepted
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::CommitReportAccepted>", func(data []byte) (interface{}, error) {
+		var results []CommitReportAccepted
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::SkippedReportExecution", func(data []byte) (interface{}, error) {
 		var result SkippedReportExecution
@@ -842,6 +1130,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for SkippedReportExecution
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::SkippedReportExecution>", func(data []byte) (interface{}, error) {
+		var results []SkippedReportExecution
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::OFFRAMP", func(data []byte) (interface{}, error) {
 		var result OFFRAMP
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -850,6 +1147,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OFFRAMP
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::OFFRAMP>", func(data []byte) (interface{}, error) {
+		var results []OFFRAMP
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_offramp::offramp::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -857,6 +1163,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip_offramp::offramp::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_onramp/onramp/onramp.go
+++ b/bindings/generated/ccip/ccip_onramp/onramp/onramp.go
@@ -583,6 +583,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OnRampState
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::OnRampState>", func(data []byte) (interface{}, error) {
+		var temps []bcsOnRampState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OnRampState, len(temps))
+		for i, temp := range temps {
+			result, err := convertOnRampStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::OnRampStatePointer", func(data []byte) (interface{}, error) {
 		var temp bcsOnRampStatePointer
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -595,6 +613,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for OnRampStatePointer
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::OnRampStatePointer>", func(data []byte) (interface{}, error) {
+		var temps []bcsOnRampStatePointer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OnRampStatePointer, len(temps))
+		for i, temp := range temps {
+			result, err := convertOnRampStatePointerFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::DestChainConfig", func(data []byte) (interface{}, error) {
 		var temp bcsDestChainConfig
@@ -609,6 +645,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DestChainConfig
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::DestChainConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsDestChainConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]DestChainConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertDestChainConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::RampMessageHeader", func(data []byte) (interface{}, error) {
 		var result RampMessageHeader
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -616,6 +670,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for RampMessageHeader
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::RampMessageHeader>", func(data []byte) (interface{}, error) {
+		var results []RampMessageHeader
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::Sui2AnyRampMessage", func(data []byte) (interface{}, error) {
 		var temp bcsSui2AnyRampMessage
@@ -630,6 +693,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Sui2AnyRampMessage
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::Sui2AnyRampMessage>", func(data []byte) (interface{}, error) {
+		var temps []bcsSui2AnyRampMessage
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Sui2AnyRampMessage, len(temps))
+		for i, temp := range temps {
+			result, err := convertSui2AnyRampMessageFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::Sui2AnyTokenTransfer", func(data []byte) (interface{}, error) {
 		var temp bcsSui2AnyTokenTransfer
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -643,6 +724,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Sui2AnyTokenTransfer
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::Sui2AnyTokenTransfer>", func(data []byte) (interface{}, error) {
+		var temps []bcsSui2AnyTokenTransfer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Sui2AnyTokenTransfer, len(temps))
+		for i, temp := range temps {
+			result, err := convertSui2AnyTokenTransferFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::StaticConfig", func(data []byte) (interface{}, error) {
 		var result StaticConfig
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -650,6 +749,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for StaticConfig
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::StaticConfig>", func(data []byte) (interface{}, error) {
+		var results []StaticConfig
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::DynamicConfig", func(data []byte) (interface{}, error) {
 		var temp bcsDynamicConfig
@@ -664,6 +772,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DynamicConfig
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::DynamicConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsDynamicConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]DynamicConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertDynamicConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::ConfigSet", func(data []byte) (interface{}, error) {
 		var temp bcsConfigSet
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -676,6 +802,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ConfigSet
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::ConfigSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsConfigSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ConfigSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertConfigSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::DestChainConfigSet", func(data []byte) (interface{}, error) {
 		var temp bcsDestChainConfigSet
@@ -690,6 +834,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DestChainConfigSet
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::DestChainConfigSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsDestChainConfigSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]DestChainConfigSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertDestChainConfigSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::CCIPMessageSent", func(data []byte) (interface{}, error) {
 		var temp bcsCCIPMessageSent
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -702,6 +864,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for CCIPMessageSent
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::CCIPMessageSent>", func(data []byte) (interface{}, error) {
+		var temps []bcsCCIPMessageSent
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]CCIPMessageSent, len(temps))
+		for i, temp := range temps {
+			result, err := convertCCIPMessageSentFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::AllowlistSendersAdded", func(data []byte) (interface{}, error) {
 		var temp bcsAllowlistSendersAdded
@@ -716,6 +896,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for AllowlistSendersAdded
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::AllowlistSendersAdded>", func(data []byte) (interface{}, error) {
+		var temps []bcsAllowlistSendersAdded
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]AllowlistSendersAdded, len(temps))
+		for i, temp := range temps {
+			result, err := convertAllowlistSendersAddedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::AllowlistSendersRemoved", func(data []byte) (interface{}, error) {
 		var temp bcsAllowlistSendersRemoved
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -728,6 +926,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for AllowlistSendersRemoved
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::AllowlistSendersRemoved>", func(data []byte) (interface{}, error) {
+		var temps []bcsAllowlistSendersRemoved
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]AllowlistSendersRemoved, len(temps))
+		for i, temp := range temps {
+			result, err := convertAllowlistSendersRemovedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::FeeTokenWithdrawn", func(data []byte) (interface{}, error) {
 		var temp bcsFeeTokenWithdrawn
@@ -742,6 +958,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for FeeTokenWithdrawn
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::FeeTokenWithdrawn>", func(data []byte) (interface{}, error) {
+		var temps []bcsFeeTokenWithdrawn
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]FeeTokenWithdrawn, len(temps))
+		for i, temp := range temps {
+			result, err := convertFeeTokenWithdrawnFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::ONRAMP", func(data []byte) (interface{}, error) {
 		var result ONRAMP
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -750,6 +984,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ONRAMP
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::ONRAMP>", func(data []byte) (interface{}, error) {
+		var results []ONRAMP
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_onramp::onramp::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -757,6 +1000,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip_onramp::onramp::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_router/router.go
+++ b/bindings/generated/ccip/ccip_router/router.go
@@ -210,6 +210,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ROUTER
+	bind.RegisterStructDecoder("vector<ccip_router::router::ROUTER>", func(data []byte) (interface{}, error) {
+		var results []ROUTER
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_router::router::OnRampSet", func(data []byte) (interface{}, error) {
 		var temp bcsOnRampSet
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -222,6 +231,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for OnRampSet
+	bind.RegisterStructDecoder("vector<ccip_router::router::OnRampSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsOnRampSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OnRampSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertOnRampSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_router::router::OnRampInfo", func(data []byte) (interface{}, error) {
 		var temp bcsOnRampInfo
@@ -236,6 +263,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OnRampInfo
+	bind.RegisterStructDecoder("vector<ccip_router::router::OnRampInfo>", func(data []byte) (interface{}, error) {
+		var temps []bcsOnRampInfo
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OnRampInfo, len(temps))
+		for i, temp := range temps {
+			result, err := convertOnRampInfoFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_router::router::RouterState", func(data []byte) (interface{}, error) {
 		var result RouterState
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -244,6 +289,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for RouterState
+	bind.RegisterStructDecoder("vector<ccip_router::router::RouterState>", func(data []byte) (interface{}, error) {
+		var results []RouterState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_router::router::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -251,6 +305,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<ccip_router::router::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool/burn_mint_token_pool.go
@@ -239,6 +239,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for BurnMintTokenPoolState
+	bind.RegisterStructDecoder("vector<burn_mint_token_pool::burn_mint_token_pool::BurnMintTokenPoolState>", func(data []byte) (interface{}, error) {
+		var results []BurnMintTokenPoolState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("burn_mint_token_pool::burn_mint_token_pool::TypeProof", func(data []byte) (interface{}, error) {
 		var result TypeProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -247,6 +256,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TypeProof
+	bind.RegisterStructDecoder("vector<burn_mint_token_pool::burn_mint_token_pool::TypeProof>", func(data []byte) (interface{}, error) {
+		var results []TypeProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("burn_mint_token_pool::burn_mint_token_pool::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -254,6 +272,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<burn_mint_token_pool::burn_mint_token_pool::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool/lock_release_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool/lock_release_token_pool.go
@@ -285,6 +285,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for LockReleaseTokenPoolState
+	bind.RegisterStructDecoder("vector<lock_release_token_pool::lock_release_token_pool::LockReleaseTokenPoolState>", func(data []byte) (interface{}, error) {
+		var temps []bcsLockReleaseTokenPoolState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]LockReleaseTokenPoolState, len(temps))
+		for i, temp := range temps {
+			result, err := convertLockReleaseTokenPoolStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("lock_release_token_pool::lock_release_token_pool::TypeProof", func(data []byte) (interface{}, error) {
 		var result TypeProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -293,6 +311,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TypeProof
+	bind.RegisterStructDecoder("vector<lock_release_token_pool::lock_release_token_pool::TypeProof>", func(data []byte) (interface{}, error) {
+		var results []TypeProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("lock_release_token_pool::lock_release_token_pool::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -300,6 +327,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<lock_release_token_pool::lock_release_token_pool::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_token_pools/managed_token_pool/managed_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/managed_token_pool/managed_token_pool.go
@@ -239,6 +239,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ManagedTokenPoolState
+	bind.RegisterStructDecoder("vector<managed_token_pool::managed_token_pool::ManagedTokenPoolState>", func(data []byte) (interface{}, error) {
+		var results []ManagedTokenPoolState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token_pool::managed_token_pool::TypeProof", func(data []byte) (interface{}, error) {
 		var result TypeProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -247,6 +256,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TypeProof
+	bind.RegisterStructDecoder("vector<managed_token_pool::managed_token_pool::TypeProof>", func(data []byte) (interface{}, error) {
+		var results []TypeProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token_pool::managed_token_pool::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -254,6 +272,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<managed_token_pool::managed_token_pool::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_token_pools/token_pool/token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/token_pool/token_pool.go
@@ -348,6 +348,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TokenPoolState
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::TokenPoolState>", func(data []byte) (interface{}, error) {
+		var temps []bcsTokenPoolState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]TokenPoolState, len(temps))
+		for i, temp := range temps {
+			result, err := convertTokenPoolStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::RemoteChainConfig", func(data []byte) (interface{}, error) {
 		var result RemoteChainConfig
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -355,6 +373,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for RemoteChainConfig
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::RemoteChainConfig>", func(data []byte) (interface{}, error) {
+		var results []RemoteChainConfig
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::LockedOrBurned", func(data []byte) (interface{}, error) {
 		var temp bcsLockedOrBurned
@@ -369,6 +396,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for LockedOrBurned
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::LockedOrBurned>", func(data []byte) (interface{}, error) {
+		var temps []bcsLockedOrBurned
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]LockedOrBurned, len(temps))
+		for i, temp := range temps {
+			result, err := convertLockedOrBurnedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::ReleasedOrMinted", func(data []byte) (interface{}, error) {
 		var temp bcsReleasedOrMinted
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -382,6 +427,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ReleasedOrMinted
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::ReleasedOrMinted>", func(data []byte) (interface{}, error) {
+		var temps []bcsReleasedOrMinted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ReleasedOrMinted, len(temps))
+		for i, temp := range temps {
+			result, err := convertReleasedOrMintedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::RemotePoolAdded", func(data []byte) (interface{}, error) {
 		var result RemotePoolAdded
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -389,6 +452,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for RemotePoolAdded
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::RemotePoolAdded>", func(data []byte) (interface{}, error) {
+		var results []RemotePoolAdded
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::RemotePoolRemoved", func(data []byte) (interface{}, error) {
 		var result RemotePoolRemoved
@@ -398,6 +470,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for RemotePoolRemoved
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::RemotePoolRemoved>", func(data []byte) (interface{}, error) {
+		var results []RemotePoolRemoved
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::ChainAdded", func(data []byte) (interface{}, error) {
 		var result ChainAdded
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -406,6 +487,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ChainAdded
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::ChainAdded>", func(data []byte) (interface{}, error) {
+		var results []ChainAdded
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::ChainRemoved", func(data []byte) (interface{}, error) {
 		var result ChainRemoved
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -413,6 +503,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ChainRemoved
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::ChainRemoved>", func(data []byte) (interface{}, error) {
+		var results []ChainRemoved
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::LiquidityAdded", func(data []byte) (interface{}, error) {
 		var temp bcsLiquidityAdded
@@ -427,6 +526,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for LiquidityAdded
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::LiquidityAdded>", func(data []byte) (interface{}, error) {
+		var temps []bcsLiquidityAdded
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]LiquidityAdded, len(temps))
+		for i, temp := range temps {
+			result, err := convertLiquidityAddedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::LiquidityRemoved", func(data []byte) (interface{}, error) {
 		var temp bcsLiquidityRemoved
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -440,6 +557,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for LiquidityRemoved
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::LiquidityRemoved>", func(data []byte) (interface{}, error) {
+		var temps []bcsLiquidityRemoved
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]LiquidityRemoved, len(temps))
+		for i, temp := range temps {
+			result, err := convertLiquidityRemovedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("ccip_token_pool::token_pool::RebalancerSet", func(data []byte) (interface{}, error) {
 		var temp bcsRebalancerSet
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -452,6 +587,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for RebalancerSet
+	bind.RegisterStructDecoder("vector<ccip_token_pool::token_pool::RebalancerSet>", func(data []byte) (interface{}, error) {
+		var temps []bcsRebalancerSet
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]RebalancerSet, len(temps))
+		for i, temp := range temps {
+			result, err := convertRebalancerSetFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/ccip_token_pools/usdc_token_pool/usdc_token_pool.go
+++ b/bindings/generated/ccip/ccip_token_pools/usdc_token_pool/usdc_token_pool.go
@@ -260,6 +260,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Domain
+	bind.RegisterStructDecoder("vector<usdc_token_pool::usdc_token_pool::Domain>", func(data []byte) (interface{}, error) {
+		var results []Domain
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("usdc_token_pool::usdc_token_pool::DomainsSet", func(data []byte) (interface{}, error) {
 		var result DomainsSet
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -267,6 +276,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for DomainsSet
+	bind.RegisterStructDecoder("vector<usdc_token_pool::usdc_token_pool::DomainsSet>", func(data []byte) (interface{}, error) {
+		var results []DomainsSet
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("usdc_token_pool::usdc_token_pool::USDCTokenPoolState", func(data []byte) (interface{}, error) {
 		var result USDCTokenPoolState
@@ -276,6 +294,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for USDCTokenPoolState
+	bind.RegisterStructDecoder("vector<usdc_token_pool::usdc_token_pool::USDCTokenPoolState>", func(data []byte) (interface{}, error) {
+		var results []USDCTokenPoolState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("usdc_token_pool::usdc_token_pool::TypeProof", func(data []byte) (interface{}, error) {
 		var result TypeProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -284,6 +311,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TypeProof
+	bind.RegisterStructDecoder("vector<usdc_token_pool::usdc_token_pool::TypeProof>", func(data []byte) (interface{}, error) {
+		var results []TypeProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("usdc_token_pool::usdc_token_pool::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -291,6 +327,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<usdc_token_pool::usdc_token_pool::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/managed_token/managed_token/managed_token.go
+++ b/bindings/generated/ccip/managed_token/managed_token/managed_token.go
@@ -345,6 +345,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for TokenState
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::TokenState>", func(data []byte) (interface{}, error) {
+		var results []TokenState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::MintCap", func(data []byte) (interface{}, error) {
 		var result MintCap
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -353,6 +362,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MintCap
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::MintCap>", func(data []byte) (interface{}, error) {
+		var results []MintCap
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::MintCapCreated", func(data []byte) (interface{}, error) {
 		var result MintCapCreated
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -360,6 +378,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for MintCapCreated
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::MintCapCreated>", func(data []byte) (interface{}, error) {
+		var results []MintCapCreated
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("managed_token::managed_token::MinterConfigured", func(data []byte) (interface{}, error) {
 		var temp bcsMinterConfigured
@@ -374,6 +401,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MinterConfigured
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::MinterConfigured>", func(data []byte) (interface{}, error) {
+		var temps []bcsMinterConfigured
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]MinterConfigured, len(temps))
+		for i, temp := range temps {
+			result, err := convertMinterConfiguredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::Minted", func(data []byte) (interface{}, error) {
 		var temp bcsMinted
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -386,6 +431,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Minted
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::Minted>", func(data []byte) (interface{}, error) {
+		var temps []bcsMinted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Minted, len(temps))
+		for i, temp := range temps {
+			result, err := convertMintedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("managed_token::managed_token::Burnt", func(data []byte) (interface{}, error) {
 		var temp bcsBurnt
@@ -400,6 +463,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Burnt
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::Burnt>", func(data []byte) (interface{}, error) {
+		var temps []bcsBurnt
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Burnt, len(temps))
+		for i, temp := range temps {
+			result, err := convertBurntFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::Blocklisted", func(data []byte) (interface{}, error) {
 		var temp bcsBlocklisted
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -412,6 +493,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Blocklisted
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::Blocklisted>", func(data []byte) (interface{}, error) {
+		var temps []bcsBlocklisted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Blocklisted, len(temps))
+		for i, temp := range temps {
+			result, err := convertBlocklistedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("managed_token::managed_token::Unblocklisted", func(data []byte) (interface{}, error) {
 		var temp bcsUnblocklisted
@@ -426,6 +525,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Unblocklisted
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::Unblocklisted>", func(data []byte) (interface{}, error) {
+		var temps []bcsUnblocklisted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Unblocklisted, len(temps))
+		for i, temp := range temps {
+			result, err := convertUnblocklistedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::Paused", func(data []byte) (interface{}, error) {
 		var result Paused
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -433,6 +550,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Paused
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::Paused>", func(data []byte) (interface{}, error) {
+		var results []Paused
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("managed_token::managed_token::Unpaused", func(data []byte) (interface{}, error) {
 		var result Unpaused
@@ -442,6 +568,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Unpaused
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::Unpaused>", func(data []byte) (interface{}, error) {
+		var results []Unpaused
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::MinterAllowanceIncremented", func(data []byte) (interface{}, error) {
 		var result MinterAllowanceIncremented
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -449,6 +584,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for MinterAllowanceIncremented
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::MinterAllowanceIncremented>", func(data []byte) (interface{}, error) {
+		var results []MinterAllowanceIncremented
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("managed_token::managed_token::MinterUnlimitedAllowanceSet", func(data []byte) (interface{}, error) {
 		var result MinterUnlimitedAllowanceSet
@@ -458,6 +602,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MinterUnlimitedAllowanceSet
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::MinterUnlimitedAllowanceSet>", func(data []byte) (interface{}, error) {
+		var results []MinterUnlimitedAllowanceSet
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("managed_token::managed_token::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -465,6 +618,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<managed_token::managed_token::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/ccip/mock_eth_token/mock_eth_token/mock_eth_token.go
+++ b/bindings/generated/ccip/mock_eth_token/mock_eth_token/mock_eth_token.go
@@ -90,6 +90,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MOCK_ETH_TOKEN
+	bind.RegisterStructDecoder("vector<mock_eth_token::mock_eth_token::MOCK_ETH_TOKEN>", func(data []byte) (interface{}, error) {
+		var results []MOCK_ETH_TOKEN
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 }
 
 // MintAndTransfer executes the mint_and_transfer Move function.

--- a/bindings/generated/ccip/mock_link_token/mock_link_token/mock_link_token.go
+++ b/bindings/generated/ccip/mock_link_token/mock_link_token/mock_link_token.go
@@ -90,6 +90,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MOCK_LINK_TOKEN
+	bind.RegisterStructDecoder("vector<mock_link_token::mock_link_token::MOCK_LINK_TOKEN>", func(data []byte) (interface{}, error) {
+		var results []MOCK_LINK_TOKEN
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 }
 
 // MintAndTransfer executes the mint_and_transfer Move function.

--- a/bindings/generated/link/link/link.go
+++ b/bindings/generated/link/link/link.go
@@ -91,6 +91,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for LINK
+	bind.RegisterStructDecoder("vector<link::link::LINK>", func(data []byte) (interface{}, error) {
+		var results []LINK
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 }
 
 // MintAndTransfer executes the mint_and_transfer Move function.

--- a/bindings/generated/mcms/mcms/mcms.go
+++ b/bindings/generated/mcms/mcms/mcms.go
@@ -788,6 +788,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MultisigState
+	bind.RegisterStructDecoder("vector<mcms::mcms::MultisigState>", func(data []byte) (interface{}, error) {
+		var temps []bcsMultisigState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]MultisigState, len(temps))
+		for i, temp := range temps {
+			result, err := convertMultisigStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::Multisig", func(data []byte) (interface{}, error) {
 		var temp bcsMultisig
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -801,6 +819,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Multisig
+	bind.RegisterStructDecoder("vector<mcms::mcms::Multisig>", func(data []byte) (interface{}, error) {
+		var temps []bcsMultisig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Multisig, len(temps))
+		for i, temp := range temps {
+			result, err := convertMultisigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::Signer", func(data []byte) (interface{}, error) {
 		var result Signer
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -808,6 +844,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Signer
+	bind.RegisterStructDecoder("vector<mcms::mcms::Signer>", func(data []byte) (interface{}, error) {
+		var results []Signer
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::Config", func(data []byte) (interface{}, error) {
 		var result Config
@@ -817,6 +862,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Config
+	bind.RegisterStructDecoder("vector<mcms::mcms::Config>", func(data []byte) (interface{}, error) {
+		var results []Config
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::ExpiringRootAndOpCount", func(data []byte) (interface{}, error) {
 		var result ExpiringRootAndOpCount
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -824,6 +878,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ExpiringRootAndOpCount
+	bind.RegisterStructDecoder("vector<mcms::mcms::ExpiringRootAndOpCount>", func(data []byte) (interface{}, error) {
+		var results []ExpiringRootAndOpCount
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::Op", func(data []byte) (interface{}, error) {
 		var temp bcsOp
@@ -838,6 +901,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Op
+	bind.RegisterStructDecoder("vector<mcms::mcms::Op>", func(data []byte) (interface{}, error) {
+		var temps []bcsOp
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Op, len(temps))
+		for i, temp := range temps {
+			result, err := convertOpFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::RootMetadata", func(data []byte) (interface{}, error) {
 		var temp bcsRootMetadata
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -851,6 +932,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for RootMetadata
+	bind.RegisterStructDecoder("vector<mcms::mcms::RootMetadata>", func(data []byte) (interface{}, error) {
+		var temps []bcsRootMetadata
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]RootMetadata, len(temps))
+		for i, temp := range temps {
+			result, err := convertRootMetadataFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::TimelockCallbackParams", func(data []byte) (interface{}, error) {
 		var result TimelockCallbackParams
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -858,6 +957,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for TimelockCallbackParams
+	bind.RegisterStructDecoder("vector<mcms::mcms::TimelockCallbackParams>", func(data []byte) (interface{}, error) {
+		var results []TimelockCallbackParams
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::MultisigStateInitialized", func(data []byte) (interface{}, error) {
 		var result MultisigStateInitialized
@@ -867,6 +975,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MultisigStateInitialized
+	bind.RegisterStructDecoder("vector<mcms::mcms::MultisigStateInitialized>", func(data []byte) (interface{}, error) {
+		var results []MultisigStateInitialized
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::ConfigSet", func(data []byte) (interface{}, error) {
 		var result ConfigSet
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -874,6 +991,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ConfigSet
+	bind.RegisterStructDecoder("vector<mcms::mcms::ConfigSet>", func(data []byte) (interface{}, error) {
+		var results []ConfigSet
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::NewRoot", func(data []byte) (interface{}, error) {
 		var temp bcsNewRoot
@@ -888,6 +1014,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for NewRoot
+	bind.RegisterStructDecoder("vector<mcms::mcms::NewRoot>", func(data []byte) (interface{}, error) {
+		var temps []bcsNewRoot
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]NewRoot, len(temps))
+		for i, temp := range temps {
+			result, err := convertNewRootFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::OpExecuted", func(data []byte) (interface{}, error) {
 		var temp bcsOpExecuted
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -901,6 +1045,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OpExecuted
+	bind.RegisterStructDecoder("vector<mcms::mcms::OpExecuted>", func(data []byte) (interface{}, error) {
+		var temps []bcsOpExecuted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OpExecuted, len(temps))
+		for i, temp := range temps {
+			result, err := convertOpExecutedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::MCMS", func(data []byte) (interface{}, error) {
 		var result MCMS
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -908,6 +1070,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for MCMS
+	bind.RegisterStructDecoder("vector<mcms::mcms::MCMS>", func(data []byte) (interface{}, error) {
+		var results []MCMS
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::McmsCallback", func(data []byte) (interface{}, error) {
 		var result McmsCallback
@@ -917,6 +1088,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for McmsCallback
+	bind.RegisterStructDecoder("vector<mcms::mcms::McmsCallback>", func(data []byte) (interface{}, error) {
+		var results []McmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::Timelock", func(data []byte) (interface{}, error) {
 		var result Timelock
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -924,6 +1104,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Timelock
+	bind.RegisterStructDecoder("vector<mcms::mcms::Timelock>", func(data []byte) (interface{}, error) {
+		var results []Timelock
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::Call", func(data []byte) (interface{}, error) {
 		var temp bcsCall
@@ -938,6 +1127,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Call
+	bind.RegisterStructDecoder("vector<mcms::mcms::Call>", func(data []byte) (interface{}, error) {
+		var temps []bcsCall
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Call, len(temps))
+		for i, temp := range temps {
+			result, err := convertCallFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::Function", func(data []byte) (interface{}, error) {
 		var temp bcsFunction
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -951,6 +1158,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Function
+	bind.RegisterStructDecoder("vector<mcms::mcms::Function>", func(data []byte) (interface{}, error) {
+		var temps []bcsFunction
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]Function, len(temps))
+		for i, temp := range temps {
+			result, err := convertFunctionFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::TimelockInitialized", func(data []byte) (interface{}, error) {
 		var result TimelockInitialized
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -958,6 +1183,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for TimelockInitialized
+	bind.RegisterStructDecoder("vector<mcms::mcms::TimelockInitialized>", func(data []byte) (interface{}, error) {
+		var results []TimelockInitialized
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::BypasserCallInitiated", func(data []byte) (interface{}, error) {
 		var temp bcsBypasserCallInitiated
@@ -972,6 +1206,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for BypasserCallInitiated
+	bind.RegisterStructDecoder("vector<mcms::mcms::BypasserCallInitiated>", func(data []byte) (interface{}, error) {
+		var temps []bcsBypasserCallInitiated
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]BypasserCallInitiated, len(temps))
+		for i, temp := range temps {
+			result, err := convertBypasserCallInitiatedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::Cancelled", func(data []byte) (interface{}, error) {
 		var result Cancelled
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -979,6 +1231,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Cancelled
+	bind.RegisterStructDecoder("vector<mcms::mcms::Cancelled>", func(data []byte) (interface{}, error) {
+		var results []Cancelled
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::CallScheduled", func(data []byte) (interface{}, error) {
 		var temp bcsCallScheduled
@@ -993,6 +1254,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CallScheduled
+	bind.RegisterStructDecoder("vector<mcms::mcms::CallScheduled>", func(data []byte) (interface{}, error) {
+		var temps []bcsCallScheduled
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]CallScheduled, len(temps))
+		for i, temp := range temps {
+			result, err := convertCallScheduledFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::CallInitiated", func(data []byte) (interface{}, error) {
 		var temp bcsCallInitiated
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -1006,6 +1285,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CallInitiated
+	bind.RegisterStructDecoder("vector<mcms::mcms::CallInitiated>", func(data []byte) (interface{}, error) {
+		var temps []bcsCallInitiated
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]CallInitiated, len(temps))
+		for i, temp := range temps {
+			result, err := convertCallInitiatedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::UpdateMinDelay", func(data []byte) (interface{}, error) {
 		var result UpdateMinDelay
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -1013,6 +1310,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for UpdateMinDelay
+	bind.RegisterStructDecoder("vector<mcms::mcms::UpdateMinDelay>", func(data []byte) (interface{}, error) {
+		var results []UpdateMinDelay
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms::FunctionBlocked", func(data []byte) (interface{}, error) {
 		var temp bcsFunctionBlocked
@@ -1027,6 +1333,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for FunctionBlocked
+	bind.RegisterStructDecoder("vector<mcms::mcms::FunctionBlocked>", func(data []byte) (interface{}, error) {
+		var temps []bcsFunctionBlocked
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]FunctionBlocked, len(temps))
+		for i, temp := range temps {
+			result, err := convertFunctionBlockedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms::FunctionUnblocked", func(data []byte) (interface{}, error) {
 		var temp bcsFunctionUnblocked
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -1039,6 +1363,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for FunctionUnblocked
+	bind.RegisterStructDecoder("vector<mcms::mcms::FunctionUnblocked>", func(data []byte) (interface{}, error) {
+		var temps []bcsFunctionUnblocked
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]FunctionUnblocked, len(temps))
+		for i, temp := range temps {
+			result, err := convertFunctionUnblockedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/mcms/mcms_account/mcms_account.go
+++ b/bindings/generated/mcms/mcms_account/mcms_account.go
@@ -218,6 +218,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OwnerCap
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::OwnerCap>", func(data []byte) (interface{}, error) {
+		var results []OwnerCap
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_account::AccountState", func(data []byte) (interface{}, error) {
 		var temp bcsAccountState
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -230,6 +239,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for AccountState
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::AccountState>", func(data []byte) (interface{}, error) {
+		var temps []bcsAccountState
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]AccountState, len(temps))
+		for i, temp := range temps {
+			result, err := convertAccountStateFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms_account::PendingTransfer", func(data []byte) (interface{}, error) {
 		var temp bcsPendingTransfer
@@ -244,6 +271,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for PendingTransfer
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::PendingTransfer>", func(data []byte) (interface{}, error) {
+		var temps []bcsPendingTransfer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]PendingTransfer, len(temps))
+		for i, temp := range temps {
+			result, err := convertPendingTransferFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_account::OwnershipTransferRequested", func(data []byte) (interface{}, error) {
 		var temp bcsOwnershipTransferRequested
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -256,6 +301,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for OwnershipTransferRequested
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::OwnershipTransferRequested>", func(data []byte) (interface{}, error) {
+		var temps []bcsOwnershipTransferRequested
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OwnershipTransferRequested, len(temps))
+		for i, temp := range temps {
+			result, err := convertOwnershipTransferRequestedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms_account::OwnershipTransferAccepted", func(data []byte) (interface{}, error) {
 		var temp bcsOwnershipTransferAccepted
@@ -270,6 +333,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OwnershipTransferAccepted
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::OwnershipTransferAccepted>", func(data []byte) (interface{}, error) {
+		var temps []bcsOwnershipTransferAccepted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OwnershipTransferAccepted, len(temps))
+		for i, temp := range temps {
+			result, err := convertOwnershipTransferAcceptedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_account::OwnershipTransferred", func(data []byte) (interface{}, error) {
 		var temp bcsOwnershipTransferred
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -283,6 +364,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for OwnershipTransferred
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::OwnershipTransferred>", func(data []byte) (interface{}, error) {
+		var temps []bcsOwnershipTransferred
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OwnershipTransferred, len(temps))
+		for i, temp := range temps {
+			result, err := convertOwnershipTransferredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_account::MCMS_ACCOUNT", func(data []byte) (interface{}, error) {
 		var result MCMS_ACCOUNT
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -290,6 +389,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for MCMS_ACCOUNT
+	bind.RegisterStructDecoder("vector<mcms::mcms_account::MCMS_ACCOUNT>", func(data []byte) (interface{}, error) {
+		var results []MCMS_ACCOUNT
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/mcms/mcms_deployer/mcms_deployer.go
+++ b/bindings/generated/mcms/mcms_deployer/mcms_deployer.go
@@ -169,6 +169,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for DeployerState
+	bind.RegisterStructDecoder("vector<mcms::mcms_deployer::DeployerState>", func(data []byte) (interface{}, error) {
+		var results []DeployerState
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_deployer::UpgradeCapRegistered", func(data []byte) (interface{}, error) {
 		var temp bcsUpgradeCapRegistered
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -181,6 +190,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for UpgradeCapRegistered
+	bind.RegisterStructDecoder("vector<mcms::mcms_deployer::UpgradeCapRegistered>", func(data []byte) (interface{}, error) {
+		var temps []bcsUpgradeCapRegistered
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]UpgradeCapRegistered, len(temps))
+		for i, temp := range temps {
+			result, err := convertUpgradeCapRegisteredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms_deployer::UpgradeTicketAuthorized", func(data []byte) (interface{}, error) {
 		var temp bcsUpgradeTicketAuthorized
@@ -195,6 +222,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for UpgradeTicketAuthorized
+	bind.RegisterStructDecoder("vector<mcms::mcms_deployer::UpgradeTicketAuthorized>", func(data []byte) (interface{}, error) {
+		var temps []bcsUpgradeTicketAuthorized
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]UpgradeTicketAuthorized, len(temps))
+		for i, temp := range temps {
+			result, err := convertUpgradeTicketAuthorizedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_deployer::UpgradeReceiptCommitted", func(data []byte) (interface{}, error) {
 		var temp bcsUpgradeReceiptCommitted
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -208,6 +253,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for UpgradeReceiptCommitted
+	bind.RegisterStructDecoder("vector<mcms::mcms_deployer::UpgradeReceiptCommitted>", func(data []byte) (interface{}, error) {
+		var temps []bcsUpgradeReceiptCommitted
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]UpgradeReceiptCommitted, len(temps))
+		for i, temp := range temps {
+			result, err := convertUpgradeReceiptCommittedFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_deployer::MCMS_DEPLOYER", func(data []byte) (interface{}, error) {
 		var result MCMS_DEPLOYER
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -215,6 +278,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for MCMS_DEPLOYER
+	bind.RegisterStructDecoder("vector<mcms::mcms_deployer::MCMS_DEPLOYER>", func(data []byte) (interface{}, error) {
+		var results []MCMS_DEPLOYER
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/mcms/mcms_registry/mcms_registry.go
+++ b/bindings/generated/mcms/mcms_registry/mcms_registry.go
@@ -192,6 +192,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Registry
+	bind.RegisterStructDecoder("vector<mcms::mcms_registry::Registry>", func(data []byte) (interface{}, error) {
+		var results []Registry
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_registry::ExecutingCallbackParams", func(data []byte) (interface{}, error) {
 		var temp bcsExecutingCallbackParams
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -204,6 +213,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ExecutingCallbackParams
+	bind.RegisterStructDecoder("vector<mcms::mcms_registry::ExecutingCallbackParams>", func(data []byte) (interface{}, error) {
+		var temps []bcsExecutingCallbackParams
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ExecutingCallbackParams, len(temps))
+		for i, temp := range temps {
+			result, err := convertExecutingCallbackParamsFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("mcms::mcms_registry::EntrypointRegistered", func(data []byte) (interface{}, error) {
 		var temp bcsEntrypointRegistered
@@ -218,6 +245,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for EntrypointRegistered
+	bind.RegisterStructDecoder("vector<mcms::mcms_registry::EntrypointRegistered>", func(data []byte) (interface{}, error) {
+		var temps []bcsEntrypointRegistered
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]EntrypointRegistered, len(temps))
+		for i, temp := range temps {
+			result, err := convertEntrypointRegisteredFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_registry::MCMS_REGISTRY", func(data []byte) (interface{}, error) {
 		var result MCMS_REGISTRY
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -226,6 +271,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MCMS_REGISTRY
+	bind.RegisterStructDecoder("vector<mcms::mcms_registry::MCMS_REGISTRY>", func(data []byte) (interface{}, error) {
+		var results []MCMS_REGISTRY
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms::mcms_registry::McmsProof", func(data []byte) (interface{}, error) {
 		var result McmsProof
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -233,6 +287,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for McmsProof
+	bind.RegisterStructDecoder("vector<mcms::mcms_registry::McmsProof>", func(data []byte) (interface{}, error) {
+		var results []McmsProof
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/mcms/mcms_user/mcms_user.go
+++ b/bindings/generated/mcms/mcms_user/mcms_user.go
@@ -175,6 +175,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for UserData
+	bind.RegisterStructDecoder("vector<mcms_test::mcms_user::UserData>", func(data []byte) (interface{}, error) {
+		var temps []bcsUserData
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]UserData, len(temps))
+		for i, temp := range temps {
+			result, err := convertUserDataFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms_test::mcms_user::MCMS_USER", func(data []byte) (interface{}, error) {
 		var result MCMS_USER
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -183,6 +201,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MCMS_USER
+	bind.RegisterStructDecoder("vector<mcms_test::mcms_user::MCMS_USER>", func(data []byte) (interface{}, error) {
+		var results []MCMS_USER
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("mcms_test::mcms_user::SampleMcmsCallback", func(data []byte) (interface{}, error) {
 		var result SampleMcmsCallback
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -190,6 +217,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for SampleMcmsCallback
+	bind.RegisterStructDecoder("vector<mcms_test::mcms_user::SampleMcmsCallback>", func(data []byte) (interface{}, error) {
+		var results []SampleMcmsCallback
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/test/complex/complex.go
+++ b/bindings/generated/test/complex/complex.go
@@ -188,6 +188,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for SampleObject
+	bind.RegisterStructDecoder("vector<test::complex::SampleObject>", func(data []byte) (interface{}, error) {
+		var temps []bcsSampleObject
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]SampleObject, len(temps))
+		for i, temp := range temps {
+			result, err := convertSampleObjectFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::complex::DroppableObject", func(data []byte) (interface{}, error) {
 		var temp bcsDroppableObject
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -200,6 +218,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for DroppableObject
+	bind.RegisterStructDecoder("vector<test::complex::DroppableObject>", func(data []byte) (interface{}, error) {
+		var temps []bcsDroppableObject
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]DroppableObject, len(temps))
+		for i, temp := range temps {
+			result, err := convertDroppableObjectFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/test/counter/counter.go
+++ b/bindings/generated/test/counter/counter.go
@@ -363,6 +363,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for COUNTER
+	bind.RegisterStructDecoder("vector<test::counter::COUNTER>", func(data []byte) (interface{}, error) {
+		var results []COUNTER
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::CounterIncremented", func(data []byte) (interface{}, error) {
 		var result CounterIncremented
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -370,6 +379,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for CounterIncremented
+	bind.RegisterStructDecoder("vector<test::counter::CounterIncremented>", func(data []byte) (interface{}, error) {
+		var results []CounterIncremented
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("test::counter::CounterDecremented", func(data []byte) (interface{}, error) {
 		var result CounterDecremented
@@ -379,6 +397,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CounterDecremented
+	bind.RegisterStructDecoder("vector<test::counter::CounterDecremented>", func(data []byte) (interface{}, error) {
+		var results []CounterDecremented
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::AdminCap", func(data []byte) (interface{}, error) {
 		var result AdminCap
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -387,6 +414,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for AdminCap
+	bind.RegisterStructDecoder("vector<test::counter::AdminCap>", func(data []byte) (interface{}, error) {
+		var results []AdminCap
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::Counter", func(data []byte) (interface{}, error) {
 		var result Counter
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -394,6 +430,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Counter
+	bind.RegisterStructDecoder("vector<test::counter::Counter>", func(data []byte) (interface{}, error) {
+		var results []Counter
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("test::counter::CounterPointer", func(data []byte) (interface{}, error) {
 		var temp bcsCounterPointer
@@ -408,6 +453,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for CounterPointer
+	bind.RegisterStructDecoder("vector<test::counter::CounterPointer>", func(data []byte) (interface{}, error) {
+		var temps []bcsCounterPointer
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]CounterPointer, len(temps))
+		for i, temp := range temps {
+			result, err := convertCounterPointerFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::AddressList", func(data []byte) (interface{}, error) {
 		var temp bcsAddressList
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -421,6 +484,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for AddressList
+	bind.RegisterStructDecoder("vector<test::counter::AddressList>", func(data []byte) (interface{}, error) {
+		var temps []bcsAddressList
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]AddressList, len(temps))
+		for i, temp := range temps {
+			result, err := convertAddressListFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::SimpleResult", func(data []byte) (interface{}, error) {
 		var result SimpleResult
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -428,6 +509,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for SimpleResult
+	bind.RegisterStructDecoder("vector<test::counter::SimpleResult>", func(data []byte) (interface{}, error) {
+		var results []SimpleResult
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("test::counter::ComplexResult", func(data []byte) (interface{}, error) {
 		var temp bcsComplexResult
@@ -442,6 +532,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for ComplexResult
+	bind.RegisterStructDecoder("vector<test::counter::ComplexResult>", func(data []byte) (interface{}, error) {
+		var temps []bcsComplexResult
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]ComplexResult, len(temps))
+		for i, temp := range temps {
+			result, err := convertComplexResultFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::NestedStruct", func(data []byte) (interface{}, error) {
 		var temp bcsNestedStruct
 		_, err := mystenbcs.Unmarshal(data, &temp)
@@ -454,6 +562,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for NestedStruct
+	bind.RegisterStructDecoder("vector<test::counter::NestedStruct>", func(data []byte) (interface{}, error) {
+		var temps []bcsNestedStruct
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]NestedStruct, len(temps))
+		for i, temp := range temps {
+			result, err := convertNestedStructFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("test::counter::MultiNestedStruct", func(data []byte) (interface{}, error) {
 		var temp bcsMultiNestedStruct
@@ -468,6 +594,24 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for MultiNestedStruct
+	bind.RegisterStructDecoder("vector<test::counter::MultiNestedStruct>", func(data []byte) (interface{}, error) {
+		var temps []bcsMultiNestedStruct
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]MultiNestedStruct, len(temps))
+		for i, temp := range temps {
+			result, err := convertMultiNestedStructFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::counter::ConfigInfo", func(data []byte) (interface{}, error) {
 		var result ConfigInfo
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -475,6 +619,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for ConfigInfo
+	bind.RegisterStructDecoder("vector<test::counter::ConfigInfo>", func(data []byte) (interface{}, error) {
+		var results []ConfigInfo
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 	bind.RegisterStructDecoder("test::counter::OCRConfig", func(data []byte) (interface{}, error) {
 		var temp bcsOCRConfig
@@ -488,6 +641,24 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for OCRConfig
+	bind.RegisterStructDecoder("vector<test::counter::OCRConfig>", func(data []byte) (interface{}, error) {
+		var temps []bcsOCRConfig
+		_, err := mystenbcs.Unmarshal(data, &temps)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]OCRConfig, len(temps))
+		for i, temp := range temps {
+			result, err := convertOCRConfigFromBCS(temp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert element %d: %w", i, err)
+			}
+			results[i] = result
+		}
+		return results, nil
 	})
 }
 

--- a/bindings/generated/test/generics/generics.go
+++ b/bindings/generated/test/generics/generics.go
@@ -128,6 +128,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Box
+	bind.RegisterStructDecoder("vector<test::generics::Box>", func(data []byte) (interface{}, error) {
+		var results []Box
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::generics::Token", func(data []byte) (interface{}, error) {
 		var result Token
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -136,6 +145,15 @@ func init() {
 		}
 		return result, nil
 	})
+	// Register vector decoder for Token
+	bind.RegisterStructDecoder("vector<test::generics::Token>", func(data []byte) (interface{}, error) {
+		var results []Token
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	})
 	bind.RegisterStructDecoder("test::generics::Pair", func(data []byte) (interface{}, error) {
 		var result Pair
 		_, err := mystenbcs.Unmarshal(data, &result)
@@ -143,6 +161,15 @@ func init() {
 			return nil, err
 		}
 		return result, nil
+	})
+	// Register vector decoder for Pair
+	bind.RegisterStructDecoder("vector<test::generics::Pair>", func(data []byte) (interface{}, error) {
+		var results []Pair
+		_, err := mystenbcs.Unmarshal(data, &results)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	})
 }
 


### PR DESCRIPTION
This PR updates the bindings template to allow auto-generation and registration of `vector<SomeStruct>` decoding for any of the contracts.