### PR TITLE
fix token transfer fee config behavior

### DIFF
--- a/contracts/ccip/ccip/sources/fee_quoter.move
+++ b/contracts/ccip/ccip/sources/fee_quoter.move
@@ -535,6 +535,9 @@ public fun apply_token_transfer_fee_config_updates(
             EInvalidDestBytesOverhead,
         );
 
+        if (token_transfer_fee_configs.contains(token)) {
+            let _old_value = token_transfer_fee_configs.remove(token);
+        };
         token_transfer_fee_configs.add(token, token_transfer_fee_config);
 
         event::emit(TokenTransferFeeConfigAdded {

--- a/contracts/ccip/ccip/tests/fee_quoter_tests.move
+++ b/contracts/ccip/ccip/tests/fee_quoter_tests.move
@@ -272,6 +272,83 @@ public fun test_apply_token_transfer_fee_config_updates_remove_token() {
     cleanup_test_scenario(scenario, owner_cap, ref);
 }
 
+#[test]
+public fun test_apply_token_transfer_fee_config_updates_overwrite_existing() {
+    let (mut scenario, owner_cap, mut ref) = setup_ccip_environment();
+    let ctx = scenario.ctx();
+    initialize_fee_quoter(&mut ref, &owner_cap, ctx);
+
+    // First, add initial token transfer fee config
+    fee_quoter::apply_token_transfer_fee_config_updates(
+        &mut ref,
+        &owner_cap,
+        10, // dest_chain_selector
+        vector[MOCK_ADDRESS_1], // add_tokens
+        vector[100], // add_min_fee_usd_cents
+        vector[1000], // add_max_fee_usd_cents
+        vector[200], // add_deci_bps
+        vector[50000], // add_dest_gas_overhead
+        vector[64], // add_dest_bytes_overhead
+        vector[true], // add_is_enabled
+        vector[], // remove_tokens
+        ctx,
+    );
+
+    // Verify initial config
+    let cfg = fee_quoter::get_token_transfer_fee_config(&ref, 10, MOCK_ADDRESS_1);
+    let (
+        min_fee_usd_cents,
+        max_fee_usd_cents,
+        deci_bps,
+        dest_gas_overhead,
+        dest_bytes_overhead,
+        is_enabled,
+    ) = fee_quoter::get_token_transfer_fee_config_fields(cfg);
+    assert!(min_fee_usd_cents == 100);
+    assert!(max_fee_usd_cents == 1000);
+    assert!(deci_bps == 200);
+    assert!(dest_gas_overhead == 50000);
+    assert!(dest_bytes_overhead == 64);
+    assert!(is_enabled);
+
+    // Now update the same token with different values
+    fee_quoter::apply_token_transfer_fee_config_updates(
+        &mut ref,
+        &owner_cap,
+        10, // dest_chain_selector (same)
+        vector[MOCK_ADDRESS_1], // add_tokens (same token)
+        vector[500], // add_min_fee_usd_cents (UPDATED)
+        vector[5000], // add_max_fee_usd_cents (UPDATED)
+        vector[800], // add_deci_bps (UPDATED)
+        vector[120000], // add_dest_gas_overhead (UPDATED)
+        vector[128], // add_dest_bytes_overhead (UPDATED)
+        vector[false], // add_is_enabled (UPDATED)
+        vector[], // remove_tokens
+        ctx,
+    );
+
+    // Verify the config was updated with new values
+    let updated_cfg = fee_quoter::get_token_transfer_fee_config(&ref, 10, MOCK_ADDRESS_1);
+    let (
+        updated_min_fee_usd_cents,
+        updated_max_fee_usd_cents,
+        updated_deci_bps,
+        updated_dest_gas_overhead,
+        updated_dest_bytes_overhead,
+        updated_is_enabled,
+    ) = fee_quoter::get_token_transfer_fee_config_fields(updated_cfg);
+
+    // Assert all values were updated
+    assert!(updated_min_fee_usd_cents == 500);
+    assert!(updated_max_fee_usd_cents == 5000);
+    assert!(updated_deci_bps == 800);
+    assert!(updated_dest_gas_overhead == 120000);
+    assert!(updated_dest_bytes_overhead == 128);
+    assert!(!updated_is_enabled);
+
+    cleanup_test_scenario(scenario, owner_cap, ref);
+}
+
 // === Premium Multiplier Tests ===
 
 #[test]


### PR DESCRIPTION
keep the behavior the same as [aptos](https://github.com/smartcontractkit/chainlink-aptos/blob/develop/contracts/ccip/ccip/sources/fee_quoter.move#L525)