### PR TITLE
fix(bindings): registryObjID as NewCCIPEntrypointArgEncoder args

### DIFF
--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -25,8 +25,8 @@ type CCIPEntrypointArgEncoder struct {
 	registryObjID string
 }
 
-func NewCCIPEntrypointArgEncoder() *CCIPEntrypointArgEncoder {
-	return &CCIPEntrypointArgEncoder{}
+func NewCCIPEntrypointArgEncoder(registryObjID string) *CCIPEntrypointArgEncoder {
+	return &CCIPEntrypointArgEncoder{registryObjID: registryObjID}
 }
 
 func deserializeFirst32Bytes(data []byte) []byte {

--- a/bindings/mcms_encoder_test.go
+++ b/bindings/mcms_encoder_test.go
@@ -1052,8 +1052,9 @@ func TestHelperFunctions(t *testing.T) {
 }
 
 func TestNewCCIPEntrypointArgEncoder(t *testing.T) {
-	encoder := NewCCIPEntrypointArgEncoder()
+	registryObjID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	encoder := NewCCIPEntrypointArgEncoder(registryObjID)
 
 	assert.NotNil(t, encoder)
-	assert.Empty(t, encoder.registryObjID)
+	assert.Equal(t, registryObjID, encoder.registryObjID)
 }


### PR DESCRIPTION
# Summary
Fixes `NewCCIPEntrypointArgEncoder` to accept a `registryObjID` as parameter. Otherwise, since `registryObjID` is unexported, it'd be impossible to initialize `&CCIPEntrypointArgEncoder{registryObjID: registryObjID}`.
