### PR TITLE
Update ownership Ops and Changesets

### DIFF
--- a/bindings/bind/call.go
+++ b/bindings/bind/call.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultGasBudget is the default gas budget for transactions
-	DefaultGasBudget uint64 = 10_000_000
+	DefaultGasBudget uint64 = 500_000_000
 )
 
 type IBoundContract interface {

--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -132,13 +132,20 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 	// OFFRAMP
 	case "offramp":
 		switch function {
-		case "accept_ownership",
-			"set_dynamic_config",
+		case "set_dynamic_config",
 			"apply_source_chain_config_updates",
 			"set_ocr3_config",
 			"transfer_ownership",
 			"execute_ownership_transfer":
 			return encodeWithCCIPObjectRefAndState()
+		case "accept_ownership":
+			offramp, err := module_offramp.NewOfframp(target, nil)
+			if err != nil {
+				return nil, err
+			}
+			ccipObjectRef := bind.Object{Id: stateObjID} // For accept_ownership, the state object is the CCIP object ref
+			stateObj := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return offramp.Encoder().McmsAcceptOwnershipWithArgs(ccipObjectRef, stateObj, registryObj, executingCallbackParams)
 		}
 
 	// ONRAMP
@@ -148,8 +155,16 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			return nil, err
 		}
 		switch function {
-		case "accept_ownership",
-			"set_dynamic_config",
+		case "accept_ownership":
+			onramp, err := module_onramp.NewOnramp(target, nil)
+			if err != nil {
+				return nil, err
+			}
+			ccipObjectRef := bind.Object{Id: stateObjID} // For accept_ownership, the state object is the CCIP object ref
+			stateObj := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return onramp.Encoder().McmsAcceptOwnershipWithArgs(ccipObjectRef, stateObj, registryObj, executingCallbackParams)
+
+		case "set_dynamic_config",
 			"apply_dest_chain_config_updates",
 			"apply_allowlist_updates",
 			"transfer_ownership",

--- a/bindings/mcms_encoder_test.go
+++ b/bindings/mcms_encoder_test.go
@@ -154,7 +154,6 @@ func TestEncodeEntryPointArg_Offramp(t *testing.T) {
 	executingCallbackParams := &transaction.Argument{}
 
 	testCases := []string{
-		"accept_ownership",
 		"set_dynamic_config",
 		"apply_source_chain_config_updates",
 		"set_ocr3_config",
@@ -283,7 +282,6 @@ func TestEncodeEntryPointArg_Onramp(t *testing.T) {
 	})
 
 	ccipTestCases := []string{
-		"accept_ownership",
 		"set_dynamic_config",
 		"apply_dest_chain_config_updates",
 		"apply_allowlist_updates",

--- a/deployment/changesets/cd_deploy_tp_and_configure.go
+++ b/deployment/changesets/cd_deploy_tp_and_configure.go
@@ -64,7 +64,7 @@ func (d DeployTPAndConfigure) Apply(e cldf.Environment, config DeployTPAndConfig
 	for _, tokenPoolType := range config.TokenPoolTypes {
 		if tokenPoolType == "bnm" {
 			config.BurnMintTpInput.CCIPPackageId = state[config.SuiChainSelector].CCIPAddress
-			config.BurnMintTpInput.MCMSAddress = state[config.SuiChainSelector].MCMsAddress
+			config.BurnMintTpInput.MCMSAddress = state[config.SuiChainSelector].MCMSPackageID
 			config.BurnMintTpInput.MCMSOwnerAddress = deployerAddr
 			config.BurnMintTpInput.CCIPObjectRefObjectId = state[config.SuiChainSelector].CCIPObjectRef
 			config.BurnMintTpInput.TokenPoolAdministrator = deployerAddr // check with felix if this is fine
@@ -98,7 +98,7 @@ func (d DeployTPAndConfigure) Apply(e cldf.Environment, config DeployTPAndConfig
 
 		if tokenPoolType == "lnr" {
 			config.LockReleaseTPInput.CCIPPackageId = state[config.SuiChainSelector].CCIPAddress
-			config.LockReleaseTPInput.MCMSAddress = state[config.SuiChainSelector].MCMsAddress
+			config.LockReleaseTPInput.MCMSAddress = state[config.SuiChainSelector].MCMSPackageID
 			config.LockReleaseTPInput.MCMSOwnerAddress = deployerAddr
 			config.LockReleaseTPInput.CCIPObjectRefObjectId = state[config.SuiChainSelector].CCIPObjectRef
 			config.LockReleaseTPInput.TokenPoolAdministrator = deployerAddr
@@ -111,7 +111,7 @@ func (d DeployTPAndConfigure) Apply(e cldf.Environment, config DeployTPAndConfig
 
 		if tokenPoolType == "managed" {
 			config.ManagedTPInput.CCIPPackageId = state[config.SuiChainSelector].CCIPAddress
-			config.ManagedTPInput.MCMSAddress = state[config.SuiChainSelector].MCMsAddress
+			config.ManagedTPInput.MCMSAddress = state[config.SuiChainSelector].MCMSPackageID
 			config.ManagedTPInput.MCMSOwnerAddress = deployerAddr
 			config.ManagedTPInput.CCIPObjectRefObjectId = state[config.SuiChainSelector].CCIPObjectRef
 			config.ManagedTPInput.TokenPoolAdministrator = deployerAddr

--- a/deployment/changesets/cs_accept_ownership_sui_chain.go
+++ b/deployment/changesets/cs_accept_ownership_sui_chain.go
@@ -4,16 +4,11 @@ import (
 	"fmt"
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
-	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
-	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
-	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
-	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
-	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	ownershipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ownership"
 	opregistry "github.com/smartcontractkit/chainlink-sui/deployment/ops/registry"
 	"github.com/smartcontractkit/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
@@ -30,9 +25,6 @@ type AcceptOwnershipCCIP struct{}
 
 // Apply implements deployment.ChangeSetV2.
 func (d AcceptOwnershipCCIP) Apply(e cldf.Environment, config AcceptOwnershipCCIPConfig) (cldf.ChangesetOutput, error) {
-	ab := cldf.NewMemoryAddressBook()
-	seqReports := make([]operations.Report[any, any], 0)
-
 	suiChain := e.BlockChains.SuiChains()[config.SuiChainSelector]
 	signer := suiChain.Signer
 
@@ -62,55 +54,38 @@ func (d AcceptOwnershipCCIP) Apply(e cldf.Environment, config AcceptOwnershipCCI
 
 	state := suiState[config.SuiChainSelector]
 
-	// Generate the proposal to accept the ownership of the deployed contracts
-	proposalInput := mcmsops.ProposalGenerateInput{
-		Defs: []operations.Definition{
-			ccipops.AcceptOwnershipStateObjectOp.Def(),
-			routerops.AcceptOwnershipOp.Def(),
-			onrampops.AcceptOwnershipOnRampOp.Def(),
-			offrampops.AcceptOwnershipOffRampOp.Def(),
-		},
-		Inputs: []any{
-			ccipops.AcceptOwnershipStateObjectInput{
-				CCIPPackageId:         state.CCIPAddress,
-				CCIPObjectRefObjectId: state.CCIPObjectRef,
-			},
-			routerops.AcceptOwnershipInput{
-				RouterPackageId:     state.CCIPRouterAddress,
-				RouterStateObjectId: state.CCIPRouterStateObjectID,
-			},
-			onrampops.AcceptOwnershipOnRampInput{
-				OnRampPackageId: state.OnRampAddress,
-				CCIPObjectRefId: state.CCIPObjectRef,
-				StateObjectId:   state.OnRampStateObjectId,
-			},
-			offrampops.AcceptOwnershipOffRampInput{
-				OffRampPackageId:     state.OffRampAddress,
-				OffRampRefObjectId:   state.CCIPObjectRef,
-				OffRampStateObjectId: state.OffRampStateObjectId,
-			},
-		},
-		// MCMS related
-		MmcsPackageID:  state.MCMSPackageID,
-		McmsStateObjID: state.MCMSStateObjectID,
-		TimelockObjID:  state.MCMSTimelockObjectID,
-		AccountObjID:   state.MCMSAccountStateObjectID,
-		RegistryObjID:  state.MCMSRegistryObjectID,
-
-		// Proposal
-		Role: suisdk.TimelockRoleProposer,
-
+	// Generate the proposal to accept the ownership of the CCIP contracts. Get the addresses from AB
+	proposalInput := ownershipops.AcceptCCIPOwnershipInput{
 		ChainSelector: config.SuiChainSelector,
+
+		// MCMS related
+		MCMSPackageId:     state.MCMSPackageID,
+		MCMSStateObjId:    state.MCMSStateObjectID,
+		MCMSTimelockObjId: state.MCMSTimelockObjectID,
+		MCMSAccountObjId:  state.MCMSAccountStateObjectID,
+		MCMSRegistryObjId: state.MCMSRegistryObjectID,
+
+		CCIPPackageId: state.CCIPAddress,
+		CCIPObjectRef: state.CCIPObjectRef,
+
+		RouterPackageId:     state.CCIPRouterAddress,
+		RouterStateObjectId: state.CCIPRouterStateObjectID,
+
+		OnRampPackageId:     state.OnRampAddress,
+		OnRampStateObjectId: state.OnRampStateObjectId,
+
+		OffRampPackageId:     state.OffRampAddress,
+		OffRampStateObjectId: state.OffRampStateObjectId,
+
+		Role: suisdk.TimelockRoleProposer,
 	}
 
-	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, ownershipops.AcceptCCIPOwnershipSeq, deps, proposalInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
 
 	return cldf.ChangesetOutput{
-		AddressBook:           ab,
-		Reports:               seqReports,
 		MCMSTimelockProposals: []mcms.TimelockProposal{acceptOwnershipProposalReport.Output},
 	}, nil
 }

--- a/deployment/changesets/cs_accept_ownership_sui_chain.go
+++ b/deployment/changesets/cs_accept_ownership_sui_chain.go
@@ -1,0 +1,122 @@
+package changesets
+
+import (
+	"fmt"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	opregistry "github.com/smartcontractkit/chainlink-sui/deployment/ops/registry"
+	"github.com/smartcontractkit/mcms"
+	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
+)
+
+type AcceptOwnershipCCIPConfig struct {
+	SuiChainSelector uint64
+}
+
+var _ cldf.ChangeSetV2[AcceptOwnershipCCIPConfig] = AcceptOwnershipCCIP{}
+
+// AcceptOwnershipCCIP deploys Sui chain packages and modules
+type AcceptOwnershipCCIP struct{}
+
+// Apply implements deployment.ChangeSetV2.
+func (d AcceptOwnershipCCIP) Apply(e cldf.Environment, config AcceptOwnershipCCIPConfig) (cldf.ChangesetOutput, error) {
+	ab := cldf.NewMemoryAddressBook()
+	seqReports := make([]operations.Report[any, any], 0)
+
+	suiChain := e.BlockChains.SuiChains()[config.SuiChainSelector]
+	signer := suiChain.Signer
+
+	deps := sui_ops.OpTxDeps{
+		Client: suiChain.Client,
+		Signer: signer,
+		GetCallOpts: func() *bind.CallOpts {
+			b := uint64(500_000_000)
+			return &bind.CallOpts{
+				WaitForExecution: true,
+				GasBudget:        &b,
+			}
+		},
+	}
+
+	// in case the registry is not loaded with all operations. Needed to build accept ownership proposals
+	ops := make([]*cld_ops.Operation[any, any, any], len(opregistry.AllOperations))
+	for i := range opregistry.AllOperations {
+		ops[i] = &opregistry.AllOperations[i]
+		cld_ops.RegisterOperation(e.OperationsBundle.OperationRegistry, &opregistry.AllOperations[i])
+	}
+
+	suiState, err := deployment.LoadOnchainStatesui(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	state := suiState[config.SuiChainSelector]
+
+	// Generate the proposal to accept the ownership of the deployed contracts
+	proposalInput := mcmsops.ProposalGenerateInput{
+		Defs: []operations.Definition{
+			ccipops.AcceptOwnershipStateObjectOp.Def(),
+			routerops.AcceptOwnershipOp.Def(),
+			onrampops.AcceptOwnershipOnRampOp.Def(),
+			offrampops.AcceptOwnershipOffRampOp.Def(),
+		},
+		Inputs: []any{
+			ccipops.AcceptOwnershipStateObjectInput{
+				CCIPPackageId:         state.CCIPAddress,
+				CCIPObjectRefObjectId: state.CCIPObjectRef,
+			},
+			routerops.AcceptOwnershipInput{
+				RouterPackageId:     state.CCIPRouterAddress,
+				RouterStateObjectId: state.CCIPRouterStateObjectID,
+			},
+			onrampops.AcceptOwnershipOnRampInput{
+				OnRampPackageId: state.OnRampAddress,
+				CCIPObjectRefId: state.CCIPObjectRef,
+				StateObjectId:   state.OnRampStateObjectId,
+			},
+			offrampops.AcceptOwnershipOffRampInput{
+				OffRampPackageId:     state.OffRampAddress,
+				OffRampRefObjectId:   state.CCIPObjectRef,
+				OffRampStateObjectId: state.OffRampStateObjectId,
+			},
+		},
+		// MCMS related
+		MmcsPackageID:  state.MCMSPackageID,
+		McmsStateObjID: state.MCMSStateObjectID,
+		TimelockObjID:  state.MCMSTimelockObjectID,
+		AccountObjID:   state.MCMSAccountStateObjectID,
+		RegistryObjID:  state.MCMSRegistryObjectID,
+
+		// Proposal
+		Role: suisdk.TimelockRoleProposer,
+
+		ChainSelector: config.SuiChainSelector,
+	}
+
+	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
+	return cldf.ChangesetOutput{
+		AddressBook:           ab,
+		Reports:               seqReports,
+		MCMSTimelockProposals: []mcms.TimelockProposal{acceptOwnershipProposalReport.Output},
+	}, nil
+}
+
+// TODO
+// VerifyPreconditions imsplements deployment.ChangeSetV2.
+func (d AcceptOwnershipCCIP) VerifyPreconditions(e cldf.Environment, config AcceptOwnershipCCIPConfig) error {
+	return nil
+}

--- a/deployment/changesets/cs_deploy_dummy_receiver.go
+++ b/deployment/changesets/cs_deploy_dummy_receiver.go
@@ -48,7 +48,7 @@ func (d DeployDummyReceiver) Apply(e cldf.Environment, config DeployDummyReceive
 	// Run DummyReceiver Operation
 	DeployDummyReceiverOp, err := operations.ExecuteOperation(e.OperationsBundle, ccipops.DeployCCIPDummyReceiverOp, deps, ccipops.DeployDummyReceiverInput{
 		CCIPPackageId: state[config.SuiChainSelector].CCIPAddress,
-		McmsPackageId: state[config.SuiChainSelector].MCMsAddress,
+		McmsPackageId: state[config.SuiChainSelector].MCMSPackageID,
 		McmsOwner:     config.McmsOwner,
 	})
 	if err != nil {

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -56,15 +56,10 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	}
 
 	// in case the registry is not loaded with all operations. Needed to build accept ownership proposals
-	if e.OperationsBundle.OperationRegistry == nil {
-		ops := make([]*cld_ops.Operation[any, any, any], len(opregistry.AllOperations))
-		for i := range opregistry.AllOperations {
-			ops[i] = &opregistry.AllOperations[i]
-		}
-		registry := cld_ops.NewOperationRegistry(
-			ops...,
-		)
-		e.OperationsBundle.OperationRegistry = registry
+	ops := make([]*cld_ops.Operation[any, any, any], len(opregistry.AllOperations))
+	for i := range opregistry.AllOperations {
+		ops[i] = &opregistry.AllOperations[i]
+		cld_ops.RegisterOperation(e.OperationsBundle.OperationRegistry, &opregistry.AllOperations[i])
 	}
 
 	suiState, err := deployment.LoadOnchainStatesui(e)

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -15,7 +15,6 @@ import (
 	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 	opregistry "github.com/smartcontractkit/chainlink-sui/deployment/ops/registry"
-	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 )
 
 type DeploySuiChainConfig struct {
@@ -69,10 +68,6 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	state := suiState[config.SuiChainSelector]
 
 	mcmsPackageId := state.MCMSPackageID
-	mcmsStateObjID := state.MCMSStateObjectID
-	timelockObjID := state.MCMSTimelockObjectID
-	accountObjID := state.MCMSAccountStateObjectID
-	registryObjID := state.MCMSRegistryObjectID
 	// If MCMS is not deployed, deploy it
 	if mcmsPackageId == "" {
 		mcmsReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, mcmsops.DeployMCMSSeqInput{
@@ -88,10 +83,6 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		}
 
 		mcmsPackageId = mcmsReport.Output.PackageId
-		mcmsStateObjID = mcmsReport.Output.Objects.McmsMultisigStateObjectId
-		timelockObjID = mcmsReport.Output.Objects.TimelockObjectId
-		accountObjID = mcmsReport.Output.Objects.McmsAccountStateObjectId
-		registryObjID = mcmsReport.Output.Objects.McmsRegistryObjectId
 	}
 
 	// Deploy Router
@@ -305,56 +296,11 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save OnRampUpgradeCapId  %s for Sui chain %d: %w", ccipOnRampSeqReport.Output.Objects.StateObjectId, config.DestChainSelector, err)
 	}
 
-	// Generate the proposal to accept the ownership of the deployed contracts
-	proposalInput := mcmsops.ProposalGenerateInput{
-		Defs: []operations.Definition{
-			ccipops.AcceptOwnershipStateObjectOp.Def(),
-			routerops.AcceptOwnershipOp.Def(),
-			onrampops.AcceptOwnershipOnRampOp.Def(),
-			offrampops.AcceptOwnershipOffRampOp.Def(),
-		},
-		Inputs: []any{
-			ccipops.AcceptOwnershipStateObjectInput{
-				CCIPPackageId:         ccipSeqReport.Output.CCIPPackageId,
-				CCIPObjectRefObjectId: ccipSeqReport.Output.Objects.CCIPObjectRefObjectId,
-			},
-			routerops.AcceptOwnershipInput{
-				RouterPackageId:     routerReport.Output.PackageId,
-				RouterStateObjectId: routerReport.Output.Objects.RouterStateObjectId,
-			},
-			onrampops.AcceptOwnershipOnRampInput{
-				OnRampPackageId: ccipOnRampSeqReport.Output.CCIPOnRampPackageId,
-				CCIPObjectRefId: ccipSeqReport.Output.Objects.CCIPObjectRefObjectId,
-				StateObjectId:   ccipOnRampSeqReport.Output.Objects.StateObjectId,
-			},
-			offrampops.AcceptOwnershipOffRampInput{
-				OffRampPackageId:     ccipOffRampSeqReport.Output.CCIPOffRampPackageId,
-				OffRampRefObjectId:   ccipSeqReport.Output.Objects.CCIPObjectRefObjectId,
-				OffRampStateObjectId: ccipOffRampSeqReport.Output.Objects.StateObjectId,
-			},
-		},
-		// MCMS related
-		MmcsPackageID:  mcmsPackageId,
-		McmsStateObjID: mcmsStateObjID,
-		TimelockObjID:  timelockObjID,
-		AccountObjID:   accountObjID,
-		RegistryObjID:  registryObjID,
-
-		// Proposal
-		Role: suisdk.TimelockRoleProposer,
-
-		ChainSelector: config.SuiChainSelector,
-	}
-
-	_, err = cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
-	if err != nil {
-		return cldf.ChangesetOutput{}, err
-	}
+	// TODO: This could return the accept ownership proposal instead of having a different changeset for it
 
 	return cldf.ChangesetOutput{
 		AddressBook: ab,
 		Reports:     seqReports,
-		// MCMSTimelockProposals: []mcms.TimelockProposal{acceptOwnershipProposalReport.Output},
 	}, nil
 }
 

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -76,6 +76,17 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy CCIP Router for Sui chain %d: %w", config.SuiChainSelector, err)
 	}
 
+	// Transfer ownership of Router to MCMS
+	_, err = operations.ExecuteOperation(e.OperationsBundle, routerops.TransferOwnershipOp, deps, routerops.TransferOwnershipInput{
+		RouterPackageId:     routerReport.Output.PackageId,
+		RouterStateObjectId: routerReport.Output.Objects.RouterStateObjectId,
+		OwnerCapObjectId:    routerReport.Output.Objects.OwnerCapObjectId,
+		NewOwner:            mcmsSeqReport.Output.PackageId,
+	})
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute ownership transfer to MCMS Router for Sui chain %d: %w", config.SuiChainSelector, err)
+	}
+
 	// save Router address to the addressbook
 	typeAndVersionRouter := cldf.NewTypeAndVersion(deployment.SuiCCIPRouterType, deployment.Version1_0_0)
 	err = ab.Save(config.SuiChainSelector, routerReport.Output.PackageId, typeAndVersionRouter)

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -70,6 +70,10 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	state := suiState[config.SuiChainSelector]
 
 	mcmsPackageId := state.MCMSPackageID
+	mcmsStateObjID := state.MCMSStateObjectID
+	timelockObjID := state.MCMSTimelockObjectID
+	accountObjID := state.MCMSAccountStateObjectID
+	registryObjID := state.MCMSRegistryObjectID
 	// If MCMS is not deployed, deploy it
 	if mcmsPackageId == "" {
 		mcmsReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, mcmsops.DeployMCMSSeqInput{
@@ -85,6 +89,10 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		}
 
 		mcmsPackageId = mcmsReport.Output.PackageId
+		mcmsStateObjID = mcmsReport.Output.Objects.McmsMultisigStateObjectId
+		timelockObjID = mcmsReport.Output.Objects.TimelockObjectId
+		accountObjID = mcmsReport.Output.Objects.McmsAccountStateObjectId
+		registryObjID = mcmsReport.Output.Objects.McmsRegistryObjectId
 	}
 
 	// Deploy Router
@@ -328,10 +336,10 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		},
 		// MCMS related
 		MmcsPackageID:  mcmsPackageId,
-		McmsStateObjID: state.MCMSStateObjectID,
-		TimelockObjID:  state.MCMSTimelockObjectID,
-		AccountObjID:   state.MCMSAccountStateObjectID,
-		RegistryObjID:  state.MCMSRegistryObjectID,
+		McmsStateObjID: mcmsStateObjID,
+		TimelockObjID:  timelockObjID,
+		AccountObjID:   accountObjID,
+		RegistryObjID:  registryObjID,
 
 		// Proposal
 		Role: suisdk.TimelockRoleProposer,

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -62,10 +62,28 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 
 	state := suiState[config.SuiChainSelector]
 
+	mcmsPackageId := state.MCMSPackageID
+	if mcmsPackageId == "" {
+		// Run DeployMCMS Sequence
+		mcmsReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, mcmsops.DeployMCMSSeqInput{
+			ChainSelector: config.SuiChainSelector,
+		})
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy MCMS for Sui chain %d: %w", config.SuiChainSelector, err)
+		}
+
+		err = storeMCMSInAddressBook(ab, config.SuiChainSelector, mcmsReport.Output)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to store MCMS in address book for Sui chain %d: %w", config.SuiChainSelector, err)
+		}
+
+		mcmsPackageId = mcmsReport.Output.PackageId
+	}
+
 	// Deploy Router
 	// TODO: Maybe make this part of CCIP sequence
 	routerReport, err := operations.ExecuteOperation(e.OperationsBundle, routerops.DeployCCIPRouterOp, deps, routerops.DeployCCIPRouterInput{
-		McmsPackageId: state.MCMSPackageID,
+		McmsPackageId: mcmsPackageId,
 		McmsOwner:     signerAddr,
 	})
 	if err != nil {
@@ -77,7 +95,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		RouterPackageId:     routerReport.Output.PackageId,
 		RouterStateObjectId: routerReport.Output.Objects.RouterStateObjectId,
 		OwnerCapObjectId:    routerReport.Output.Objects.OwnerCapObjectId,
-		NewOwner:            state.MCMSPackageID,
+		NewOwner:            mcmsPackageId,
 	})
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute ownership transfer to MCMS Router for Sui chain %d: %w", config.SuiChainSelector, err)
@@ -105,7 +123,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	ccipSeqInput.LinkTokenCoinMetadataObjectId = config.LinkTokenCoinMetadataObjectId
 	ccipSeqInput.LocalChainSelector = config.SuiChainSelector
 	ccipSeqInput.DestChainSelector = config.DestChainSelector
-	ccipSeqInput.DeployCCIPInput.McmsPackageId = state.MCMSPackageID
+	ccipSeqInput.DeployCCIPInput.McmsPackageId = mcmsPackageId
 	ccipSeqInput.DeployCCIPInput.McmsOwner = signerAddr
 
 	ccipSeqReport, err := operations.ExecuteSequence(e.OperationsBundle, ccipops.DeployAndInitCCIPSequence, deps, ccipSeqInput)
@@ -170,7 +188,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	ccipOnRampSeqInput := deployment.DefaultOnRampSeqConfig
 
 	ccipOnRampSeqInput.DeployCCIPOnRampInput.CCIPPackageId = ccipSeqReport.Output.CCIPPackageId
-	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSPackageId = state.MCMSPackageID
+	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSPackageId = mcmsPackageId
 	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSOwnerPackageId = signerAddr
 	ccipOnRampSeqInput.OnRampInitializeInput.NonceManagerCapId = ccipSeqReport.Output.Objects.NonceManagerCapObjectId
 	ccipOnRampSeqInput.OnRampInitializeInput.SourceTransferCapId = ccipSeqReport.Output.Objects.SourceTransferCapObjectId
@@ -229,7 +247,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	// Inject dynamic values for deployment
 	ccipOffRampSeqInput.CCIPObjectRefId = ccipSeqReport.Output.Objects.CCIPObjectRefObjectId
 	ccipOffRampSeqInput.DeployCCIPOffRampInput.CCIPPackageId = ccipSeqReport.Output.CCIPPackageId
-	ccipOffRampSeqInput.DeployCCIPOffRampInput.MCMSPackageId = state.MCMSPackageID
+	ccipOffRampSeqInput.DeployCCIPOffRampInput.MCMSPackageId = mcmsPackageId
 
 	ccipOffRampSeqInput.InitializeOffRampInput.DestTransferCapId = ccipSeqReport.Output.Objects.DestTransferCapObjectId
 	ccipOffRampSeqInput.InitializeOffRampInput.FeeQuoterCapId = ccipSeqReport.Output.Objects.FeeQuoterCapObjectId
@@ -302,7 +320,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 			},
 		},
 		// MCMS related
-		MmcsPackageID:  state.MCMSPackageID,
+		MmcsPackageID:  mcmsPackageId,
 		McmsStateObjID: state.MCMSStateObjectID,
 		TimelockObjID:  state.MCMSTimelockObjectID,
 		AccountObjID:   state.MCMSAccountStateObjectID,

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -15,7 +15,6 @@ import (
 	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 	opregistry "github.com/smartcontractkit/chainlink-sui/deployment/ops/registry"
-	"github.com/smartcontractkit/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 )
 
@@ -347,15 +346,15 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		ChainSelector: config.SuiChainSelector,
 	}
 
-	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+	_, err = cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, err
 	}
 
 	return cldf.ChangesetOutput{
-		AddressBook:           ab,
-		Reports:               seqReports,
-		MCMSTimelockProposals: []mcms.TimelockProposal{acceptOwnershipProposalReport.Output},
+		AddressBook: ab,
+		Reports:     seqReports,
+		// MCMSTimelockProposals: []mcms.TimelockProposal{acceptOwnershipProposalReport.Output},
 	}, nil
 }
 

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -14,6 +14,7 @@ import (
 	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
 	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	opregistry "github.com/smartcontractkit/chainlink-sui/deployment/ops/registry"
 	"github.com/smartcontractkit/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 )
@@ -32,7 +33,6 @@ type DeploySuiChain struct{}
 
 // Apply implements deployment.ChangeSetV2.
 func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (cldf.ChangesetOutput, error) {
-
 	ab := cldf.NewMemoryAddressBook()
 	seqReports := make([]operations.Report[any, any], 0)
 
@@ -55,6 +55,18 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		},
 	}
 
+	// in case the registry is not loaded with all operations. Needed to build accept ownership proposals
+	if e.OperationsBundle.OperationRegistry == nil {
+		ops := make([]*cld_ops.Operation[any, any, any], len(opregistry.AllOperations))
+		for i := range opregistry.AllOperations {
+			ops[i] = &opregistry.AllOperations[i]
+		}
+		registry := cld_ops.NewOperationRegistry(
+			ops...,
+		)
+		e.OperationsBundle.OperationRegistry = registry
+	}
+
 	suiState, err := deployment.LoadOnchainStatesui(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
@@ -63,8 +75,8 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	state := suiState[config.SuiChainSelector]
 
 	mcmsPackageId := state.MCMSPackageID
+	// If MCMS is not deployed, deploy it
 	if mcmsPackageId == "" {
-		// Run DeployMCMS Sequence
 		mcmsReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, mcmsops.DeployMCMSSeqInput{
 			ChainSelector: config.SuiChainSelector,
 		})

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -5,6 +5,7 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
@@ -13,6 +14,8 @@ import (
 	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
 	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	"github.com/smartcontractkit/mcms"
+	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 )
 
 type DeploySuiChainConfig struct {
@@ -52,24 +55,17 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		},
 	}
 
-	// Deploy MCMS
-	mcmsSeqReport, err := operations.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, mcmsops.DeployMCMSSeqInput{})
+	suiState, err := deployment.LoadOnchainStatesui(e)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy CCIP for Sui chain %d: %w", config.SuiChainSelector, err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
-	seqReports = append(seqReports, mcmsSeqReport.ExecutionReports...)
 
-	// save MCMs address to the addressbook
-	typeAndVersionMCMS := cldf.NewTypeAndVersion(deployment.SuiMcmsPackageIDType, deployment.Version1_0_0)
-	err = ab.Save(config.SuiChainSelector, mcmsSeqReport.Output.PackageId, typeAndVersionMCMS)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS address %s for Sui chain %d: %w", mcmsSeqReport.Output.PackageId, config.SuiChainSelector, err)
-	}
+	state := suiState[config.SuiChainSelector]
 
 	// Deploy Router
 	// TODO: Maybe make this part of CCIP sequence
 	routerReport, err := operations.ExecuteOperation(e.OperationsBundle, routerops.DeployCCIPRouterOp, deps, routerops.DeployCCIPRouterInput{
-		McmsPackageId: mcmsSeqReport.Output.PackageId,
+		McmsPackageId: state.MCMSPackageID,
 		McmsOwner:     signerAddr,
 	})
 	if err != nil {
@@ -81,7 +77,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		RouterPackageId:     routerReport.Output.PackageId,
 		RouterStateObjectId: routerReport.Output.Objects.RouterStateObjectId,
 		OwnerCapObjectId:    routerReport.Output.Objects.OwnerCapObjectId,
-		NewOwner:            mcmsSeqReport.Output.PackageId,
+		NewOwner:            state.MCMSPackageID,
 	})
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute ownership transfer to MCMS Router for Sui chain %d: %w", config.SuiChainSelector, err)
@@ -94,6 +90,12 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save Router address %s for Sui chain %d: %w", routerReport.Output.PackageId, config.SuiChainSelector, err)
 	}
 
+	typeAndVersionRouterObject := cldf.NewTypeAndVersion(deployment.SuiCCIPRouterStateObjectType, deployment.Version1_0_0)
+	err = ab.Save(config.SuiChainSelector, routerReport.Output.Objects.RouterStateObjectId, typeAndVersionRouterObject)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save Router state object Id %s for Sui chain %d: %w", routerReport.Output.Objects.RouterStateObjectId, config.SuiChainSelector, err)
+	}
+
 	// --------------------------
 	// CCIP SEQUENCE
 	// --------------------------
@@ -103,7 +105,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	ccipSeqInput.LinkTokenCoinMetadataObjectId = config.LinkTokenCoinMetadataObjectId
 	ccipSeqInput.LocalChainSelector = config.SuiChainSelector
 	ccipSeqInput.DestChainSelector = config.DestChainSelector
-	ccipSeqInput.DeployCCIPInput.McmsPackageId = mcmsSeqReport.Output.PackageId
+	ccipSeqInput.DeployCCIPInput.McmsPackageId = state.MCMSPackageID
 	ccipSeqInput.DeployCCIPInput.McmsOwner = signerAddr
 
 	ccipSeqReport, err := operations.ExecuteSequence(e.OperationsBundle, ccipops.DeployAndInitCCIPSequence, deps, ccipSeqInput)
@@ -168,7 +170,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	ccipOnRampSeqInput := deployment.DefaultOnRampSeqConfig
 
 	ccipOnRampSeqInput.DeployCCIPOnRampInput.CCIPPackageId = ccipSeqReport.Output.CCIPPackageId
-	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSPackageId = mcmsSeqReport.Output.PackageId
+	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSPackageId = state.MCMSPackageID
 	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSOwnerPackageId = signerAddr
 	ccipOnRampSeqInput.OnRampInitializeInput.NonceManagerCapId = ccipSeqReport.Output.Objects.NonceManagerCapObjectId
 	ccipOnRampSeqInput.OnRampInitializeInput.SourceTransferCapId = ccipSeqReport.Output.Objects.SourceTransferCapObjectId
@@ -225,8 +227,9 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 	onRampBytes := [][]byte{config.DestChainOnRampAddressBytes}
 
 	// Inject dynamic values for deployment
+	ccipOffRampSeqInput.CCIPObjectRefId = ccipSeqReport.Output.Objects.CCIPObjectRefObjectId
 	ccipOffRampSeqInput.DeployCCIPOffRampInput.CCIPPackageId = ccipSeqReport.Output.CCIPPackageId
-	ccipOffRampSeqInput.DeployCCIPOffRampInput.MCMSPackageId = mcmsSeqReport.Output.PackageId
+	ccipOffRampSeqInput.DeployCCIPOffRampInput.MCMSPackageId = state.MCMSPackageID
 
 	ccipOffRampSeqInput.InitializeOffRampInput.DestTransferCapId = ccipSeqReport.Output.Objects.DestTransferCapObjectId
 	ccipOffRampSeqInput.InitializeOffRampInput.FeeQuoterCapId = ccipSeqReport.Output.Objects.FeeQuoterCapObjectId
@@ -270,9 +273,56 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save OnRampUpgradeCapId  %s for Sui chain %d: %w", ccipOnRampSeqReport.Output.Objects.StateObjectId, config.DestChainSelector, err)
 	}
 
+	// Generate the proposal to accept the ownership of the deployed contracts
+	proposalInput := mcmsops.ProposalGenerateInput{
+		Defs: []operations.Definition{
+			ccipops.AcceptOwnershipStateObjectOp.Def(),
+			routerops.AcceptOwnershipOp.Def(),
+			onrampops.AcceptOwnershipOnRampOp.Def(),
+			offrampops.AcceptOwnershipOffRampOp.Def(),
+		},
+		Inputs: []any{
+			ccipops.AcceptOwnershipStateObjectInput{
+				CCIPPackageId:         ccipSeqReport.Output.CCIPPackageId,
+				CCIPObjectRefObjectId: ccipSeqReport.Output.Objects.CCIPObjectRefObjectId,
+			},
+			routerops.AcceptOwnershipInput{
+				RouterPackageId:     routerReport.Output.PackageId,
+				RouterStateObjectId: routerReport.Output.Objects.RouterStateObjectId,
+			},
+			onrampops.AcceptOwnershipOnRampInput{
+				OnRampPackageId: ccipOnRampSeqReport.Output.CCIPOnRampPackageId,
+				CCIPObjectRefId: ccipSeqReport.Output.Objects.CCIPObjectRefObjectId,
+				StateObjectId:   ccipOnRampSeqReport.Output.Objects.StateObjectId,
+			},
+			offrampops.AcceptOwnershipOffRampInput{
+				OffRampPackageId:     ccipOffRampSeqReport.Output.CCIPOffRampPackageId,
+				OffRampRefObjectId:   ccipSeqReport.Output.Objects.CCIPObjectRefObjectId,
+				OffRampStateObjectId: ccipOffRampSeqReport.Output.Objects.StateObjectId,
+			},
+		},
+		// MCMS related
+		MmcsPackageID:  state.MCMSPackageID,
+		McmsStateObjID: state.MCMSStateObjectID,
+		TimelockObjID:  state.MCMSTimelockObjectID,
+		AccountObjID:   state.MCMSAccountStateObjectID,
+		RegistryObjID:  state.MCMSRegistryObjectID,
+
+		// Proposal
+		Role: suisdk.TimelockRoleProposer,
+
+		ChainSelector: config.SuiChainSelector,
+	}
+
+	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
 	return cldf.ChangesetOutput{
-		AddressBook: ab,
-		Reports:     seqReports,
+		AddressBook:           ab,
+		Reports:               seqReports,
+		MCMSTimelockProposals: []mcms.TimelockProposal{acceptOwnershipProposalReport.Output},
 	}, nil
 }
 

--- a/deployment/changesets/cs_mcms_deploy.go
+++ b/deployment/changesets/cs_mcms_deploy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	"github.com/smartcontractkit/mcms"
 )
 
 var _ cldf.ChangeSetV2[mcmsops.DeployMCMSSeqInput] = DeployMCMS{}
@@ -85,8 +86,9 @@ func (d DeployMCMS) Apply(e cldf.Environment, config mcmsops.DeployMCMSSeqInput)
 	}
 
 	return cldf.ChangesetOutput{
-		AddressBook: ab,
-		Reports:     seqReports,
+		AddressBook:           ab,
+		Reports:               seqReports,
+		MCMSTimelockProposals: []mcms.TimelockProposal{mcmsReport.Output.AcceptOwnershipProposal},
 	}, nil
 }
 

--- a/deployment/changesets/cs_mcms_deploy.go
+++ b/deployment/changesets/cs_mcms_deploy.go
@@ -43,46 +43,9 @@ func (d DeployMCMS) Apply(e cldf.Environment, config mcmsops.DeployMCMSSeqInput)
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy MCMS for Sui chain %d: %w", config.ChainSelector, err)
 	}
 
-	// save MCMS address to the addressbook
-	typeAndVersionMCMS := cldf.NewTypeAndVersion(deployment.SuiMcmsPackageIDType, deployment.Version1_0_0)
-	err = ab.Save(config.ChainSelector, mcmsReport.Output.PackageId, typeAndVersionMCMS)
+	err = storeMCMSInAddressBook(ab, config.ChainSelector, mcmsReport.Output)
 	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS address %s for Sui chain %d: %w", mcmsReport.Output.PackageId, config.ChainSelector, err)
-	}
-
-	// save MCMS MultisigState object ID to the addressbook
-	typeAndVersionMCMSObject := cldf.NewTypeAndVersion(deployment.SuiMcmsObjectIDType, deployment.Version1_0_0)
-	err = ab.Save(config.ChainSelector, mcmsReport.Output.Objects.McmsMultisigStateObjectId, typeAndVersionMCMSObject)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS MultisigState object ID %s for Sui chain %d: %w", mcmsReport.Output.Objects.McmsMultisigStateObjectId, config.ChainSelector, err)
-	}
-
-	// save MCMS Registry object ID to the addressbook
-	typeAndVersionMCMSRegistry := cldf.NewTypeAndVersion(deployment.SuiMcmsRegistryObjectIDType, deployment.Version1_0_0)
-	err = ab.Save(config.ChainSelector, mcmsReport.Output.Objects.McmsRegistryObjectId, typeAndVersionMCMSRegistry)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS Registry object ID %s for Sui chain %d: %w", mcmsReport.Output.Objects.McmsRegistryObjectId, config.ChainSelector, err)
-	}
-
-	// save MCMS AccountState object ID to the addressbook
-	typeAndVersionMCMSAccountState := cldf.NewTypeAndVersion(deployment.SuiMcmsAccountStateObjectIDType, deployment.Version1_0_0)
-	err = ab.Save(config.ChainSelector, mcmsReport.Output.Objects.McmsAccountStateObjectId, typeAndVersionMCMSAccountState)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS AccountState object ID %s for Sui chain %d: %w", mcmsReport.Output.Objects.McmsAccountStateObjectId, config.ChainSelector, err)
-	}
-
-	// save MCMS AccountOwnerCap object ID to the addressbook
-	typeAndVersionMCMSAccountOwnerCap := cldf.NewTypeAndVersion(deployment.SuiMcmsAccountOwnerCapObjectIDType, deployment.Version1_0_0)
-	err = ab.Save(config.ChainSelector, mcmsReport.Output.Objects.McmsAccountOwnerCapObjectId, typeAndVersionMCMSAccountOwnerCap)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS AccountOwnerCap object ID %s for Sui chain %d: %w", mcmsReport.Output.Objects.McmsAccountOwnerCapObjectId, config.ChainSelector, err)
-	}
-
-	// save MCMS Timelock object ID to the addressbook
-	typeAndVersionMCMSTimelock := cldf.NewTypeAndVersion(deployment.SuiMcmsTimelockObjectIDType, deployment.Version1_0_0)
-	err = ab.Save(config.ChainSelector, mcmsReport.Output.Objects.TimelockObjectId, typeAndVersionMCMSTimelock)
-	if err != nil {
-		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save MCMS Timelock object ID %s for Sui chain %d: %w", mcmsReport.Output.Objects.TimelockObjectId, config.ChainSelector, err)
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to store MCMS in address book for Sui chain %d: %w", config.ChainSelector, err)
 	}
 
 	return cldf.ChangesetOutput{
@@ -94,5 +57,51 @@ func (d DeployMCMS) Apply(e cldf.Environment, config mcmsops.DeployMCMSSeqInput)
 
 // VerifyPreconditions implements deployment.ChangeSetV2.
 func (d DeployMCMS) VerifyPreconditions(e cldf.Environment, config mcmsops.DeployMCMSSeqInput) error {
+	return nil
+}
+
+func storeMCMSInAddressBook(ab *cldf.AddressBookMap, chainSelector uint64, mcmsReport mcmsops.DeployMCMSSeqOutput) error {
+	// save MCMS address to the addressbook
+	typeAndVersionMCMS := cldf.NewTypeAndVersion(deployment.SuiMcmsPackageIDType, deployment.Version1_0_0)
+	err := ab.Save(chainSelector, mcmsReport.PackageId, typeAndVersionMCMS)
+	if err != nil {
+		return fmt.Errorf("failed to save MCMS address %s for Sui chain %d: %w", mcmsReport.PackageId, chainSelector, err)
+	}
+
+	// save MCMS MultisigState object ID to the addressbook
+	typeAndVersionMCMSObject := cldf.NewTypeAndVersion(deployment.SuiMcmsObjectIDType, deployment.Version1_0_0)
+	err = ab.Save(chainSelector, mcmsReport.Objects.McmsMultisigStateObjectId, typeAndVersionMCMSObject)
+	if err != nil {
+		return fmt.Errorf("failed to save MCMS MultisigState object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsMultisigStateObjectId, chainSelector, err)
+	}
+
+	// save MCMS Registry object ID to the addressbook
+	typeAndVersionMCMSRegistry := cldf.NewTypeAndVersion(deployment.SuiMcmsRegistryObjectIDType, deployment.Version1_0_0)
+	err = ab.Save(chainSelector, mcmsReport.Objects.McmsRegistryObjectId, typeAndVersionMCMSRegistry)
+	if err != nil {
+		return fmt.Errorf("failed to save MCMS Registry object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsRegistryObjectId, chainSelector, err)
+	}
+
+	// save MCMS AccountState object ID to the addressbook
+	typeAndVersionMCMSAccountState := cldf.NewTypeAndVersion(deployment.SuiMcmsAccountStateObjectIDType, deployment.Version1_0_0)
+	err = ab.Save(chainSelector, mcmsReport.Objects.McmsAccountStateObjectId, typeAndVersionMCMSAccountState)
+	if err != nil {
+		return fmt.Errorf("failed to save MCMS AccountState object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsAccountStateObjectId, chainSelector, err)
+	}
+
+	// save MCMS AccountOwnerCap object ID to the addressbook
+	typeAndVersionMCMSAccountOwnerCap := cldf.NewTypeAndVersion(deployment.SuiMcmsAccountOwnerCapObjectIDType, deployment.Version1_0_0)
+	err = ab.Save(chainSelector, mcmsReport.Objects.McmsAccountOwnerCapObjectId, typeAndVersionMCMSAccountOwnerCap)
+	if err != nil {
+		return fmt.Errorf("failed to save MCMS AccountOwnerCap object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsAccountOwnerCapObjectId, chainSelector, err)
+	}
+
+	// save MCMS Timelock object ID to the addressbook
+	typeAndVersionMCMSTimelock := cldf.NewTypeAndVersion(deployment.SuiMcmsTimelockObjectIDType, deployment.Version1_0_0)
+	err = ab.Save(chainSelector, mcmsReport.Objects.TimelockObjectId, typeAndVersionMCMSTimelock)
+	if err != nil {
+		return fmt.Errorf("failed to save MCMS Timelock object ID %s for Sui chain %d: %w", mcmsReport.Objects.TimelockObjectId, chainSelector, err)
+	}
+
 	return nil
 }

--- a/deployment/changesets/cs_mcms_execute_ownership_transfer.go
+++ b/deployment/changesets/cs_mcms_execute_ownership_transfer.go
@@ -169,5 +169,11 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 
 // VerifyPreconditions implements deployment.ChangeSetV2.
 func (d MCMSExecuteTransferOwnership) VerifyPreconditions(e cldf.Environment, config MCMSExecuteTransferOwnershipInput) error {
+	// Check that at least one contract type is selected
+	if !config.MCMS && !config.StateObject && !config.OnRamp && !config.OffRamp &&
+		!config.Router && !config.ManagedToken && !config.BurnMintTokenPool &&
+		!config.LockReleaseTokenPool && !config.UsdcTokenPool && !config.ManagedTokenPool {
+		return fmt.Errorf("at least one contract type must be selected for ownership transfer")
+	}
 	return nil
 }

--- a/deployment/changesets/cs_mcms_execute_ownership_transfer.go
+++ b/deployment/changesets/cs_mcms_execute_ownership_transfer.go
@@ -1,0 +1,173 @@
+package changesets
+
+import (
+	"fmt"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	burnminttokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_burn_mint_token_pool"
+	lockreleasetokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_lock_release_token_pool"
+	managedtokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_managed_token_pool"
+	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
+	usdctokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_usdc_token_pool"
+	managedtokenops "github.com/smartcontractkit/chainlink-sui/deployment/ops/managed_token"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	ownershipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ownership"
+)
+
+var _ cldf.ChangeSetV2[MCMSExecuteTransferOwnershipInput] = MCMSExecuteTransferOwnership{}
+
+type MCMSExecuteTransferOwnership struct{}
+
+type MCMSExecuteTransferOwnershipInput struct {
+	ChainSelector uint64 `json:"chainSelector" yaml:"chainSelector"`
+
+	// Type of contracts to execute the transfer on
+	MCMS                 bool `json:"mcms,omitempty" yaml:"mcms,omitempty"`
+	StateObject          bool `json:"state_object,omitempty" yaml:"state_object,omitempty"`
+	OnRamp               bool `json:"onramp,omitempty" yaml:"onramp,omitempty"`
+	OffRamp              bool `json:"offramp,omitempty" yaml:"offramp,omitempty"`
+	Router               bool `json:"router,omitempty" yaml:"router,omitempty"`
+	ManagedToken         bool `json:"managed_token,omitempty" yaml:"managed_token,omitempty"`
+	BurnMintTokenPool    bool `json:"burn_mint_token_pool,omitempty" yaml:"burn_mint_token_pool,omitempty"`
+	LockReleaseTokenPool bool `json:"lock_release_token_pool,omitempty" yaml:"lock_release_token_pool,omitempty"`
+	UsdcTokenPool        bool `json:"usdc_token_pool,omitempty" yaml:"usdc_token_pool,omitempty"`
+	ManagedTokenPool     bool `json:"managed_token_pool,omitempty" yaml:"managed_token_pool,omitempty"`
+}
+
+func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecuteTransferOwnershipInput) (cldf.ChangesetOutput, error) {
+	suiState, err := deployment.LoadOnchainStatesui(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	state := suiState[config.ChainSelector]
+
+	suiChains := e.BlockChains.SuiChains()
+
+	suiChain := suiChains[config.ChainSelector]
+	deps := sui_ops.OpTxDeps{
+		Client: suiChain.Client,
+		Signer: suiChain.Signer,
+		GetCallOpts: func() *bind.CallOpts {
+			b := uint64(400_000_000)
+			return &bind.CallOpts{
+				WaitForExecution: true,
+				GasBudget:        &b,
+			}
+		},
+	}
+
+	input := ownershipops.ExecuteOwnershipTransferToMcmsSeqInput{}
+
+	// Populate the input fields
+	if config.MCMS {
+		input.MCMS = &mcmsops.MCMSExecuteTransferOwnershipInput{
+			McmsPackageID:    state.MCMSPackageID,
+			OwnerCap:         state.MCMSAccountOwnerCapObjectID,
+			AccountObjectID:  state.MCMSAccountStateObjectID,
+			RegistryObjectID: state.MCMSRegistryObjectID,
+		}
+	}
+
+	if config.StateObject {
+		input.StateObject = &ccipops.ExecuteOwnershipTransferToMcmsStateObjectInput{
+			CCIPPackageId:         state.CCIPAddress,
+			OwnerCapObjectId:      state.CCIPOwnerCapObjectId,
+			CCIPObjectRefObjectId: state.CCIPObjectRef,
+			RegistryObjectId:      state.MCMSRegistryObjectID,
+			To:                    state.MCMSPackageID,
+		}
+	}
+
+	if config.OnRamp {
+		input.OnRamp = &onrampops.ExecuteOwnershipTransferToMcmsOnRampInput{
+			OnRampPackageId:     state.OnRampAddress,
+			OnRampRefObjectId:   state.CCIPObjectRef,
+			OnRampStateObjectId: state.OnRampStateObjectId,
+			OwnerCapObjectId:    state.OnRampOwnerCapObjectId,
+			RegistryObjectId:    state.MCMSRegistryObjectID,
+			To:                  state.MCMSPackageID,
+		}
+	}
+
+	if config.OffRamp {
+		input.OffRamp = &offrampops.ExecuteOwnershipTransferToMcmsOffRampInput{
+			OffRampPackageId:     state.OffRampAddress,
+			OffRampRefObjectId:   state.CCIPObjectRef,
+			OffRampStateObjectId: state.OffRampStateObjectId,
+			OwnerCapObjectId:     state.OffRampOwnerCapId,
+			RegistryObjectId:     state.MCMSRegistryObjectID,
+			To:                   state.MCMSPackageID,
+		}
+	}
+
+	if config.Router {
+		input.Router = &routerops.ExecuteOwnershipTransferToMcmsRouterInput{
+			RouterPackageId:     state.CCIPRouterAddress,
+			OwnerCapObjectId:    state.CCIPOwnerCapObjectId,
+			RouterStateObjectId: state.CCIPRouterStateObjectID,
+			RegistryObjectId:    state.MCMSRegistryObjectID,
+			To:                  state.MCMSPackageID,
+		}
+	}
+
+	// TODO: Need typeargs support
+	if config.ManagedToken {
+		input.ManagedToken = &managedtokenops.ExecuteOwnershipTransferToMcmsManagedTokenInput{
+			ManagedTokenPackageId: state.CCIPAddress,
+			OwnerCapObjectId:      state.CCIPOwnerCapObjectId,
+			RegistryObjectId:      state.MCMSRegistryObjectID,
+			To:                    state.MCMSPackageID,
+		}
+	}
+
+	// TODO: Need typeargs support
+	if config.BurnMintTokenPool {
+		input.BurnMintTokenPool = &burnminttokenpoolops.ExecuteOwnershipTransferToMcmsBurnMintTokenPoolInput{
+			BurnMintTokenPoolPackageId: state.CCIPBurnMintTokenPool,
+			OwnerCapObjectId:           state.CCIPOwnerCapObjectId,
+			RegistryObjectId:           state.MCMSRegistryObjectID,
+			To:                         state.MCMSPackageID,
+		}
+	}
+
+	// TODO: Need typeargs support
+	if config.LockReleaseTokenPool {
+		input.LockReleaseTokenPool = &lockreleasetokenpoolops.ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolInput{
+			LockReleaseTokenPoolPackageId: state.LockReleaseAddress,
+			OwnerCapObjectId:              state.CCIPOwnerCapObjectId,
+			RegistryObjectId:              state.MCMSRegistryObjectID,
+			To:                            state.MCMSPackageID,
+		}
+	}
+
+	// TODO: not supported yet
+	if config.UsdcTokenPool {
+		input.UsdcTokenPool = &usdctokenpoolops.ExecuteOwnershipTransferToMcmsUsdcTokenPoolInput{}
+	}
+
+	// TODO: not supported yet
+	if config.ManagedTokenPool {
+		input.ManagedTokenPool = &managedtokenpoolops.ExecuteOwnershipTransferToMcmsManagedTokenPoolInput{}
+	}
+
+	// Execute the sequence
+	_, err = cld_ops.ExecuteSequence(e.OperationsBundle, ownershipops.ExecuteOwnershipTransferToMcmsSequence, deps, input)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute sequence: %w", err)
+	}
+
+	return cldf.ChangesetOutput{}, nil
+}
+
+// VerifyPreconditions implements deployment.ChangeSetV2.
+func (d MCMSExecuteTransferOwnership) VerifyPreconditions(e cldf.Environment, config MCMSExecuteTransferOwnershipInput) error {
+	return nil
+}

--- a/deployment/changesets/cs_mcms_proposal_generate.go
+++ b/deployment/changesets/cs_mcms_proposal_generate.go
@@ -25,11 +25,13 @@ func (d MCMSProposalGenerate) Apply(e cldf.Environment, config mcmsops.ProposalG
 	state := suiState[config.ChainSelector]
 
 	// Get necessary MCMS state from onchain AB
-	config.MmcsPackageID = state.MCMSPackageID
-	config.McmsStateObjID = state.MCMSStateObjectID
-	config.TimelockObjID = state.MCMSTimelockObjectID
-	config.AccountObjID = state.MCMSAccountStateObjectID
-	config.RegistryObjID = state.MCMSRegistryObjectID
+	if config.MmcsPackageID == "" || config.McmsStateObjID == "" || config.TimelockObjID == "" || config.AccountObjID == "" || config.RegistryObjID == "" {
+		config.MmcsPackageID = state.MCMSPackageID
+		config.McmsStateObjID = state.MCMSStateObjectID
+		config.TimelockObjID = state.MCMSTimelockObjectID
+		config.AccountObjID = state.MCMSAccountStateObjectID
+		config.RegistryObjID = state.MCMSRegistryObjectID
+	}
 
 	suiChains := e.BlockChains.SuiChains()
 

--- a/deployment/changesets/cs_mcms_proposal_generate.go
+++ b/deployment/changesets/cs_mcms_proposal_generate.go
@@ -6,6 +6,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 	"github.com/smartcontractkit/mcms"
@@ -16,6 +17,20 @@ var _ cldf.ChangeSetV2[mcmsops.ProposalGenerateInput] = MCMSProposalGenerate{}
 type MCMSProposalGenerate struct{}
 
 func (d MCMSProposalGenerate) Apply(e cldf.Environment, config mcmsops.ProposalGenerateInput) (cldf.ChangesetOutput, error) {
+	suiState, err := deployment.LoadOnchainStatesui(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
+	}
+
+	state := suiState[config.ChainSelector]
+
+	// Get necessary MCMS state from onchain AB
+	config.MmcsPackageID = state.MCMSPackageID
+	config.McmsStateObjID = state.MCMSStateObjectID
+	config.TimelockObjID = state.MCMSTimelockObjectID
+	config.AccountObjID = state.MCMSAccountStateObjectID
+	config.RegistryObjID = state.MCMSRegistryObjectID
+
 	suiChains := e.BlockChains.SuiChains()
 
 	suiChain := suiChains[config.ChainSelector]

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -11,6 +11,7 @@ replace github.com/smartcontractkit/chainlink-sui => ../
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/aptos-labs/aptos-go-sdk v1.7.1-0.20250602153733-bb1facae1d43
 	github.com/block-vision/sui-go-sdk v1.1.2
 	github.com/ethereum/go-ethereum v1.15.7
 	github.com/smartcontractkit/chain-selectors v1.0.71
@@ -26,7 +27,6 @@ require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/XSAM/otelsql v0.37.0 // indirect
-	github.com/aptos-labs/aptos-go-sdk v1.7.1-0.20250602153733-bb1facae1d43 // indirect
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/deployment/ops/ccip/op_fee_quoter.go
+++ b/deployment/ops/ccip/op_fee_quoter.go
@@ -487,15 +487,3 @@ var FeeQuoterUpdatePricesWithOwnerCapOp = cld_ops.NewOperation(
 	"Update prices using owner cap in CCIP Fee Quoter contract",
 	updatePricesWithOwnerCapHandler,
 )
-
-var AllOperationsFeeQuoter = []cld_ops.Operation[any, any, any]{
-	*FeeQuoterInitializeOp.AsUntyped(),
-	*FeeQuoterApplyFeeTokenUpdatesOp.AsUntyped(),
-	*FeeQuoterApplyTokenTransferFeeConfigUpdatesOp.AsUntyped(),
-	*FeeQuoterApplyDestChainConfigUpdatesOp.AsUntyped(),
-	*FeeQuoterApplyPremiumMultiplierWeiPerEthUpdatesOp.AsUntyped(),
-	*FeeQuoterUpdateTokenPricesOp.AsUntyped(),
-	*FeeQuoterNewFeeQuoterCapOp.AsUntyped(),
-	*FeeQuoterDestroyFeeQuoterCapOp.AsUntyped(),
-	*FeeQuoterUpdatePricesWithOwnerCapOp.AsUntyped(),
-}

--- a/deployment/ops/ccip/op_registry.go
+++ b/deployment/ops/ccip/op_registry.go
@@ -1,0 +1,40 @@
+package ccipops
+
+import (
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+// Exports every operation available so they can be registered to be used in dynamic changesets
+var AllOperationsCCIP = []cld_ops.Operation[any, any, any]{
+	// Fee Quoter Operations
+	*FeeQuoterInitializeOp.AsUntyped(),
+	*FeeQuoterApplyFeeTokenUpdatesOp.AsUntyped(),
+	*FeeQuoterApplyTokenTransferFeeConfigUpdatesOp.AsUntyped(),
+	*FeeQuoterApplyDestChainConfigUpdatesOp.AsUntyped(),
+	*FeeQuoterApplyPremiumMultiplierWeiPerEthUpdatesOp.AsUntyped(),
+	*FeeQuoterUpdateTokenPricesOp.AsUntyped(),
+	*FeeQuoterNewFeeQuoterCapOp.AsUntyped(),
+	*FeeQuoterDestroyFeeQuoterCapOp.AsUntyped(),
+	*FeeQuoterUpdatePricesWithOwnerCapOp.AsUntyped(),
+	// State Object Operations
+	*AddPackageIdStateObjectOp.AsUntyped(),
+	*RemovePackageIdStateObjectOp.AsUntyped(),
+	*GetOwnerCapIdStateObjectOp.AsUntyped(),
+	*GetOwnerStateObjectOp.AsUntyped(),
+	*GetPendingTransferStateObjectOp.AsUntyped(),
+	*TransferOwnershipStateObjectOp.AsUntyped(),
+	*AcceptOwnershipStateObjectOp.AsUntyped(),
+	*ExecuteOwnershipTransferToMcmsStateObjectOp.AsUntyped(),
+	// Token Admin Registry Operations
+	*TokenAdminRegistryInitializeOp.AsUntyped(),
+	*TokenAdminRegistryUnregisterPoolOp.AsUntyped(),
+	*TokenAdminRegistryTransferAdminRoleOp.AsUntyped(),
+	*TokenAdminRegistryAcceptAdminRoleOp.AsUntyped(),
+	// Upgrade Registry Operations
+	*UpgradeRegistryInitializeOp.AsUntyped(),
+	*BlockVersionOp.AsUntyped(),
+	*BlockFunctionOp.AsUntyped(),
+	*GetModuleRestrictionsOp.AsUntyped(),
+	*IsFunctionAllowedOp.AsUntyped(),
+	*VerifyFunctionAllowedOp.AsUntyped(),
+}

--- a/deployment/ops/ccip/op_state_object.go
+++ b/deployment/ops/ccip/op_state_object.go
@@ -536,14 +536,3 @@ var ExecuteOwnershipTransferToMcmsStateObjectOp = cld_ops.NewOperation(
 	"Executes ownership transfer to MCMS for the CCIP StateObject",
 	executeOwnershipTransferToMcmsStateObjectHandler,
 )
-
-var AllOperationsStateObject = []cld_ops.Operation[any, any, any]{
-	*AddPackageIdStateObjectOp.AsUntyped(),
-	*RemovePackageIdStateObjectOp.AsUntyped(),
-	*GetOwnerCapIdStateObjectOp.AsUntyped(),
-	*GetOwnerStateObjectOp.AsUntyped(),
-	*GetPendingTransferStateObjectOp.AsUntyped(),
-	*TransferOwnershipStateObjectOp.AsUntyped(),
-	*AcceptOwnershipStateObjectOp.AsUntyped(),
-	*ExecuteOwnershipTransferToMcmsStateObjectOp.AsUntyped(),
-}

--- a/deployment/ops/ccip/op_state_object.go
+++ b/deployment/ops/ccip/op_state_object.go
@@ -457,6 +457,86 @@ var AcceptOwnershipStateObjectOp = cld_ops.NewOperation(
 	acceptOwnershipStateObjectHandler,
 )
 
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsStateObjectInput struct {
+	CCIPPackageId         string
+	CCIPObjectRefObjectId string
+	OwnerCapObjectId      string
+	RegistryObjectId      string
+	To                    string
+}
+
+type ExecuteOwnershipTransferToMcmsStateObjectObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsStateObjectHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsStateObjectInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects], err error) {
+	contract, err := module_state_object.NewStateObject(input.CCIPPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{}, fmt.Errorf("failed to create StateObject contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		bind.Object{Id: input.CCIPObjectRefObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.CCIPObjectRefObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on StateObject as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{
+			Digest:    "",
+			PackageId: input.CCIPPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsStateObjectObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on StateObject: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, bind.Object{Id: input.CCIPObjectRefObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{}, fmt.Errorf("failed to get new owner for StateObject: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for StateObject: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for CCIP StateObject", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsStateObjectObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.CCIPPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsStateObjectObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsStateObjectOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "state_object", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP StateObject",
+	executeOwnershipTransferToMcmsStateObjectHandler,
+)
+
 var AllOperationsStateObject = []cld_ops.Operation[any, any, any]{
 	*AddPackageIdStateObjectOp.AsUntyped(),
 	*RemovePackageIdStateObjectOp.AsUntyped(),
@@ -465,4 +545,5 @@ var AllOperationsStateObject = []cld_ops.Operation[any, any, any]{
 	*GetPendingTransferStateObjectOp.AsUntyped(),
 	*TransferOwnershipStateObjectOp.AsUntyped(),
 	*AcceptOwnershipStateObjectOp.AsUntyped(),
+	*ExecuteOwnershipTransferToMcmsStateObjectOp.AsUntyped(),
 }

--- a/deployment/ops/ccip/op_token_admin_registry.go
+++ b/deployment/ops/ccip/op_token_admin_registry.go
@@ -195,10 +195,3 @@ var TokenAdminRegistryAcceptAdminRoleOp = cld_ops.NewOperation(
 	"Accepts admin role for a token in the CCIP Token Admin Registry",
 	acceptAdminRoleHandler,
 )
-
-var AllOperationsTokenAdminRegistry = []cld_ops.Operation[any, any, any]{
-	*TokenAdminRegistryInitializeOp.AsUntyped(),
-	*TokenAdminRegistryUnregisterPoolOp.AsUntyped(),
-	*TokenAdminRegistryTransferAdminRoleOp.AsUntyped(),
-	*TokenAdminRegistryAcceptAdminRoleOp.AsUntyped(),
-}

--- a/deployment/ops/ccip/op_upgrade_registry.go
+++ b/deployment/ops/ccip/op_upgrade_registry.go
@@ -335,12 +335,3 @@ var VerifyFunctionAllowedOp = cld_ops.NewOperation(
 	"Verifies that a function is allowed in the UpgradeRegistry (throws error if not allowed)",
 	verifyFunctionAllowedHandler,
 )
-
-var AllOperationsUpgradeRegistry = []cld_ops.Operation[any, any, any]{
-	*UpgradeRegistryInitializeOp.AsUntyped(),
-	*BlockVersionOp.AsUntyped(),
-	*BlockFunctionOp.AsUntyped(),
-	*GetModuleRestrictionsOp.AsUntyped(),
-	*IsFunctionAllowedOp.AsUntyped(),
-	*VerifyFunctionAllowedOp.AsUntyped(),
-}

--- a/deployment/ops/ccip/seq_deploy_and_init_ccip.go
+++ b/deployment/ops/ccip/seq_deploy_and_init_ccip.go
@@ -251,6 +251,19 @@ var DeployAndInitCCIPSequence = cld_ops.NewSequence(
 			return DeployCCIPSeqOutput{}, err
 		}
 
+		// init transfer ownership to MCMS
+		_, err = cld_ops.ExecuteOperation(
+			env,
+			TransferOwnershipStateObjectOp,
+			deps,
+			TransferOwnershipStateObjectInput{
+				CCIPPackageId:         deployReport.Output.PackageId,
+				CCIPObjectRefObjectId: deployReport.Output.Objects.CCIPObjectRefObjectId,
+				OwnerCapObjectId:      deployReport.Output.Objects.OwnerCapObjectId,
+				To:                    input.DeployCCIPInput.McmsPackageId,
+			},
+		)
+
 		return DeployCCIPSeqOutput{
 			CCIPPackageId: deployReport.Output.PackageId,
 			Objects: DeployCCIPSeqObjects{

--- a/deployment/ops/ccip_burn_mint_token_pool/op_deploy.go
+++ b/deployment/ops/ccip_burn_mint_token_pool/op_deploy.go
@@ -1,10 +1,14 @@
 package burnminttokenpoolops
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_burnminttokenpool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool"
 	burnminttokenpool "github.com/smartcontractkit/chainlink-sui/bindings/packages/ccip_token_pools/burn_mint_token_pool"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
@@ -44,4 +48,114 @@ var DeployCCIPBurnMintTokenPoolOp = cld_ops.NewOperation(
 	semver.MustParse("0.1.0"),
 	"Deploys the CCIP burn mint token pool package",
 	deployHandler,
+)
+
+type TransferOwnershipBurnMintTokenPoolInput struct {
+	BurnMintTokenPoolPackageId string
+	TypeArgs                   []string
+	StateObjectId              string
+	OwnerCapObjectId           string
+	To                         string
+}
+
+type TransferOwnershipBurnMintTokenPoolObjects struct {
+	// No specific objects are returned from transfer_ownership
+}
+
+var transferOwnershipBurnMintTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipBurnMintTokenPoolInput) (output sui_ops.OpTxResult[TransferOwnershipBurnMintTokenPoolObjects], err error) {
+	burnMintTokenPoolPackage, err := module_burnminttokenpool.NewBurnMintTokenPool(input.BurnMintTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipBurnMintTokenPoolObjects]{}, err
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := burnMintTokenPoolPackage.TransferOwnership(
+		b.GetContext(),
+		opts,
+		input.TypeArgs,
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to execute TransferOwnership on BurnMintTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership transfer initiated for BurnMintTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[TransferOwnershipBurnMintTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.BurnMintTokenPoolPackageId,
+		Objects:   TransferOwnershipBurnMintTokenPoolObjects{},
+	}, nil
+}
+
+var TransferOwnershipBurnMintTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-burn-mint-token-pool-transfer-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the BurnMintTokenPool",
+	transferOwnershipBurnMintTokenPoolHandler,
+)
+
+type AcceptOwnershipBurnMintTokenPoolInput struct {
+	BurnMintTokenPoolPackageId string
+	TypeArgs                   []string
+	StateObjectId              string
+}
+
+type AcceptOwnershipBurnMintTokenPoolObjects struct {
+	// No specific objects are returned from accept_ownership
+}
+
+var acceptOwnershipBurnMintTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipBurnMintTokenPoolInput) (output sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects], err error) {
+	burnMintTokenPoolPackage, err := module_burnminttokenpool.NewBurnMintTokenPool(input.BurnMintTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects]{}, err
+	}
+
+	encodedCall, err := burnMintTokenPoolPackage.Encoder().AcceptOwnership(input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on BurnMintTokenPool as per no Signer provided")
+		return sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.BurnMintTokenPoolPackageId,
+			Objects:   AcceptOwnershipBurnMintTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := burnMintTokenPoolPackage.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on BurnMintTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for BurnMintTokenPool")
+
+	return sui_ops.OpTxResult[AcceptOwnershipBurnMintTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.BurnMintTokenPoolPackageId,
+		Objects:   AcceptOwnershipBurnMintTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var AcceptOwnershipBurnMintTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-burn-mint-token-pool-accept-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership of the BurnMintTokenPool",
+	acceptOwnershipBurnMintTokenPoolHandler,
 )

--- a/deployment/ops/ccip_burn_mint_token_pool/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_burn_mint_token_pool/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package burnminttokenpoolops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_burn_mint_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/burn_mint_token_pool"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsBurnMintTokenPoolInput struct {
+	BurnMintTokenPoolPackageId string
+	TypeArgs                   []string
+	OwnerCapObjectId           string
+	StateObjectId              string
+	RegistryObjectId           string
+	To                         string
+}
+
+type ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsBurnMintTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsBurnMintTokenPoolInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects], err error) {
+	contract, err := module_burn_mint_token_pool.NewBurnMintTokenPool(input.BurnMintTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to create BurnMintTokenPool contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		input.TypeArgs,
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on BurnMintTokenPool as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.BurnMintTokenPoolPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on BurnMintTokenPool: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{}, fmt.Errorf("failed to get new owner for BurnMintTokenPool: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for BurnMintTokenPool: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for BurnMintTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.BurnMintTokenPoolPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsBurnMintTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsBurnMintTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "burn_mint_token_pool", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP BurnMintTokenPool",
+	executeOwnershipTransferToMcmsBurnMintTokenPoolHandler,
+)

--- a/deployment/ops/ccip_lock_release_token_pool/op_deploy.go
+++ b/deployment/ops/ccip_lock_release_token_pool/op_deploy.go
@@ -1,10 +1,14 @@
 package lockreleasetokenpoolops
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_lockreleasetokenpool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool"
 	lockreleasetokenpool "github.com/smartcontractkit/chainlink-sui/bindings/packages/ccip_token_pools/lock_release_token_pool"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
@@ -44,4 +48,114 @@ var DeployCCIPLockReleaseTokenPoolOp = cld_ops.NewOperation(
 	semver.MustParse("0.1.0"),
 	"Deploys the CCIP lock release token pool package",
 	deployHandler,
+)
+
+type TransferOwnershipLockReleaseTokenPoolInput struct {
+	LockReleaseTokenPoolPackageId string
+	TypeArgs                      []string
+	StateObjectId                 string
+	OwnerCapObjectId              string
+	To                            string
+}
+
+type TransferOwnershipLockReleaseTokenPoolObjects struct {
+	// No specific objects are returned from transfer_ownership
+}
+
+var transferOwnershipLockReleaseTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipLockReleaseTokenPoolInput) (output sui_ops.OpTxResult[TransferOwnershipLockReleaseTokenPoolObjects], err error) {
+	lockReleaseTokenPoolPackage, err := module_lockreleasetokenpool.NewLockReleaseTokenPool(input.LockReleaseTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipLockReleaseTokenPoolObjects]{}, err
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := lockReleaseTokenPoolPackage.TransferOwnership(
+		b.GetContext(),
+		opts,
+		input.TypeArgs,
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to execute TransferOwnership on LockReleaseTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership transfer initiated for LockReleaseTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[TransferOwnershipLockReleaseTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.LockReleaseTokenPoolPackageId,
+		Objects:   TransferOwnershipLockReleaseTokenPoolObjects{},
+	}, nil
+}
+
+var TransferOwnershipLockReleaseTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-lock-release-token-pool-transfer-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the LockReleaseTokenPool",
+	transferOwnershipLockReleaseTokenPoolHandler,
+)
+
+type AcceptOwnershipLockReleaseTokenPoolInput struct {
+	LockReleaseTokenPoolPackageId string
+	TypeArgs                      []string
+	StateObjectId                 string
+}
+
+type AcceptOwnershipLockReleaseTokenPoolObjects struct {
+	// No specific objects are returned from accept_ownership
+}
+
+var acceptOwnershipLockReleaseTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipLockReleaseTokenPoolInput) (output sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects], err error) {
+	lockReleaseTokenPoolPackage, err := module_lockreleasetokenpool.NewLockReleaseTokenPool(input.LockReleaseTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects]{}, err
+	}
+
+	encodedCall, err := lockReleaseTokenPoolPackage.Encoder().AcceptOwnership(input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on LockReleaseTokenPool as per no Signer provided")
+		return sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.LockReleaseTokenPoolPackageId,
+			Objects:   AcceptOwnershipLockReleaseTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := lockReleaseTokenPoolPackage.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on LockReleaseTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for LockReleaseTokenPool")
+
+	return sui_ops.OpTxResult[AcceptOwnershipLockReleaseTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.LockReleaseTokenPoolPackageId,
+		Objects:   AcceptOwnershipLockReleaseTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var AcceptOwnershipLockReleaseTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-lock-release-token-pool-accept-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership of the LockReleaseTokenPool",
+	acceptOwnershipLockReleaseTokenPoolHandler,
 )

--- a/deployment/ops/ccip_lock_release_token_pool/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_lock_release_token_pool/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package lockreleasetokenpoolops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_lock_release_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolInput struct {
+	LockReleaseTokenPoolPackageId string
+	TypeArgs                      []string
+	OwnerCapObjectId              string
+	StateObjectId                 string
+	RegistryObjectId              string
+	To                            string
+}
+
+type ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsLockReleaseTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects], err error) {
+	contract, err := module_lock_release_token_pool.NewLockReleaseTokenPool(input.LockReleaseTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to create LockReleaseTokenPool contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		input.TypeArgs,
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on LockReleaseTokenPool as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.LockReleaseTokenPoolPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on LockReleaseTokenPool: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{}, fmt.Errorf("failed to get new owner for LockReleaseTokenPool: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for LockReleaseTokenPool: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for LockReleaseTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.LockReleaseTokenPoolPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "lock_release_token_pool", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP LockReleaseTokenPool",
+	executeOwnershipTransferToMcmsLockReleaseTokenPoolHandler,
+)

--- a/deployment/ops/ccip_managed_token_pool/op_deploy.go
+++ b/deployment/ops/ccip_managed_token_pool/op_deploy.go
@@ -1,10 +1,14 @@
 package managedtokenpoolops
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_managedtokenpool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/managed_token_pool"
 	managedtokenpool "github.com/smartcontractkit/chainlink-sui/bindings/packages/ccip_token_pools/managed_token_pool"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
@@ -46,4 +50,114 @@ var DeployCCIPManagedTokenPoolOp = cld_ops.NewOperation(
 	semver.MustParse("0.1.0"),
 	"Deploys the CCIP managed token pool package",
 	deployHandler,
+)
+
+type TransferOwnershipManagedTokenPoolInput struct {
+	ManagedTokenPoolPackageId string
+	TypeArgs                  []string
+	StateObjectId             string
+	OwnerCapObjectId          string
+	To                        string
+}
+
+type TransferOwnershipManagedTokenPoolObjects struct {
+	// No specific objects are returned from transfer_ownership
+}
+
+var transferOwnershipManagedTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipManagedTokenPoolInput) (output sui_ops.OpTxResult[TransferOwnershipManagedTokenPoolObjects], err error) {
+	managedTokenPoolPackage, err := module_managedtokenpool.NewManagedTokenPool(input.ManagedTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipManagedTokenPoolObjects]{}, err
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := managedTokenPoolPackage.TransferOwnership(
+		b.GetContext(),
+		opts,
+		input.TypeArgs,
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipManagedTokenPoolObjects]{}, fmt.Errorf("failed to execute TransferOwnership on ManagedTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership transfer initiated for ManagedTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[TransferOwnershipManagedTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.ManagedTokenPoolPackageId,
+		Objects:   TransferOwnershipManagedTokenPoolObjects{},
+	}, nil
+}
+
+var TransferOwnershipManagedTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-managed-token-pool-transfer-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the ManagedTokenPool",
+	transferOwnershipManagedTokenPoolHandler,
+)
+
+type AcceptOwnershipManagedTokenPoolInput struct {
+	ManagedTokenPoolPackageId string
+	TypeArgs                  []string
+	StateObjectId             string
+}
+
+type AcceptOwnershipManagedTokenPoolObjects struct {
+	// No specific objects are returned from accept_ownership
+}
+
+var acceptOwnershipManagedTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipManagedTokenPoolInput) (output sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects], err error) {
+	managedTokenPoolPackage, err := module_managedtokenpool.NewManagedTokenPool(input.ManagedTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects]{}, err
+	}
+
+	encodedCall, err := managedTokenPoolPackage.Encoder().AcceptOwnership(input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on ManagedTokenPool as per no Signer provided")
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.ManagedTokenPoolPackageId,
+			Objects:   AcceptOwnershipManagedTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := managedTokenPoolPackage.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on ManagedTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for ManagedTokenPool")
+
+	return sui_ops.OpTxResult[AcceptOwnershipManagedTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.ManagedTokenPoolPackageId,
+		Objects:   AcceptOwnershipManagedTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var AcceptOwnershipManagedTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-managed-token-pool-accept-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership of the ManagedTokenPool",
+	acceptOwnershipManagedTokenPoolHandler,
 )

--- a/deployment/ops/ccip_managed_token_pool/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_managed_token_pool/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package managedtokenpoolops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_managed_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/managed_token_pool"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsManagedTokenPoolInput struct {
+	ManagedTokenPoolPackageId string
+	TypeArgs                  []string
+	OwnerCapObjectId          string
+	StateObjectId             string
+	RegistryObjectId          string
+	To                        string
+}
+
+type ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsManagedTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsManagedTokenPoolInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects], err error) {
+	contract, err := module_managed_token_pool.NewManagedTokenPool(input.ManagedTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{}, fmt.Errorf("failed to create ManagedTokenPool contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		input.TypeArgs,
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on ManagedTokenPool as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.ManagedTokenPoolPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on ManagedTokenPool: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{}, fmt.Errorf("failed to get new owner for ManagedTokenPool: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for ManagedTokenPool: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for ManagedTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.ManagedTokenPoolPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsManagedTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsManagedTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "managed_token_pool", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP ManagedTokenPool",
+	executeOwnershipTransferToMcmsManagedTokenPoolHandler,
+)

--- a/deployment/ops/ccip_offramp/op_deploy.go
+++ b/deployment/ops/ccip_offramp/op_deploy.go
@@ -314,7 +314,7 @@ var RemovePackageIdOffRampOp = cld_ops.NewOperation(
 
 type TransferOwnershipOffRampInput struct {
 	OffRampPackageId     string
-	OffRampRefObjectId   string
+	CCIPObjectRefId      string
 	OffRampStateObjectId string
 	OwnerCapObjectId     string
 	To                   string
@@ -335,7 +335,7 @@ var transferOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDe
 	tx, err := offRampPackage.TransferOwnership(
 		b.GetContext(),
 		opts,
-		bind.Object{Id: input.OffRampRefObjectId},
+		bind.Object{Id: input.CCIPObjectRefId},
 		bind.Object{Id: input.OffRampStateObjectId},
 		bind.Object{Id: input.OwnerCapObjectId},
 		input.To,

--- a/deployment/ops/ccip_offramp/op_deploy.go
+++ b/deployment/ops/ccip_offramp/op_deploy.go
@@ -380,7 +380,7 @@ var acceptOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps
 	if err != nil {
 		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
 	}
-	call, err := sui_ops.ToTransactionCall(encodedCall, input.OffRampRefObjectId)
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.OffRampStateObjectId)
 	if err != nil {
 		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
 	}

--- a/deployment/ops/ccip_offramp/op_deploy.go
+++ b/deployment/ops/ccip_offramp/op_deploy.go
@@ -311,3 +311,113 @@ var RemovePackageIdOffRampOp = cld_ops.NewOperation(
 	"Removes a package ID from the OffRamp state for upgrade tracking",
 	removePackageIdOffRampHandler,
 )
+
+type TransferOwnershipOffRampInput struct {
+	OffRampPackageId     string
+	OffRampRefObjectId   string
+	OffRampStateObjectId string
+	OwnerCapObjectId     string
+	To                   string
+}
+
+type TransferOwnershipOffRampObjects struct {
+	// No specific objects are returned from transfer_ownership
+}
+
+var transferOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipOffRampInput) (output sui_ops.OpTxResult[TransferOwnershipOffRampObjects], err error) {
+	offRampPackage, err := module_offramp.NewOfframp(input.OffRampPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipOffRampObjects]{}, err
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := offRampPackage.TransferOwnership(
+		b.GetContext(),
+		opts,
+		bind.Object{Id: input.OffRampRefObjectId},
+		bind.Object{Id: input.OffRampStateObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipOffRampObjects]{}, fmt.Errorf("failed to execute TransferOwnership on OffRamp: %w", err)
+	}
+
+	b.Logger.Infow("Ownership transfer initiated for OffRamp", "to", input.To)
+
+	return sui_ops.OpTxResult[TransferOwnershipOffRampObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.OffRampPackageId,
+		Objects:   TransferOwnershipOffRampObjects{},
+	}, nil
+}
+
+var TransferOwnershipOffRampOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-offramp-transfer-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the OffRamp",
+	transferOwnershipOffRampHandler,
+)
+
+type AcceptOwnershipOffRampInput struct {
+	OffRampPackageId     string
+	OffRampRefObjectId   string
+	OffRampStateObjectId string
+}
+
+type AcceptOwnershipOffRampObjects struct {
+	// No specific objects are returned from accept_ownership
+}
+
+var acceptOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipOffRampInput) (output sui_ops.OpTxResult[AcceptOwnershipOffRampObjects], err error) {
+	offRampPackage, err := module_offramp.NewOfframp(input.OffRampPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, err
+	}
+
+	encodedCall, err := offRampPackage.Encoder().AcceptOwnership(bind.Object{Id: input.OffRampRefObjectId}, bind.Object{Id: input.OffRampStateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.OffRampRefObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on OffRamp as per no Signer provided")
+		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{
+			Digest:    "",
+			PackageId: input.OffRampPackageId,
+			Objects:   AcceptOwnershipOffRampObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := offRampPackage.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on OffRamp: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for OffRamp")
+
+	return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.OffRampPackageId,
+		Objects:   AcceptOwnershipOffRampObjects{},
+		Call:      call,
+	}, nil
+}
+
+var AcceptOwnershipOffRampOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-offramp-accept-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership of the OffRamp",
+	acceptOwnershipOffRampHandler,
+)

--- a/deployment/ops/ccip_offramp/op_deploy.go
+++ b/deployment/ops/ccip_offramp/op_deploy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
+	module_ownable "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/ownable"
 	"github.com/smartcontractkit/chainlink-sui/bindings/packages/offramp"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
@@ -371,16 +372,20 @@ type AcceptOwnershipOffRampObjects struct {
 }
 
 var acceptOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipOffRampInput) (output sui_ops.OpTxResult[AcceptOwnershipOffRampObjects], err error) {
-	offRampPackage, err := module_offramp.NewOfframp(input.OffRampPackageId, deps.Client)
+	// mcms_accept_ownership uses the Ownable module
+	ownablePackage, err := module_ownable.NewOwnable(input.OffRampPackageId, deps.Client)
 	if err != nil {
 		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, err
 	}
 
-	encodedCall, err := offRampPackage.Encoder().AcceptOwnership(bind.Object{Id: input.OffRampRefObjectId}, bind.Object{Id: input.OffRampStateObjectId})
+	encodedCall, err := ownablePackage.Encoder().AcceptOwnership(bind.Object{Id: input.OffRampStateObjectId})
 	if err != nil {
 		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
 	}
-	call, err := sui_ops.ToTransactionCall(encodedCall, input.OffRampStateObjectId)
+	// We need ownable encoding, but we call the offramp
+	encodedCall.Module.ModuleName = "offramp"
+	// we set the ref object as the state of the call, so we can access it in the entrypoint encoder
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.OffRampRefObjectId)
 	if err != nil {
 		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
 	}
@@ -394,12 +399,18 @@ var acceptOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps
 		}, nil
 	}
 
+	// If we have a signer, this is accepting the ownership from EOA, we use the offramp directly
+	offRampPackage, err := module_offramp.NewOfframp(input.OffRampPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, err
+	}
 	opts := deps.GetCallOpts()
 	opts.Signer = deps.Signer
-	tx, err := offRampPackage.Bound().ExecuteTransaction(
+	tx, err := offRampPackage.AcceptOwnership(
 		b.GetContext(),
 		opts,
-		encodedCall,
+		bind.Object{Id: input.OffRampRefObjectId},
+		bind.Object{Id: input.OffRampStateObjectId},
 	)
 	if err != nil {
 		return sui_ops.OpTxResult[AcceptOwnershipOffRampObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on OffRamp: %w", err)
@@ -411,7 +422,6 @@ var acceptOwnershipOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps
 		Digest:    tx.Digest,
 		PackageId: input.OffRampPackageId,
 		Objects:   AcceptOwnershipOffRampObjects{},
-		Call:      call,
 	}, nil
 }
 

--- a/deployment/ops/ccip_offramp/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_offramp/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package offrampops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsOffRampInput struct {
+	OffRampPackageId     string
+	OffRampRefObjectId   string
+	OwnerCapObjectId     string
+	OffRampStateObjectId string
+	RegistryObjectId     string
+	To                   string
+}
+
+type ExecuteOwnershipTransferToMcmsOffRampObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsOffRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsOffRampInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects], err error) {
+	contract, err := module_offramp.NewOfframp(input.OffRampPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{}, fmt.Errorf("failed to create OffRamp contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		bind.Object{Id: input.OffRampRefObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.OffRampStateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.OffRampStateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on OffRamp as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{
+			Digest:    "",
+			PackageId: input.OffRampPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsOffRampObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on OffRamp: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, bind.Object{Id: input.OffRampStateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{}, fmt.Errorf("failed to get new owner for OffRamp: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for OffRamp: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for OffRamp", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOffRampObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.OffRampPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsOffRampObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsOffRampOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "offramp", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP OffRamp",
+	executeOwnershipTransferToMcmsOffRampHandler,
+)

--- a/deployment/ops/ccip_offramp/op_registry.go
+++ b/deployment/ops/ccip_offramp/op_registry.go
@@ -1,0 +1,9 @@
+package offrampops
+
+import cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+var AllOperationsOfframp = []cld_ops.Operation[any, any, any]{
+	*TransferOwnershipOffRampOp.AsUntyped(),
+	*AcceptOwnershipOffRampOp.AsUntyped(),
+	*ExecuteOwnershipTransferToMcmsOffRampOp.AsUntyped(),
+}

--- a/deployment/ops/ccip_offramp/seq_deploy_and_init_ccip_offramp.go
+++ b/deployment/ops/ccip_offramp/seq_deploy_and_init_ccip_offramp.go
@@ -11,6 +11,7 @@ import (
 type DeployAndInitCCIPOffRampSeqInput struct {
 	DeployCCIPOffRampInput
 	InitializeOffRampInput
+	CCIPObjectRefId     string
 	CommitOCR3Config    SetOCR3ConfigInput
 	ExecutionOCR3Config SetOCR3ConfigInput
 }
@@ -42,6 +43,19 @@ var DeployAndInitCCIPOffRampSequence = cld_ops.NewSequence(
 		input.InitializeOffRampInput.OffRampStateId = deployReport.Output.Objects.CCIPOffRampStateObjectId
 
 		_, err = cld_ops.ExecuteOperation(env, InitializeOffRampOp, deps, input.InitializeOffRampInput)
+		if err != nil {
+			return DeployCCIPOffRampSeqOutput{}, err
+		}
+
+		// init transfer to mcms
+		executeOwnershipTransferToMcmsInput := TransferOwnershipOffRampInput{
+			OffRampPackageId:     deployReport.Output.PackageId,
+			CCIPObjectRefId:      input.CCIPObjectRefId,
+			OffRampStateObjectId: deployReport.Output.Objects.CCIPOffRampStateObjectId,
+			OwnerCapObjectId:     deployReport.Output.Objects.OwnerCapObjectId,
+			To:                   input.DeployCCIPOffRampInput.MCMSPackageId,
+		}
+		_, err = cld_ops.ExecuteOperation(env, TransferOwnershipOffRampOp, deps, executeOwnershipTransferToMcmsInput)
 		if err != nil {
 			return DeployCCIPOffRampSeqOutput{}, err
 		}

--- a/deployment/ops/ccip_offramp/seq_deploy_and_init_ccip_offramp_test.go
+++ b/deployment/ops/ccip_offramp/seq_deploy_and_init_ccip_offramp_test.go
@@ -107,6 +107,7 @@ func TestDeployAndInitCCIPOfframpSeq(t *testing.T) {
 
 	// Run OffRamp Sequence
 	seqOffRampInput := DeployAndInitCCIPOffRampSeqInput{
+		CCIPObjectRefId: reportCCIP.Output.Objects.CCIPObjectRefObjectId,
 		DeployCCIPOffRampInput: DeployCCIPOffRampInput{
 			CCIPPackageId: reportCCIP.Output.PackageId,
 			MCMSPackageId: reportMCMs.Output.PackageId,

--- a/deployment/ops/ccip_onramp/op_deploy.go
+++ b/deployment/ops/ccip_onramp/op_deploy.go
@@ -603,37 +603,55 @@ var TransferOwnershipOnRampOp = cld_ops.NewOperation(
 
 type AcceptOwnershipOnRampInput struct {
 	OnRampPackageId string
+	CCIPObjectRefId string
 	StateObjectId   string
 }
 
-type AcceptOwnershipOnRampObjects struct {
+type NoObjects struct {
 	// No specific objects are returned from accept_ownership
 }
 
-var acceptOwnershipOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipOnRampInput) (output sui_ops.OpTxResult[AcceptOwnershipOnRampObjects], err error) {
+var acceptOwnershipOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipOnRampInput) (output sui_ops.OpTxResult[NoObjects], err error) {
 	onRampPackage, err := module_onramp.NewOnramp(input.OnRampPackageId, deps.Client)
 	if err != nil {
-		return sui_ops.OpTxResult[AcceptOwnershipOnRampObjects]{}, err
+		return sui_ops.OpTxResult[NoObjects]{}, err
+	}
+
+	encodedCall, err := onRampPackage.Encoder().AcceptOwnership(bind.Object{Id: input.CCIPObjectRefId}, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on OnRamp as per no Signer provided")
+		return sui_ops.OpTxResult[NoObjects]{
+			Digest:    "",
+			PackageId: input.OnRampPackageId,
+			Objects:   NoObjects{},
+			Call:      call,
+		}, nil
 	}
 
 	opts := deps.GetCallOpts()
 	opts.Signer = deps.Signer
-	tx, err := onRampPackage.AcceptOwnership(
+	tx, err := onRampPackage.Bound().ExecuteTransaction(
 		b.GetContext(),
 		opts,
-		bind.Object{Id: input.StateObjectId},
-		bind.Object{Id: input.StateObjectId},
+		encodedCall,
 	)
 	if err != nil {
-		return sui_ops.OpTxResult[AcceptOwnershipOnRampObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on OnRamp: %w", err)
+		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on StateObject: %w", err)
 	}
 
-	b.Logger.Infow("Ownership accepted for OnRamp")
+	b.Logger.Infow("Ownership accepted for CCIP StateObject")
 
-	return sui_ops.OpTxResult[AcceptOwnershipOnRampObjects]{
+	return sui_ops.OpTxResult[NoObjects]{
 		Digest:    tx.Digest,
 		PackageId: input.OnRampPackageId,
-		Objects:   AcceptOwnershipOnRampObjects{},
+		Call:      call,
 	}, nil
 }
 

--- a/deployment/ops/ccip_onramp/op_deploy.go
+++ b/deployment/ops/ccip_onramp/op_deploy.go
@@ -555,6 +555,7 @@ var GetPendingTransferOnRampOp = cld_ops.NewOperation(
 
 type TransferOwnershipOnRampInput struct {
 	OnRampPackageId  string
+	CCIPObjectRefId  string
 	StateObjectId    string
 	OwnerCapObjectId string
 	To               string
@@ -575,7 +576,7 @@ var transferOwnershipOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDep
 	tx, err := onRampPackage.TransferOwnership(
 		b.GetContext(),
 		opts,
-		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.CCIPObjectRefId},
 		bind.Object{Id: input.StateObjectId},
 		bind.Object{Id: input.OwnerCapObjectId},
 		input.To,

--- a/deployment/ops/ccip_onramp/op_deploy.go
+++ b/deployment/ops/ccip_onramp/op_deploy.go
@@ -12,6 +12,7 @@ import (
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 
 	module_onramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/onramp"
+	module_ownable "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/ownable"
 )
 
 type DeployCCIPOnRampObjects struct {
@@ -612,16 +613,20 @@ type NoObjects struct {
 }
 
 var acceptOwnershipOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipOnRampInput) (output sui_ops.OpTxResult[NoObjects], err error) {
-	onRampPackage, err := module_onramp.NewOnramp(input.OnRampPackageId, deps.Client)
+	// mcms_accept_ownership uses the Ownable module
+	ownablePackage, err := module_ownable.NewOwnable(input.OnRampPackageId, deps.Client)
 	if err != nil {
 		return sui_ops.OpTxResult[NoObjects]{}, err
 	}
 
-	encodedCall, err := onRampPackage.Encoder().AcceptOwnership(bind.Object{Id: input.CCIPObjectRefId}, bind.Object{Id: input.StateObjectId})
+	encodedCall, err := ownablePackage.Encoder().AcceptOwnership(bind.Object{Id: input.StateObjectId})
 	if err != nil {
 		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
 	}
-	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	// We need ownable encoding, but we call the onramp
+	encodedCall.Module.ModuleName = "onramp"
+	// we set the ref object as the state of the call, so we can access it in the entrypoint encoder
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.CCIPObjectRefId)
 	if err != nil {
 		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
 	}
@@ -635,12 +640,15 @@ var acceptOwnershipOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps,
 		}, nil
 	}
 
+	// If we have a signer, this is accepting the ownership from EOA, we use the onramp directly
+	onRampPackage, err := module_onramp.NewOnramp(input.OnRampPackageId, deps.Client)
 	opts := deps.GetCallOpts()
 	opts.Signer = deps.Signer
-	tx, err := onRampPackage.Bound().ExecuteTransaction(
+	tx, err := onRampPackage.AcceptOwnership(
 		b.GetContext(),
 		opts,
-		encodedCall,
+		bind.Object{Id: input.CCIPObjectRefId},
+		bind.Object{Id: input.StateObjectId},
 	)
 	if err != nil {
 		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on StateObject: %w", err)
@@ -651,7 +659,6 @@ var acceptOwnershipOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps,
 	return sui_ops.OpTxResult[NoObjects]{
 		Digest:    tx.Digest,
 		PackageId: input.OnRampPackageId,
-		Call:      call,
 	}, nil
 }
 

--- a/deployment/ops/ccip_onramp/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_onramp/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package onrampops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_onramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/onramp"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsOnRampInput struct {
+	OnRampPackageId     string
+	OnRampRefObjectId   string
+	OwnerCapObjectId    string
+	OnRampStateObjectId string
+	RegistryObjectId    string
+	To                  string
+}
+
+type ExecuteOwnershipTransferToMcmsOnRampObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsOnRampHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsOnRampInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects], err error) {
+	contract, err := module_onramp.NewOnramp(input.OnRampPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{}, fmt.Errorf("failed to create OnRamp contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		bind.Object{Id: input.OnRampRefObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.OnRampStateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.OnRampStateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on OnRamp as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{
+			Digest:    "",
+			PackageId: input.OnRampPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsOnRampObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on OnRamp: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, bind.Object{Id: input.OnRampStateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{}, fmt.Errorf("failed to get new owner for OnRamp: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for OnRamp: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for OnRamp", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsOnRampObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.OnRampPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsOnRampObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsOnRampOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "onramp", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP OnRamp",
+	executeOwnershipTransferToMcmsOnRampHandler,
+)

--- a/deployment/ops/ccip_onramp/op_registry.go
+++ b/deployment/ops/ccip_onramp/op_registry.go
@@ -1,0 +1,9 @@
+package onrampops
+
+import cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+var AllOperationsOnramp = []cld_ops.Operation[any, any, any]{
+	*TransferOwnershipOnRampOp.AsUntyped(),
+	*AcceptOwnershipOnRampOp.AsUntyped(),
+	*ExecuteOwnershipTransferToMcmsOnRampOp.AsUntyped(),
+}

--- a/deployment/ops/ccip_onramp/seq_deploy_and_init_ccip_onramp.go
+++ b/deployment/ops/ccip_onramp/seq_deploy_and_init_ccip_onramp.go
@@ -83,6 +83,7 @@ var DeployAndInitCCIPOnRampSequence = cld_ops.NewSequence(
 		// transfer ownership to MCMS
 		executeOwnershipTransferToMcmsInput := TransferOwnershipOnRampInput{
 			OnRampPackageId:  deployReport.Output.PackageId,
+			CCIPObjectRefId:  input.ApplyDestChainConfigureOnRampInput.CCIPObjectRefId,
 			StateObjectId:    deployReport.Output.Objects.CCIPOnrampStateObjectId,
 			OwnerCapObjectId: deployReport.Output.Objects.OwnerCapObjectId,
 			To:               input.DeployCCIPOnRampInput.MCMSPackageId,

--- a/deployment/ops/ccip_onramp/seq_deploy_and_init_ccip_onramp.go
+++ b/deployment/ops/ccip_onramp/seq_deploy_and_init_ccip_onramp.go
@@ -80,6 +80,18 @@ var DeployAndInitCCIPOnRampSequence = cld_ops.NewSequence(
 			}
 		}
 
+		// transfer ownership to MCMS
+		executeOwnershipTransferToMcmsInput := TransferOwnershipOnRampInput{
+			OnRampPackageId:  deployReport.Output.PackageId,
+			StateObjectId:    deployReport.Output.Objects.CCIPOnrampStateObjectId,
+			OwnerCapObjectId: deployReport.Output.Objects.OwnerCapObjectId,
+			To:               input.DeployCCIPOnRampInput.MCMSPackageId,
+		}
+		_, err = cld_ops.ExecuteOperation(env, TransferOwnershipOnRampOp, deps, executeOwnershipTransferToMcmsInput)
+		if err != nil {
+			return DeployCCIPOnRampSeqOutput{}, err
+		}
+
 		return DeployCCIPOnRampSeqOutput{
 			CCIPOnRampPackageId: deployReport.Output.PackageId,
 			Objects: DeployCCIPOnRampSeqObjects{

--- a/deployment/ops/ccip_router/op_deploy.go
+++ b/deployment/ops/ccip_router/op_deploy.go
@@ -234,23 +234,41 @@ var acceptOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input
 		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to create router contract: %w", err)
 	}
 
-	opts := deps.GetCallOpts()
-	opts.Signer = deps.Signer
-	tx, err := routerContract.AcceptOwnership(
-		b.GetContext(),
-		opts,
-		bind.Object{Id: input.RouterStateObjectId},
-	)
+	encodedCall, err := routerContract.Encoder().AcceptOwnership(bind.Object{Id: input.RouterStateObjectId})
 	if err != nil {
-		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to execute accept ownership: %w", err)
+		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.RouterStateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on Router as per no Signer provided")
+		return sui_ops.OpTxResult[NoObjects]{
+			Digest:    "",
+			PackageId: input.RouterPackageId,
+			Objects:   NoObjects{},
+			Call:      call,
+		}, nil
 	}
 
-	b.Logger.Infow("AcceptOwnership on Router", "PackageId:", input.RouterPackageId, "StateObjectId:", input.RouterStateObjectId)
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := routerContract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[NoObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on StateObject: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for CCIP StateObject")
 
 	return sui_ops.OpTxResult[NoObjects]{
 		Digest:    tx.Digest,
 		PackageId: input.RouterPackageId,
-		Objects:   NoObjects{},
+		Call:      call,
 	}, nil
 }
 

--- a/deployment/ops/ccip_router/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_router/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,93 @@
+package routerops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_router "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_router"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsRouterInput struct {
+	RouterPackageId     string
+	OwnerCapObjectId    string
+	RouterStateObjectId string
+	RegistryObjectId    string
+	To                  string
+}
+
+type ExecuteOwnershipTransferToMcmsRouterObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsRouterHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsRouterInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects], err error) {
+	contract, err := module_router.NewRouter(input.RouterPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{}, fmt.Errorf("failed to create Router contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.RouterStateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.RouterStateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on Router as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{
+			Digest:    "",
+			PackageId: input.RouterPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsRouterObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on Router: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, bind.Object{Id: input.RouterStateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{}, fmt.Errorf("failed to get new owner for Router: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for Router: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for Router", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsRouterObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.RouterPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsRouterObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsRouterOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "router", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP Router",
+	executeOwnershipTransferToMcmsRouterHandler,
+)

--- a/deployment/ops/ccip_router/op_registry.go
+++ b/deployment/ops/ccip_router/op_registry.go
@@ -1,0 +1,9 @@
+package routerops
+
+import cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+var AllOperationsRouter = []cld_ops.Operation[any, any, any]{
+	*TransferOwnershipOp.AsUntyped(),
+	*AcceptOwnershipOp.AsUntyped(),
+	*ExecuteOwnershipTransferOp.AsUntyped(),
+}

--- a/deployment/ops/ccip_usdc_token_pool/op_deploy.go
+++ b/deployment/ops/ccip_usdc_token_pool/op_deploy.go
@@ -1,10 +1,14 @@
 package usdctokenpoolops
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_usdctokenpool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/usdc_token_pool"
 	usdctokenpool "github.com/smartcontractkit/chainlink-sui/bindings/packages/ccip_token_pools/usdc_token_pool"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
@@ -56,4 +60,114 @@ var DeployCCIPUSDCTokenPoolOp = cld_ops.NewOperation(
 	semver.MustParse("0.1.0"),
 	"Deploys the CCIP USDC token pool package",
 	deployHandler,
+)
+
+type TransferOwnershipUsdcTokenPoolInput struct {
+	UsdcTokenPoolPackageId string
+	TypeArgs               []string
+	StateObjectId          string
+	OwnerCapObjectId       string
+	To                     string
+}
+
+type TransferOwnershipUsdcTokenPoolObjects struct {
+	// No specific objects are returned from transfer_ownership
+}
+
+var transferOwnershipUsdcTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipUsdcTokenPoolInput) (output sui_ops.OpTxResult[TransferOwnershipUsdcTokenPoolObjects], err error) {
+	usdcTokenPoolPackage, err := module_usdctokenpool.NewUsdcTokenPool(input.UsdcTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipUsdcTokenPoolObjects]{}, err
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := usdcTokenPoolPackage.TransferOwnership(
+		b.GetContext(),
+		opts,
+		input.TypeArgs,
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipUsdcTokenPoolObjects]{}, fmt.Errorf("failed to execute TransferOwnership on UsdcTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership transfer initiated for UsdcTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[TransferOwnershipUsdcTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.UsdcTokenPoolPackageId,
+		Objects:   TransferOwnershipUsdcTokenPoolObjects{},
+	}, nil
+}
+
+var TransferOwnershipUsdcTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-usdc-token-pool-transfer-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the UsdcTokenPool",
+	transferOwnershipUsdcTokenPoolHandler,
+)
+
+type AcceptOwnershipUsdcTokenPoolInput struct {
+	UsdcTokenPoolPackageId string
+	TypeArgs               []string
+	StateObjectId          string
+}
+
+type AcceptOwnershipUsdcTokenPoolObjects struct {
+	// No specific objects are returned from accept_ownership
+}
+
+var acceptOwnershipUsdcTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipUsdcTokenPoolInput) (output sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects], err error) {
+	usdcTokenPoolPackage, err := module_usdctokenpool.NewUsdcTokenPool(input.UsdcTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects]{}, err
+	}
+
+	encodedCall, err := usdcTokenPoolPackage.Encoder().AcceptOwnership(input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on UsdcTokenPool as per no Signer provided")
+		return sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.UsdcTokenPoolPackageId,
+			Objects:   AcceptOwnershipUsdcTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := usdcTokenPoolPackage.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on UsdcTokenPool: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for UsdcTokenPool")
+
+	return sui_ops.OpTxResult[AcceptOwnershipUsdcTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.UsdcTokenPoolPackageId,
+		Objects:   AcceptOwnershipUsdcTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var AcceptOwnershipUsdcTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-usdc-token-pool-accept-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership of the UsdcTokenPool",
+	acceptOwnershipUsdcTokenPoolHandler,
 )

--- a/deployment/ops/ccip_usdc_token_pool/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ccip_usdc_token_pool/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package usdctokenpoolops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_usdc_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/usdc_token_pool"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsUsdcTokenPoolInput struct {
+	UsdcTokenPoolPackageId string
+	TypeArgs               []string
+	OwnerCapObjectId       string
+	StateObjectId          string
+	RegistryObjectId       string
+	To                     string
+}
+
+type ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsUsdcTokenPoolHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsUsdcTokenPoolInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects], err error) {
+	contract, err := module_usdc_token_pool.NewUsdcTokenPool(input.UsdcTokenPoolPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{}, fmt.Errorf("failed to create UsdcTokenPool contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		input.TypeArgs,
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on UsdcTokenPool as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{
+			Digest:    "",
+			PackageId: input.UsdcTokenPoolPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on UsdcTokenPool: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{}, fmt.Errorf("failed to get new owner for UsdcTokenPool: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for UsdcTokenPool: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for UsdcTokenPool", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.UsdcTokenPoolPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsUsdcTokenPoolObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsUsdcTokenPoolOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "usdc_token_pool", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP UsdcTokenPool",
+	executeOwnershipTransferToMcmsUsdcTokenPoolHandler,
+)

--- a/deployment/ops/managed_token/op_deploy.go
+++ b/deployment/ops/managed_token/op_deploy.go
@@ -1,10 +1,14 @@
 package managedtokenops
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_managedtoken "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/managed_token/managed_token"
 	managedtoken "github.com/smartcontractkit/chainlink-sui/bindings/packages/managed_token"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
@@ -42,4 +46,114 @@ var DeployCCIPManagedTokenOp = cld_ops.NewOperation(
 	semver.MustParse("0.1.0"),
 	"Deploys the CCIP managed token package",
 	deployHandler,
+)
+
+type TransferOwnershipManagedTokenInput struct {
+	ManagedTokenPackageId string
+	TypeArgs              []string
+	StateObjectId         string
+	OwnerCapObjectId      string
+	To                    string
+}
+
+type TransferOwnershipManagedTokenObjects struct {
+	// No specific objects are returned from transfer_ownership
+}
+
+var transferOwnershipManagedTokenHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipManagedTokenInput) (output sui_ops.OpTxResult[TransferOwnershipManagedTokenObjects], err error) {
+	managedTokenPackage, err := module_managedtoken.NewManagedToken(input.ManagedTokenPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipManagedTokenObjects]{}, err
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := managedTokenPackage.TransferOwnership(
+		b.GetContext(),
+		opts,
+		input.TypeArgs,
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.OwnerCapObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[TransferOwnershipManagedTokenObjects]{}, fmt.Errorf("failed to execute TransferOwnership on ManagedToken: %w", err)
+	}
+
+	b.Logger.Infow("Ownership transfer initiated for ManagedToken", "to", input.To)
+
+	return sui_ops.OpTxResult[TransferOwnershipManagedTokenObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.ManagedTokenPackageId,
+		Objects:   TransferOwnershipManagedTokenObjects{},
+	}, nil
+}
+
+var TransferOwnershipManagedTokenOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-managed-token-transfer-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the ManagedToken",
+	transferOwnershipManagedTokenHandler,
+)
+
+type AcceptOwnershipManagedTokenInput struct {
+	ManagedTokenPackageId string
+	TypeArgs              []string
+	StateObjectId         string
+}
+
+type AcceptOwnershipManagedTokenObjects struct {
+	// No specific objects are returned from accept_ownership
+}
+
+var acceptOwnershipManagedTokenHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipManagedTokenInput) (output sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects], err error) {
+	managedTokenPackage, err := module_managedtoken.NewManagedToken(input.ManagedTokenPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects]{}, err
+	}
+
+	encodedCall, err := managedTokenPackage.Encoder().AcceptOwnership(input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on ManagedToken as per no Signer provided")
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects]{
+			Digest:    "",
+			PackageId: input.ManagedTokenPackageId,
+			Objects:   AcceptOwnershipManagedTokenObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := managedTokenPackage.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects]{}, fmt.Errorf("failed to execute AcceptOwnership on ManagedToken: %w", err)
+	}
+
+	b.Logger.Infow("Ownership accepted for ManagedToken")
+
+	return sui_ops.OpTxResult[AcceptOwnershipManagedTokenObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.ManagedTokenPackageId,
+		Objects:   AcceptOwnershipManagedTokenObjects{},
+		Call:      call,
+	}, nil
+}
+
+var AcceptOwnershipManagedTokenOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-managed-token-accept-ownership", "package", "configure"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership of the ManagedToken",
+	acceptOwnershipManagedTokenHandler,
 )

--- a/deployment/ops/managed_token/op_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/managed_token/op_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,95 @@
+package managedtokenops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_managed_token "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/managed_token/managed_token"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// =================== Execute Ownership Transfer To MCMS Operations =================== //
+
+type ExecuteOwnershipTransferToMcmsManagedTokenInput struct {
+	ManagedTokenPackageId string
+	TypeArgs              []string
+	OwnerCapObjectId      string
+	StateObjectId         string
+	RegistryObjectId      string
+	To                    string
+}
+
+type ExecuteOwnershipTransferToMcmsManagedTokenObjects struct {
+	// No specific objects are returned from execute_ownership_transfer_to_mcms
+}
+
+var executeOwnershipTransferToMcmsManagedTokenHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsManagedTokenInput) (output sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects], err error) {
+	contract, err := module_managed_token.NewManagedToken(input.ManagedTokenPackageId, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{}, fmt.Errorf("failed to create ManagedToken contract: %w", err)
+	}
+
+	encodedCall, err := contract.Encoder().ExecuteOwnershipTransferToMcms(
+		input.TypeArgs,
+		bind.Object{Id: input.OwnerCapObjectId},
+		bind.Object{Id: input.StateObjectId},
+		bind.Object{Id: input.RegistryObjectId},
+		input.To,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{}, fmt.Errorf("failed to encode ExecuteOwnershipTransferToMcms call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.StateObjectId)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of ExecuteOwnershipTransferToMcms on ManagedToken as per no Signer provided", "to", input.To)
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{
+			Digest:    "",
+			PackageId: input.ManagedTokenPackageId,
+			Objects:   ExecuteOwnershipTransferToMcmsManagedTokenObjects{},
+			Call:      call,
+		}, nil
+	}
+
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	tx, err := contract.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{}, fmt.Errorf("failed to execute ExecuteOwnershipTransferToMcms on ManagedToken: %w", err)
+	}
+
+	newOwner, err := contract.DevInspect().Owner(b.GetContext(), opts, input.TypeArgs, bind.Object{Id: input.StateObjectId})
+	if err != nil {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{}, fmt.Errorf("failed to get new owner for ManagedToken: %w", err)
+	}
+
+	if newOwner != input.To {
+		return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{}, fmt.Errorf("ownership transfer to MCMS failed for ManagedToken: expected new owner %s, got %s", input.To, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully for ManagedToken", "to", input.To)
+
+	return sui_ops.OpTxResult[ExecuteOwnershipTransferToMcmsManagedTokenObjects]{
+		Digest:    tx.Digest,
+		PackageId: input.ManagedTokenPackageId,
+		Objects:   ExecuteOwnershipTransferToMcmsManagedTokenObjects{},
+		Call:      call,
+	}, nil
+}
+
+var ExecuteOwnershipTransferToMcmsManagedTokenOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip", "managed_token", "execute_ownership_transfer_to_mcms"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for the CCIP ManagedToken",
+	executeOwnershipTransferToMcmsManagedTokenHandler,
+)

--- a/deployment/ops/mcms/op_ownership.go
+++ b/deployment/ops/mcms/op_ownership.go
@@ -67,7 +67,7 @@ var acceptOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input
 		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, errors.New("Accept Ownership as timelock cannot be called directly, only through MCMS proposal")
 	}
 
-	b.Logger.Infow("Skipping execution of AcceptOwnership on StateObject as per no Signer provided")
+	b.Logger.Infow("Skipping execution of AcceptOwnership on MCMS Account as per no Signer provided")
 	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
 		Digest:    "",
 		PackageId: input.McmsPackageID,

--- a/deployment/ops/mcms/op_ownership.go
+++ b/deployment/ops/mcms/op_ownership.go
@@ -27,6 +27,11 @@ var transferOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inp
 	}
 
 	tx, err := mcmsAccount.TransferOwnershipToSelf(b.GetContext(), opts, bind.Object{Id: input.OwnerCap}, bind.Object{Id: input.AccountObjectID})
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
+	}
+
+	b.Logger.Infow("Transfer ownership to MCMS executed successfully", "to", input.McmsPackageID)
 
 	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
 		Digest:    tx.Digest,

--- a/deployment/ops/mcms/op_ownership.go
+++ b/deployment/ops/mcms/op_ownership.go
@@ -1,0 +1,129 @@
+package mcmsops
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	modulemcmsaccount "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms_account"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+type MCMSTransferOwnershipInput struct {
+	McmsPackageID   string `json:"mcmsPackageID"`
+	OwnerCap        string `json:"ownerCap"`
+	AccountObjectID string `json:"accountObjectID"`
+}
+
+var transferOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input MCMSTransferOwnershipInput) (output sui_ops.OpTxResult[cld_ops.EmptyInput], err error) {
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	mcmsAccount, err := modulemcmsaccount.NewMcmsAccount(input.McmsPackageID, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
+	}
+
+	tx, err := mcmsAccount.TransferOwnershipToSelf(b.GetContext(), opts, bind.Object{Id: input.OwnerCap}, bind.Object{Id: input.AccountObjectID})
+
+	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
+		Digest:    tx.Digest,
+		PackageId: input.McmsPackageID,
+	}, err
+}
+
+var MCMSTransferOwnershipOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("mcms", "mcms_account", "transfer_ownership"),
+	semver.MustParse("0.1.0"),
+	"Init the transfer ownership of the MCMS contract to itself",
+	transferOwnershipHandler,
+)
+
+type MCMSAcceptOwnershipInput struct {
+	McmsPackageID   string `json:"mcmsPackageID"`
+	AccountObjectID string `json:"accountObjectID"`
+}
+
+var acceptOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input MCMSAcceptOwnershipInput) (output sui_ops.OpTxResult[cld_ops.EmptyInput], err error) {
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	mcmsAccount, err := modulemcmsaccount.NewMcmsAccount(input.McmsPackageID, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
+	}
+
+	encodedCall, err := mcmsAccount.Encoder().AcceptOwnershipAsTimelock(bind.Object{Id: input.AccountObjectID})
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.AccountObjectID)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+
+	if deps.Signer != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, errors.New("Accept Ownership as timelock cannot be called directly, only through MCMS proposal")
+	}
+
+	b.Logger.Infow("Skipping execution of AcceptOwnership on StateObject as per no Signer provided")
+	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
+		Digest:    "",
+		PackageId: input.McmsPackageID,
+		Objects:   cld_ops.EmptyInput{},
+		Call:      call,
+	}, nil
+}
+
+var MCMSAcceptOwnershipOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("mcms", "mcms_account", "accept_ownership"),
+	semver.MustParse("0.1.0"),
+	"Accept ownership of the MCMS contract as MCMS",
+	acceptOwnershipHandler,
+)
+
+type MCMSExecuteTransferOwnershipInput struct {
+	// MCMS related
+	McmsPackageID    string `json:"mcmsPackageID"`
+	OwnerCap         string `json:"ownerCap"`
+	AccountObjectID  string `json:"accountObjectID"`
+	RegistryObjectID string `json:"registryObjectID"`
+}
+
+var executeTransferOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input MCMSExecuteTransferOwnershipInput) (output sui_ops.OpTxResult[cld_ops.EmptyInput], err error) {
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+	mcmsAccount, err := modulemcmsaccount.NewMcmsAccount(input.McmsPackageID, deps.Client)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
+	}
+
+	tx, err := mcmsAccount.ExecuteOwnershipTransfer(b.GetContext(), opts, bind.Object{Id: input.OwnerCap}, bind.Object{Id: input.AccountObjectID}, bind.Object{Id: input.RegistryObjectID}, input.McmsPackageID)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
+	}
+
+	newOwner, err := mcmsAccount.DevInspect().Owner(b.GetContext(), opts, bind.Object{Id: input.AccountObjectID})
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to get new owner for MCMS: %w", err)
+	}
+
+	if newOwner != input.McmsPackageID {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("ownership transfer to MCMS failed: expected new owner %s, got %s", input.McmsPackageID, newOwner)
+	}
+
+	b.Logger.Infow("Ownership transfer to MCMS executed successfully", "to", input.McmsPackageID)
+
+	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
+		Digest:    tx.Digest,
+		PackageId: input.McmsPackageID,
+	}, err
+}
+
+var MCMSExecuteTransferOwnershipOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("mcms", "mcms_account", "execute_transfer_ownership"),
+	semver.MustParse("0.1.0"),
+	"Execute transfer ownership of the MCMS contract to itself",
+	executeTransferOwnershipHandler,
+)

--- a/deployment/ops/mcms/op_proposal_generate.go
+++ b/deployment/ops/mcms/op_proposal_generate.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	module_mcms "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	"github.com/smartcontractkit/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
@@ -87,8 +89,18 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 		Transactions:  mcmsTxs,
 	}
 
+	mcmsContract, err := module_mcms.NewMcms(input.MmcsPackageID, deps.Client)
+	if err != nil {
+		return mcms.TimelockProposal{}, fmt.Errorf("failed to create MCMS contract instance: %w", err)
+	}
+
+	opCount, err := mcmsContract.DevInspect().GetOpCount(b.GetContext(), deps.GetCallOpts(), bind.Object{Id: input.McmsStateObjID}, input.Role.Byte())
+	if err != nil {
+		return mcms.TimelockProposal{}, fmt.Errorf("failed to get operation count from MCMS: %w", err)
+	}
+
 	validUntilMs := uint32(time.Now().Add(time.Duration(DefaultTimelockExpirationInHours) * time.Hour).Unix())
-	metadata, err := suisdk.NewChainMetadata(0, input.Role, input.MmcsPackageID, input.McmsStateObjID, input.AccountObjID, input.RegistryObjID, input.TimelockObjID)
+	metadata, err := suisdk.NewChainMetadata(opCount, input.Role, input.MmcsPackageID, input.McmsStateObjID, input.AccountObjID, input.RegistryObjID, input.TimelockObjID)
 	if err != nil {
 		return mcms.TimelockProposal{}, fmt.Errorf("failed to create chain metadata: %w", err)
 	}

--- a/deployment/ops/mcms/op_proposal_generate.go
+++ b/deployment/ops/mcms/op_proposal_generate.go
@@ -46,7 +46,7 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 	for i, def := range input.Defs {
 		op, err := b.OperationRegistry.Retrieve(def)
 		if err != nil {
-			return mcms.TimelockProposal{}, err
+			return mcms.TimelockProposal{}, fmt.Errorf("failed to retrieve operation %s: %w", def.ID, err)
 		}
 		// Remove the signer to make the operations read-only, and prevent accidental tx sends during execution
 		deps.Signer = nil

--- a/deployment/ops/mcms/op_proposal_generate.go
+++ b/deployment/ops/mcms/op_proposal_generate.go
@@ -49,7 +49,10 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 		return mcms.TimelockProposal{}, fmt.Errorf("failed to create MCMS contract instance: %w", err)
 	}
 
-	opCount, err := mcmsContract.DevInspect().GetOpCount(b.GetContext(), deps.GetCallOpts(), bind.Object{Id: input.McmsStateObjID}, input.Role.Byte())
+	opts := deps.GetCallOpts()
+	opts.Signer = deps.Signer
+
+	opCount, err := mcmsContract.DevInspect().GetOpCount(b.GetContext(), opts, bind.Object{Id: input.McmsStateObjID}, input.Role.Byte())
 	if err != nil {
 		return mcms.TimelockProposal{}, fmt.Errorf("failed to get operation count from MCMS: %w", err)
 	}

--- a/deployment/ops/mcms/op_proposal_generate.go
+++ b/deployment/ops/mcms/op_proposal_generate.go
@@ -43,6 +43,17 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 	if len(input.Defs) != len(input.Inputs) {
 		return mcms.TimelockProposal{}, fmt.Errorf("number of definitions (%d) does not match number of inputs (%d)", len(input.Defs), len(input.Inputs))
 	}
+
+	mcmsContract, err := module_mcms.NewMcms(input.MmcsPackageID, deps.Client)
+	if err != nil {
+		return mcms.TimelockProposal{}, fmt.Errorf("failed to create MCMS contract instance: %w", err)
+	}
+
+	opCount, err := mcmsContract.DevInspect().GetOpCount(b.GetContext(), deps.GetCallOpts(), bind.Object{Id: input.McmsStateObjID}, input.Role.Byte())
+	if err != nil {
+		return mcms.TimelockProposal{}, fmt.Errorf("failed to get operation count from MCMS: %w", err)
+	}
+
 	mcmsTxs := make([]mcmstypes.Transaction, len(input.Defs))
 
 	for i, def := range input.Defs {
@@ -87,16 +98,6 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 	op := types.BatchOperation{
 		ChainSelector: types.ChainSelector(input.ChainSelector),
 		Transactions:  mcmsTxs,
-	}
-
-	mcmsContract, err := module_mcms.NewMcms(input.MmcsPackageID, deps.Client)
-	if err != nil {
-		return mcms.TimelockProposal{}, fmt.Errorf("failed to create MCMS contract instance: %w", err)
-	}
-
-	opCount, err := mcmsContract.DevInspect().GetOpCount(b.GetContext(), deps.GetCallOpts(), bind.Object{Id: input.McmsStateObjID}, input.Role.Byte())
-	if err != nil {
-		return mcms.TimelockProposal{}, fmt.Errorf("failed to get operation count from MCMS: %w", err)
 	}
 
 	validUntilMs := uint32(time.Now().Add(time.Duration(DefaultTimelockExpirationInHours) * time.Hour).Unix())

--- a/deployment/ops/mcms/op_proposal_generate.go
+++ b/deployment/ops/mcms/op_proposal_generate.go
@@ -44,6 +44,22 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 		return mcms.TimelockProposal{}, fmt.Errorf("number of definitions (%d) does not match number of inputs (%d)", len(input.Defs), len(input.Inputs))
 	}
 
+	var action types.TimelockAction
+	var delay *types.Duration
+	switch input.Role {
+	case suisdk.TimelockRoleProposer:
+		action = types.TimelockActionSchedule
+		delayDuration := types.NewDuration(input.Delay)
+		delay = &delayDuration
+	case suisdk.TimelockRoleBypasser:
+		action = types.TimelockActionBypass
+	case suisdk.TimelockRoleCanceller:
+		action = types.TimelockActionCancel
+	default:
+		// NewChainMetadata will always error on invalid role, but this is a safeguard
+		return mcms.TimelockProposal{}, fmt.Errorf("unsupported role: %v", input.Role)
+	}
+
 	mcmsContract, err := module_mcms.NewMcms(input.MmcsPackageID, deps.Client)
 	if err != nil {
 		return mcms.TimelockProposal{}, fmt.Errorf("failed to create MCMS contract instance: %w", err)
@@ -107,22 +123,6 @@ var generateProposalHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inpu
 	metadata, err := suisdk.NewChainMetadata(opCount, input.Role, input.MmcsPackageID, input.McmsStateObjID, input.AccountObjID, input.RegistryObjID, input.TimelockObjID)
 	if err != nil {
 		return mcms.TimelockProposal{}, fmt.Errorf("failed to create chain metadata: %w", err)
-	}
-
-	var action types.TimelockAction
-	var delay *types.Duration
-	switch input.Role {
-	case suisdk.TimelockRoleProposer:
-		action = types.TimelockActionSchedule
-		delayDuration := types.NewDuration(input.Delay)
-		delay = &delayDuration
-	case suisdk.TimelockRoleBypasser:
-		action = types.TimelockActionBypass
-	case suisdk.TimelockRoleCanceller:
-		action = types.TimelockActionCancel
-	default:
-		// NewChainMetadata will always error on invalid role, but this is a safeguard
-		return mcms.TimelockProposal{}, fmt.Errorf("unsupported role: %v", input.Role)
 	}
 
 	var description string = "Invokes the following set of operations: "

--- a/deployment/ops/mcms/op_proposal_generate_test.go
+++ b/deployment/ops/mcms/op_proposal_generate_test.go
@@ -35,6 +35,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 
 	// Create a registry with state object operations that support exporting the Call
 	registry := cld_ops.NewOperationRegistry(
+		MCMSAcceptOwnershipOp.AsUntyped(),
 		ccipops.AddPackageIdStateObjectOp.AsUntyped(),
 		ccipops.RemovePackageIdStateObjectOp.AsUntyped(),
 		ccipops.TransferOwnershipStateObjectOp.AsUntyped(),
@@ -67,17 +68,18 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 	testCCIPPackageId := "0x1234567890abcdef"
 	testObjectRefId := "0xabcdef1234567890"
 	testOwnerCapId := "0x9876543210fedcba"
-	testPackageId := "0xdeadbeefcafebabe"
+
+	mcmsPackageId := report.Output.PackageId
+	mcmsStateObjID := report.Output.Objects.McmsMultisigStateObjectId
+	timelockObjID := report.Output.Objects.TimelockObjectId
+	accountObjID := report.Output.Objects.McmsAccountStateObjectId
+	registryObjID := report.Output.Objects.McmsRegistryObjectId
 	testNewOwner := "0x1111111111111111"
-	testTimelockObjID := "0x2222222222222222"
-	testAccountObjID := "0x3333333333333333"
-	testRegistryObjID := "0x4444444444444444"
 	testChainSelector := cselectors.SUI_TESTNET.Selector
 
 	t.Run("Generate Proposal with Multiple Operations - Proposer Role", func(t *testing.T) {
 		// Create operation definitions and inputs
 		defs := []cld_ops.Definition{
-			MCMSAcceptOwnershipOp.Def(),
 			ccipops.AddPackageIdStateObjectOp.Def(),
 			ccipops.TransferOwnershipStateObjectOp.Def(),
 			ccipops.AcceptOwnershipStateObjectOp.Def(),
@@ -88,7 +90,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 				CCIPPackageId:         testCCIPPackageId,
 				CCIPObjectRefObjectId: testObjectRefId,
 				OwnerCapObjectId:      testOwnerCapId,
-				PackageId:             testPackageId,
+				PackageId:             mcmsPackageId,
 			},
 			ccipops.TransferOwnershipStateObjectInput{
 				CCIPPackageId:         testCCIPPackageId,
@@ -106,11 +108,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 			Defs:   defs,
 			Inputs: inputs,
 
-			MmcsPackageID:  report.Output.PackageId,
-			McmsStateObjID: report.Output.Objects.McmsMultisigStateObjectId,
-			TimelockObjID:  report.Output.Objects.TimelockObjectId,
-			AccountObjID:   report.Output.Objects.McmsAccountStateObjectId,
-			RegistryObjID:  report.Output.Objects.McmsRegistryObjectId,
+			MmcsPackageID:  mcmsPackageId,
+			McmsStateObjID: mcmsStateObjID,
+			TimelockObjID:  timelockObjID,
+			AccountObjID:   accountObjID,
+			RegistryObjID:  registryObjID,
 
 			Role:  suisdk.TimelockRoleProposer,
 			Delay: time.Hour * 24,
@@ -132,7 +134,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 
 		// Verify timelock addresses
 		require.Len(t, proposal.TimelockAddresses, 1, "should have one timelock address")
-		assert.Equal(t, testTimelockObjID, proposal.TimelockAddresses[types.ChainSelector(testChainSelector)], "timelock address should match")
+		assert.Equal(t, timelockObjID, proposal.TimelockAddresses[types.ChainSelector(testChainSelector)], "timelock address should match")
 
 		// Verify chain metadata
 		require.Len(t, proposal.ChainMetadata, 1, "should have one chain metadata")
@@ -146,8 +148,6 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 
 		// Verify delay is set for proposer role
 		assert.NotZero(t, proposal.Delay, "delay should be set for proposer role")
-		// Note: Delay verification simplified for test
-
 	})
 
 	t.Run("Generate Proposal with Single Operation - Bypasser Role", func(t *testing.T) {
@@ -157,12 +157,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 		}
 
 		inputs := []any{
-
 			ccipops.RemovePackageIdStateObjectInput{
 				CCIPPackageId:         testCCIPPackageId,
 				CCIPObjectRefObjectId: testObjectRefId,
 				OwnerCapObjectId:      testOwnerCapId,
-				PackageId:             testPackageId,
+				PackageId:             mcmsPackageId,
 			},
 		}
 
@@ -170,11 +169,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 			Defs:   defs,
 			Inputs: inputs,
 
-			MmcsPackageID:  testCCIPPackageId,
-			McmsStateObjID: testObjectRefId,
-			TimelockObjID:  testTimelockObjID,
-			AccountObjID:   testAccountObjID,
-			RegistryObjID:  testRegistryObjID,
+			MmcsPackageID:  mcmsPackageId,
+			McmsStateObjID: mcmsStateObjID,
+			TimelockObjID:  timelockObjID,
+			AccountObjID:   accountObjID,
+			RegistryObjID:  registryObjID,
 
 			Role:  suisdk.TimelockRoleBypasser,
 			Delay: 0, // No delay for bypasser
@@ -208,12 +207,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 		}
 
 		inputs := []any{
-
 			ccipops.AddPackageIdStateObjectInput{
 				CCIPPackageId:         testCCIPPackageId,
 				CCIPObjectRefObjectId: testObjectRefId,
 				OwnerCapObjectId:      testOwnerCapId,
-				PackageId:             testPackageId,
+				PackageId:             mcmsPackageId,
 			},
 		}
 
@@ -221,11 +219,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 			Defs:   defs,
 			Inputs: inputs,
 
-			MmcsPackageID:  testCCIPPackageId,
-			McmsStateObjID: testObjectRefId,
-			TimelockObjID:  testTimelockObjID,
-			AccountObjID:   testAccountObjID,
-			RegistryObjID:  testRegistryObjID,
+			MmcsPackageID:  mcmsPackageId,
+			McmsStateObjID: mcmsStateObjID,
+			TimelockObjID:  timelockObjID,
+			AccountObjID:   accountObjID,
+			RegistryObjID:  registryObjID,
 
 			Role:  suisdk.TimelockRole(100), // Invalid role
 			Delay: time.Hour,
@@ -237,7 +235,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 		bundle := newTestBundle(t, registry)
 		_, err := cld_ops.ExecuteSequence(bundle, MCMSDynamicProposalGenerateSeq, deps, proposalInput)
 		require.Error(t, err, "should fail with invalid role")
-		assert.Contains(t, err.Error(), "invalid timelock role", "error should mention invalid timelock role")
+		assert.Contains(t, err.Error(), "unsupported role", "error should mention unsupported role")
 	})
 
 	t.Run("Generate Proposal with Mismatched Definitions and Inputs", func(t *testing.T) {
@@ -253,7 +251,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 				CCIPPackageId:         testCCIPPackageId,
 				CCIPObjectRefObjectId: testObjectRefId,
 				OwnerCapObjectId:      testOwnerCapId,
-				PackageId:             testPackageId,
+				PackageId:             mcmsPackageId,
 			},
 
 			// Missing second input
@@ -263,11 +261,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 			Defs:   defs,
 			Inputs: inputs[:1], // Only one input for two definitions
 
-			MmcsPackageID:  testCCIPPackageId,
-			McmsStateObjID: testObjectRefId,
-			TimelockObjID:  testTimelockObjID,
-			AccountObjID:   testAccountObjID,
-			RegistryObjID:  testRegistryObjID,
+			MmcsPackageID:  mcmsPackageId,
+			McmsStateObjID: mcmsStateObjID,
+			TimelockObjID:  timelockObjID,
+			AccountObjID:   accountObjID,
+			RegistryObjID:  registryObjID,
 
 			Role:  suisdk.TimelockRoleProposer,
 			Delay: time.Hour,

--- a/deployment/ops/mcms/op_proposal_generate_test.go
+++ b/deployment/ops/mcms/op_proposal_generate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-sui/bindings/tests/testenv"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
@@ -77,6 +78,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 	t.Run("Generate Proposal with Multiple Operations - Proposer Role", func(t *testing.T) {
 		// Create operation definitions and inputs
 		defs := []cld_ops.Definition{
+			mcmsops.MCMSAcceptOwnershipOp.Def(),
 			ccipops.AddPackageIdStateObjectOp.Def(),
 			ccipops.TransferOwnershipStateObjectOp.Def(),
 			ccipops.AcceptOwnershipStateObjectOp.Def(),

--- a/deployment/ops/mcms/op_proposal_generate_test.go
+++ b/deployment/ops/mcms/op_proposal_generate_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package mcmsops
 
 import (
@@ -8,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	"github.com/smartcontractkit/chainlink-sui/bindings/tests/testenv"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
@@ -38,14 +41,27 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 		ccipops.AcceptOwnershipStateObjectOp.AsUntyped(),
 	)
 
+	// Execute the operation
+	bundle := newTestBundle(t, registry)
+	signer, client := testenv.SetupEnvironment(t)
+
 	// Create mock dependencies
 	deps := sui_ops.OpTxDeps{
-		Client: nil, // We don't need a real client for this test since NoExecute=true
-		Signer: nil, // We don't need a real signer for this test since NoExecute=true
+		Client: client,
+		Signer: signer,
 		GetCallOpts: func() *bind.CallOpts {
-			return &bind.CallOpts{}
+			b := uint64(300_000_000)
+			return &bind.CallOpts{
+				WaitForExecution: true,
+				GasBudget:        &b,
+			}
 		},
 	}
+
+	report, err := cld_ops.ExecuteSequence(bundle, DeployMCMSSequence, deps, DeployMCMSSeqInput{
+		ChainSelector: cselectors.SUI_TESTNET.Selector,
+	})
+	require.NoError(t, err, "should deploy mcms successfully")
 
 	// Test data
 	testCCIPPackageId := "0x1234567890abcdef"
@@ -89,11 +105,11 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 			Defs:   defs,
 			Inputs: inputs,
 
-			MmcsPackageID:  testCCIPPackageId,
-			McmsStateObjID: testObjectRefId,
-			TimelockObjID:  testTimelockObjID,
-			AccountObjID:   testAccountObjID,
-			RegistryObjID:  testRegistryObjID,
+			MmcsPackageID:  report.Output.PackageId,
+			McmsStateObjID: report.Output.Objects.McmsMultisigStateObjectId,
+			TimelockObjID:  report.Output.Objects.TimelockObjectId,
+			AccountObjID:   report.Output.Objects.McmsAccountStateObjectId,
+			RegistryObjID:  report.Output.Objects.McmsRegistryObjectId,
 
 			Role:  suisdk.TimelockRoleProposer,
 			Delay: time.Hour * 24,
@@ -101,8 +117,6 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 			ChainSelector: testChainSelector,
 		}
 
-		// Execute the operation
-		bundle := newTestBundle(t, registry)
 		result, err := cld_ops.ExecuteSequence(bundle, MCMSDynamicProposalGenerateSeq, deps, proposalInput)
 		require.NoError(t, err, "should generate proposal successfully")
 

--- a/deployment/ops/mcms/op_proposal_generate_test.go
+++ b/deployment/ops/mcms/op_proposal_generate_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-sui/bindings/tests/testenv"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
-	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
@@ -78,7 +77,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 	t.Run("Generate Proposal with Multiple Operations - Proposer Role", func(t *testing.T) {
 		// Create operation definitions and inputs
 		defs := []cld_ops.Definition{
-			mcmsops.MCMSAcceptOwnershipOp.Def(),
+			MCMSAcceptOwnershipOp.Def(),
 			ccipops.AddPackageIdStateObjectOp.Def(),
 			ccipops.TransferOwnershipStateObjectOp.Def(),
 			ccipops.AcceptOwnershipStateObjectOp.Def(),

--- a/deployment/ops/mcms/op_registry.go
+++ b/deployment/ops/mcms/op_registry.go
@@ -1,8 +1,105 @@
 package mcmsops
 
 import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+	"github.com/block-vision/sui-go-sdk/transaction"
+
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
+
+type AddModulesMCMSInput struct {
+	MCMSPackageId     string
+	MCMSRegistryObjId string
+	AllowedModules    []string
+}
+
+var addModulesHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AddModulesMCMSInput) (output sui_ops.OpTxResult[cld_ops.EmptyInput], err error) {
+
+	registryBytes, err := hex.DecodeString(strings.TrimPrefix(input.MCMSRegistryObjId, "0x"))
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to convert registry object ID to bytes: %w", err)
+	}
+	nameBytes, err := encodeAddModulesCall(input.AllowedModules)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to encode add modules call: %w", err)
+	}
+	encodedCall := bind.EncodedCall{
+		Module: bind.ModuleInformation{
+			PackageID:   input.MCMSPackageId,
+			ModuleName:  "mcms_registry",
+			PackageName: "mcms",
+		},
+		Function: "add_allowed_modules",
+		CallArgs: []*bind.EncodedCallArgument{
+			{
+				CallArg: &transaction.CallArg{
+					Pure: &transaction.Pure{
+						Bytes: registryBytes,
+					},
+				},
+			},
+			{
+				CallArg: &transaction.CallArg{
+					Pure: &transaction.Pure{
+						Bytes: nameBytes,
+					},
+				},
+			},
+		},
+	}
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to encode AcceptOwnership call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(&encodedCall, input.MCMSRegistryObjId)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on StateObject as per no Signer provided")
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{
+			Digest:    "",
+			PackageId: input.MCMSPackageId,
+			Call:      call,
+		}, nil
+	}
+
+	return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("cannot execute this call directly: %w", err)
+}
+
+var AddModulesMCMSOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("mcms", "package", "add_modules"),
+	semver.MustParse("0.1.0"),
+	"Add modules to the MCMS registry",
+	addModulesHandler,
+)
+
+func encodeAddModulesCall(moduleNames []string) ([]byte, error) {
+	// Create a BCS serializer
+	serializer := &bcs.Serializer{}
+
+	// Serialize the length of the vector using ULEB128 (BCS standard for vector lengths)
+	serializer.Uleb128(uint32(len(moduleNames)))
+
+	// Serialize each module name as a vector<u8> (since strings in Move are vector<u8>)
+	for _, moduleName := range moduleNames {
+		// Each string is serialized as:
+		// 1. Length of the string (ULEB128)
+		// 2. The bytes of the string
+		moduleBytes := []byte(moduleName)
+		serializer.Uleb128(uint32(len(moduleBytes)))
+		serializer.FixedBytes(moduleBytes)
+	}
+
+	return serializer.ToBytes(), nil
+}
 
 // Exports every operation available so they can be registered to be used in dynamic changesets
 var AllOperationsMCMS = []cld_ops.Operation[any, any, any]{
@@ -10,4 +107,5 @@ var AllOperationsMCMS = []cld_ops.Operation[any, any, any]{
 	*MCMSTransferOwnershipOp.AsUntyped(),
 	*MCMSExecuteTransferOwnershipOp.AsUntyped(),
 	*SetConfigMCMSOp.AsUntyped(),
+	*AddModulesMCMSOp.AsUntyped(),
 }

--- a/deployment/ops/mcms/op_registry.go
+++ b/deployment/ops/mcms/op_registry.go
@@ -1,0 +1,13 @@
+package mcmsops
+
+import (
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+// Exports every operation available so they can be registered to be used in dynamic changesets
+var AllOperationsMCMS = []cld_ops.Operation[any, any, any]{
+	*MCMSAcceptOwnershipOp.AsUntyped(),
+	*MCMSTransferOwnershipOp.AsUntyped(),
+	*MCMSExecuteTransferOwnershipOp.AsUntyped(),
+	*SetConfigMCMSOp.AsUntyped(),
+}

--- a/deployment/ops/mcms/op_set_config.go
+++ b/deployment/ops/mcms/op_set_config.go
@@ -1,11 +1,17 @@
 package mcmsops
 
 import (
-	"github.com/Masterminds/semver/v3"
-	"github.com/block-vision/sui-go-sdk/models"
+	"fmt"
+	"math/big"
 
+	"github.com/Masterminds/semver/v3"
+
+	cselectors "github.com/smartcontractkit/chain-selectors"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	modulemcms "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	"github.com/smartcontractkit/mcms/sdk/evm"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -19,26 +25,69 @@ type MCMSSetConfigInput struct {
 	// Timelock related
 	Role suisdk.TimelockRole `json:"role"`
 	// Config related
-	Config types.Config `json:"config"`
+	Config    types.Config `json:"config"`
+	ClearRoot bool         `json:"clearRoot"`
 }
 
 var setConfigMcmsHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input MCMSSetConfigInput) (output sui_ops.OpTxResult[cld_ops.EmptyInput], err error) {
 	opts := deps.GetCallOpts()
 	opts.Signer = deps.Signer
-	mcmsConfigurer, err := suisdk.NewConfigurer(deps.Client, deps.Signer, input.Role, input.McmsPackageID, input.OwnerCap, input.ChainSelector)
+	mcms, err := modulemcms.NewMcms(input.McmsPackageID, deps.Client)
 	if err != nil {
 		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
 	}
 
-	mcmsTx, err := mcmsConfigurer.SetConfig(b.GetContext(), input.McmsObjectID, &input.Config, true)
+	chainID, err := cselectors.SuiChainIdFromSelector(input.ChainSelector)
 	if err != nil {
 		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, err
 	}
+	chainIDBig := new(big.Int).SetUint64(chainID)
+	groupQuorum, groupParents, signerAddresses, signerGroups, err := evm.ExtractSetConfigInputs(&input.Config)
 
-	suiTx := mcmsTx.RawData.(*models.SuiTransactionBlockResponse)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("unable to extract set config inputs: %w", err)
+	}
+	signers := make([][]byte, len(signerAddresses))
+	for i, addr := range signerAddresses {
+		signers[i] = addr.Bytes()
+	}
+
+	encodedCall, err := mcms.Encoder().SetConfig(
+		bind.Object{Id: input.OwnerCap},
+		bind.Object{Id: input.McmsObjectID},
+		input.Role.Byte(),
+		chainIDBig,
+		signers,
+		signerGroups,
+		groupQuorum[:],
+		groupParents[:],
+		input.ClearRoot,
+	)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to encode SetConfig call: %w", err)
+	}
+	call, err := sui_ops.ToTransactionCall(encodedCall, input.McmsObjectID)
+	if err != nil {
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{}, fmt.Errorf("failed to convert encoded call to TransactionCall: %w", err)
+	}
+
+	if deps.Signer == nil {
+		b.Logger.Infow("Skipping execution of AcceptOwnership on StateObject as per no Signer provided")
+		return sui_ops.OpTxResult[cld_ops.EmptyInput]{
+			Digest:    "",
+			PackageId: input.McmsPackageID,
+			Call:      call,
+		}, nil
+	}
+
+	tx, err := mcms.Bound().ExecuteTransaction(
+		b.GetContext(),
+		opts,
+		encodedCall,
+	)
 
 	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
-		Digest:    suiTx.Digest,
+		Digest:    tx.Digest,
 		PackageId: input.McmsPackageID,
 	}, err
 }

--- a/deployment/ops/mcms/op_set_config.go
+++ b/deployment/ops/mcms/op_set_config.go
@@ -87,6 +87,7 @@ var setConfigMcmsHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input M
 	)
 
 	return sui_ops.OpTxResult[cld_ops.EmptyInput]{
+		Call:      call,
 		Digest:    tx.Digest,
 		PackageId: input.McmsPackageID,
 	}, err

--- a/deployment/ops/mcms/seq_deploy.go
+++ b/deployment/ops/mcms/seq_deploy.go
@@ -1,6 +1,8 @@
 package mcmsops
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -35,7 +37,7 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 		// Deploy MCMS first
 		deployReport, err := cld_ops.ExecuteOperation(env, DeployMCMSOp, deps, cld_ops.EmptyInput{})
 		if err != nil {
-			return DeployMCMSSeqOutput{}, err
+			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to deploy MCMS: %w", err)
 		}
 
 		// Configure each timelock role if config is provided
@@ -62,7 +64,7 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 
 				_, err = cld_ops.ExecuteOperation(env, SetConfigMCMSOp, deps, setConfigInput)
 				if err != nil {
-					return DeployMCMSSeqOutput{}, err
+					return DeployMCMSSeqOutput{}, fmt.Errorf("failed to set config for role %s: %w", roleConfig.name, err)
 				}
 
 				env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
@@ -77,7 +79,7 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 		}
 		_, err = cld_ops.ExecuteOperation(env, MCMSTransferOwnershipOp, deps, transferOwnershipInput)
 		if err != nil {
-			return DeployMCMSSeqOutput{}, err
+			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to transfer ownership to MCMS: %w", err)
 		}
 
 		// Generate the proposal to accept the ownership
@@ -106,7 +108,7 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 
 		acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(env, MCMSDynamicProposalGenerateSeq, deps, proposalInput)
 		if err != nil {
-			return DeployMCMSSeqOutput{}, err
+			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to generate accept ownership proposal: %w", err)
 		}
 
 		output := DeployMCMSSeqOutput{

--- a/deployment/ops/mcms/seq_deploy.go
+++ b/deployment/ops/mcms/seq_deploy.go
@@ -5,6 +5,7 @@ import (
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	"github.com/smartcontractkit/mcms"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -20,15 +21,21 @@ type DeployMCMSSeqInput struct {
 	Canceller *types.Config `json:"canceller,omitempty" yaml:"canceller,omitempty"`
 }
 
+type DeployMCMSSeqOutput struct {
+	AcceptOwnershipProposal mcms.TimelockProposal `json:"acceptOwnershipProposal"`
+	PackageId               string                `json:"packageId"`
+	Objects                 DeployMCMSObjects     `json:"objects"`
+}
+
 var DeployMCMSSequence = cld_ops.NewSequence(
 	"sui-deploy-mcms-seq",
 	semver.MustParse("0.1.0"),
-	"Deploys the MCMS package, sets the initial configuration and init the ownership transfer to self",
-	func(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input DeployMCMSSeqInput) (sui_ops.OpTxResult[DeployMCMSObjects], error) {
+	"Deploys the MCMS package, sets the initial configuration, init the ownership transfer to self and generates the proposal to accept the ownership",
+	func(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input DeployMCMSSeqInput) (DeployMCMSSeqOutput, error) {
 		// Deploy MCMS first
 		deployReport, err := cld_ops.ExecuteOperation(env, DeployMCMSOp, deps, cld_ops.EmptyInput{})
 		if err != nil {
-			return sui_ops.OpTxResult[DeployMCMSObjects]{}, err
+			return DeployMCMSSeqOutput{}, err
 		}
 
 		// Configure each timelock role if config is provided
@@ -55,7 +62,7 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 
 				_, err = cld_ops.ExecuteOperation(env, SetConfigMCMSOp, deps, setConfigInput)
 				if err != nil {
-					return sui_ops.OpTxResult[DeployMCMSObjects]{}, err
+					return DeployMCMSSeqOutput{}, err
 				}
 
 				env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
@@ -70,9 +77,44 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 		}
 		_, err = cld_ops.ExecuteOperation(env, MCMSTransferOwnershipOp, deps, transferOwnershipInput)
 		if err != nil {
-			return sui_ops.OpTxResult[DeployMCMSObjects]{}, err
+			return DeployMCMSSeqOutput{}, err
 		}
 
-		return deployReport.Output, nil
+		// Generate the proposal to accept the ownership
+		proposalInput := ProposalGenerateInput{
+			Defs: []cld_ops.Definition{
+				MCMSAcceptOwnershipOp.Def(),
+			},
+			Inputs: []any{
+				MCMSAcceptOwnershipInput{
+					McmsPackageID:   deployReport.Output.PackageId,
+					AccountObjectID: deployReport.Output.Objects.McmsAccountStateObjectId,
+				},
+			},
+			// MCMS related
+			MmcsPackageID:  deployReport.Output.PackageId,
+			McmsStateObjID: deployReport.Output.Objects.McmsMultisigStateObjectId,
+			TimelockObjID:  deployReport.Output.Objects.TimelockObjectId,
+			AccountObjID:   deployReport.Output.Objects.McmsAccountStateObjectId,
+			RegistryObjID:  deployReport.Output.Objects.McmsRegistryObjectId,
+
+			// Proposal
+			Role: suisdk.TimelockRoleProposer,
+
+			ChainSelector: uint64(input.ChainSelector),
+		}
+
+		acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(env, MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+		if err != nil {
+			return DeployMCMSSeqOutput{}, err
+		}
+
+		output := DeployMCMSSeqOutput{
+			AcceptOwnershipProposal: acceptOwnershipProposalReport.Output,
+			PackageId:               deployReport.Output.PackageId,
+			Objects:                 deployReport.Output.Objects,
+		}
+
+		return output, nil
 	},
 )

--- a/deployment/ops/mcms/seq_deploy.go
+++ b/deployment/ops/mcms/seq_deploy.go
@@ -23,7 +23,7 @@ type DeployMCMSSeqInput struct {
 var DeployMCMSSequence = cld_ops.NewSequence(
 	"sui-deploy-mcms-seq",
 	semver.MustParse("0.1.0"),
-	"Deploys and sets initial MCMS configuration",
+	"Deploys the MCMS package, sets the initial configuration and init the ownership transfer to self",
 	func(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input DeployMCMSSeqInput) (sui_ops.OpTxResult[DeployMCMSObjects], error) {
 		// Deploy MCMS first
 		deployReport, err := cld_ops.ExecuteOperation(env, DeployMCMSOp, deps, cld_ops.EmptyInput{})
@@ -60,6 +60,17 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 
 				env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
 			}
+		}
+
+		// Init the ownership transfer to self
+		transferOwnershipInput := MCMSTransferOwnershipInput{
+			McmsPackageID:   deployReport.Output.PackageId,
+			OwnerCap:        deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
+			AccountObjectID: deployReport.Output.Objects.McmsAccountStateObjectId,
+		}
+		_, err = cld_ops.ExecuteOperation(env, MCMSTransferOwnershipOp, deps, transferOwnershipInput)
+		if err != nil {
+			return sui_ops.OpTxResult[DeployMCMSObjects]{}, err
 		}
 
 		return deployReport.Output, nil

--- a/deployment/ops/mcms/seq_deploy_test.go
+++ b/deployment/ops/mcms/seq_deploy_test.go
@@ -54,11 +54,16 @@ func TestDeployMCMSSeq(t *testing.T) {
 		},
 	}
 
+	registry := cld_ops.NewOperationRegistry(
+		MCMSAcceptOwnershipOp.AsUntyped(),
+	)
+
 	reporter := cld_ops.NewMemoryReporter()
 	bundle := cld_ops.NewBundle(
 		context.Background,
 		logger.Test(t),
 		reporter,
+		cld_ops.WithOperationRegistry(registry),
 	)
 
 	// Generate sorted signers for testing (similar to Test_Sui_SetConfig)
@@ -176,6 +181,6 @@ func TestDeployMCMSSeq(t *testing.T) {
 	require.NotEmpty(t, objects.McmsRegistryObjectId, "MCMS Registry Object ID should not be empty")
 	require.NotEmpty(t, objects.McmsAccountStateObjectId, "MCMS Account State Object ID should not be empty")
 	require.NotEmpty(t, objects.McmsAccountOwnerCapObjectId, "MCMS Account Owner Cap Object ID should not be empty")
-	require.NotEmpty(t, report.Output.Digest, "Transaction digest should not be empty")
 	require.NotEmpty(t, report.Output.PackageId, "Package ID should not be empty")
+	require.NotEmpty(t, report.Output.AcceptOwnershipProposal, "Accept Ownership Proposal should not be empty")
 }

--- a/deployment/ops/ownership/seq_accept_ccip_ownership.go
+++ b/deployment/ops/ownership/seq_accept_ccip_ownership.go
@@ -1,0 +1,107 @@
+package ownershipops
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/mcms"
+
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
+)
+
+type AcceptCCIPOwnershipInput struct {
+	// MCMS related
+	MCMSPackageId     string
+	MCMSStateObjId    string
+	MCMSTimelockObjId string
+	MCMSAccountObjId  string
+	MCMSRegistryObjId string
+
+	// Proposal
+	Role          suisdk.TimelockRole
+	ChainSelector uint64
+
+	// CCIP related
+	CCIPPackageId string
+	CCIPObjectRef string
+
+	// Router related
+	RouterPackageId     string
+	RouterStateObjectId string
+
+	// OnRamp related
+	OnRampPackageId     string
+	OnRampStateObjectId string
+
+	// OffRamp related
+	OffRampPackageId     string
+	OffRampStateObjectId string
+}
+
+var AcceptCCIPOwnershipSeq = cld_ops.NewSequence(
+	"sui-accept-ownership-ccip-seq",
+	semver.MustParse("0.1.0"),
+	"Creates accept ownership proposal from MCMS for every CCIP contract",
+	func(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptCCIPOwnershipInput) (mcms.TimelockProposal, error) {
+		// Generate the proposal to accept the ownership of the deployed contracts
+		proposalInput := mcmsops.ProposalGenerateInput{
+			Defs: []operations.Definition{
+				ccipops.AcceptOwnershipStateObjectOp.Def(),
+				routerops.AcceptOwnershipOp.Def(),
+				onrampops.AcceptOwnershipOnRampOp.Def(),
+				offrampops.AcceptOwnershipOffRampOp.Def(),
+			},
+			Inputs: []any{
+				ccipops.AcceptOwnershipStateObjectInput{
+					CCIPPackageId:         input.CCIPPackageId,
+					CCIPObjectRefObjectId: input.CCIPObjectRef,
+				},
+				routerops.AcceptOwnershipInput{
+					RouterPackageId:     input.RouterPackageId,
+					RouterStateObjectId: input.RouterStateObjectId,
+				},
+				onrampops.AcceptOwnershipOnRampInput{
+					OnRampPackageId: input.OnRampPackageId,
+					CCIPObjectRefId: input.CCIPObjectRef,
+					StateObjectId:   input.OnRampStateObjectId,
+				},
+				offrampops.AcceptOwnershipOffRampInput{
+					OffRampPackageId:     input.OffRampPackageId,
+					OffRampRefObjectId:   input.CCIPObjectRef,
+					OffRampStateObjectId: input.OffRampStateObjectId,
+				},
+			},
+			// MCMS related
+			MmcsPackageID:  input.MCMSPackageId,
+			McmsStateObjID: input.MCMSStateObjId,
+			TimelockObjID:  input.MCMSTimelockObjId,
+			AccountObjID:   input.MCMSAccountObjId,
+			RegistryObjID:  input.MCMSRegistryObjId,
+
+			// Proposal
+			Role: input.Role,
+
+			ChainSelector: input.ChainSelector,
+		}
+
+		jsonbytes, _ := json.MarshalIndent(proposalInput, "", " ")
+		fmt.Println("Accept CCIP Ownership Proposal Input: ", string(jsonbytes))
+
+		acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(env, mcmsops.MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+		if err != nil {
+			return mcms.TimelockProposal{}, err
+		}
+
+		return acceptOwnershipProposalReport.Output, nil
+	},
+)

--- a/deployment/ops/ownership/seq_execute_ownership_transfer_to_mcms.go
+++ b/deployment/ops/ownership/seq_execute_ownership_transfer_to_mcms.go
@@ -1,0 +1,198 @@
+package ownershipops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	burnminttokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_burn_mint_token_pool"
+	lockreleasetokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_lock_release_token_pool"
+	managedtokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_managed_token_pool"
+	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
+	usdctokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_usdc_token_pool"
+	managedtokenops "github.com/smartcontractkit/chainlink-sui/deployment/ops/managed_token"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+)
+
+// ContractType represents the different contract types that support ownership transfer to MCMS
+type ContractType string
+
+const (
+	ContractTypeStateObject          ContractType = "state_object"
+	ContractTypeOnRamp               ContractType = "onramp"
+	ContractTypeOffRamp              ContractType = "offramp"
+	ContractTypeRouter               ContractType = "router"
+	ContractTypeManagedToken         ContractType = "managed_token"
+	ContractTypeBurnMintTokenPool    ContractType = "burn_mint_token_pool"
+	ContractTypeLockReleaseTokenPool ContractType = "lock_release_token_pool"
+	ContractTypeUsdcTokenPool        ContractType = "usdc_token_pool"
+	ContractTypeManagedTokenPool     ContractType = "managed_token_pool"
+	ContractTypeMCMS                 ContractType = "mcms"
+)
+
+type ExecuteOwnershipTransferToMcmsSeqInput struct {
+	// Specific input for each contract type - only include the ones you want to transfer
+	MCMS                 *mcmsops.MCMSExecuteTransferOwnershipInput                                       `json:"mcms,omitempty"`
+	StateObject          *ccipops.ExecuteOwnershipTransferToMcmsStateObjectInput                          `json:"state_object,omitempty"`
+	OnRamp               *onrampops.ExecuteOwnershipTransferToMcmsOnRampInput                             `json:"onramp,omitempty"`
+	OffRamp              *offrampops.ExecuteOwnershipTransferToMcmsOffRampInput                           `json:"offramp,omitempty"`
+	Router               *routerops.ExecuteOwnershipTransferToMcmsRouterInput                             `json:"router,omitempty"`
+	ManagedToken         *managedtokenops.ExecuteOwnershipTransferToMcmsManagedTokenInput                 `json:"managed_token,omitempty"`
+	BurnMintTokenPool    *burnminttokenpoolops.ExecuteOwnershipTransferToMcmsBurnMintTokenPoolInput       `json:"burn_mint_token_pool,omitempty"`
+	LockReleaseTokenPool *lockreleasetokenpoolops.ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolInput `json:"lock_release_token_pool,omitempty"`
+	UsdcTokenPool        *usdctokenpoolops.ExecuteOwnershipTransferToMcmsUsdcTokenPoolInput               `json:"usdc_token_pool,omitempty"`
+	ManagedTokenPool     *managedtokenpoolops.ExecuteOwnershipTransferToMcmsManagedTokenPoolInput         `json:"managed_token_pool,omitempty"`
+}
+
+type ExecuteOwnershipTransferToMcmsSeqOutput struct {
+	// Map of contract type to execution results
+	Results map[ContractType]string // Transaction digests
+}
+
+var ExecuteOwnershipTransferToMcmsSequence = cld_ops.NewSequence(
+	"sui-execute-ownership-transfer-to-mcms-seq",
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer to MCMS for specified CCIP contracts",
+	func(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferToMcmsSeqInput) (ExecuteOwnershipTransferToMcmsSeqOutput, error) {
+		results := make(map[ContractType]string)
+
+		// Execute MCMS ownership transfer if provided
+		if input.MCMS != nil {
+			report, err := cld_ops.ExecuteOperation(env, mcmsops.MCMSExecuteTransferOwnershipOp, deps, *input.MCMS)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for MCMS: %w", err)
+			}
+			results[ContractTypeMCMS] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for MCMS",
+				"packageId", input.MCMS.McmsPackageID,
+				"to", input.MCMS.McmsPackageID,
+				"digest", report.Output.Digest)
+		}
+		// Execute StateObject ownership transfer if provided
+		if input.StateObject != nil {
+			report, err := cld_ops.ExecuteOperation(env, ccipops.ExecuteOwnershipTransferToMcmsStateObjectOp, deps, *input.StateObject)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for StateObject: %w", err)
+			}
+			results[ContractTypeStateObject] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for StateObject",
+				"packageId", input.StateObject.CCIPPackageId,
+				"to", input.StateObject.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute OnRamp ownership transfer if provided
+		if input.OnRamp != nil {
+			report, err := cld_ops.ExecuteOperation(env, onrampops.ExecuteOwnershipTransferToMcmsOnRampOp, deps, *input.OnRamp)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for OnRamp: %w", err)
+			}
+			results[ContractTypeOnRamp] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for OnRamp",
+				"packageId", input.OnRamp.OnRampPackageId,
+				"to", input.OnRamp.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute OffRamp ownership transfer if provided
+		if input.OffRamp != nil {
+			report, err := cld_ops.ExecuteOperation(env, offrampops.ExecuteOwnershipTransferToMcmsOffRampOp, deps, *input.OffRamp)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for OffRamp: %w", err)
+			}
+			results[ContractTypeOffRamp] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for OffRamp",
+				"packageId", input.OffRamp.OffRampPackageId,
+				"to", input.OffRamp.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute Router ownership transfer if provided
+		if input.Router != nil {
+			report, err := cld_ops.ExecuteOperation(env, routerops.ExecuteOwnershipTransferToMcmsRouterOp, deps, *input.Router)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for Router: %w", err)
+			}
+			results[ContractTypeRouter] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for Router",
+				"packageId", input.Router.RouterPackageId,
+				"to", input.Router.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute ManagedToken ownership transfer if provided
+		if input.ManagedToken != nil {
+			report, err := cld_ops.ExecuteOperation(env, managedtokenops.ExecuteOwnershipTransferToMcmsManagedTokenOp, deps, *input.ManagedToken)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for ManagedToken: %w", err)
+			}
+			results[ContractTypeManagedToken] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for ManagedToken",
+				"packageId", input.ManagedToken.ManagedTokenPackageId,
+				"to", input.ManagedToken.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute BurnMintTokenPool ownership transfer if provided
+		if input.BurnMintTokenPool != nil {
+			report, err := cld_ops.ExecuteOperation(env, burnminttokenpoolops.ExecuteOwnershipTransferToMcmsBurnMintTokenPoolOp, deps, *input.BurnMintTokenPool)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for BurnMintTokenPool: %w", err)
+			}
+			results[ContractTypeBurnMintTokenPool] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for BurnMintTokenPool",
+				"packageId", input.BurnMintTokenPool.BurnMintTokenPoolPackageId,
+				"to", input.BurnMintTokenPool.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute LockReleaseTokenPool ownership transfer if provided
+		if input.LockReleaseTokenPool != nil {
+			report, err := cld_ops.ExecuteOperation(env, lockreleasetokenpoolops.ExecuteOwnershipTransferToMcmsLockReleaseTokenPoolOp, deps, *input.LockReleaseTokenPool)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for LockReleaseTokenPool: %w", err)
+			}
+			results[ContractTypeLockReleaseTokenPool] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for LockReleaseTokenPool",
+				"packageId", input.LockReleaseTokenPool.LockReleaseTokenPoolPackageId,
+				"to", input.LockReleaseTokenPool.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute UsdcTokenPool ownership transfer if provided
+		if input.UsdcTokenPool != nil {
+			report, err := cld_ops.ExecuteOperation(env, usdctokenpoolops.ExecuteOwnershipTransferToMcmsUsdcTokenPoolOp, deps, *input.UsdcTokenPool)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for UsdcTokenPool: %w", err)
+			}
+			results[ContractTypeUsdcTokenPool] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for UsdcTokenPool",
+				"packageId", input.UsdcTokenPool.UsdcTokenPoolPackageId,
+				"to", input.UsdcTokenPool.To,
+				"digest", report.Output.Digest)
+		}
+
+		// Execute ManagedTokenPool ownership transfer if provided
+		if input.ManagedTokenPool != nil {
+			report, err := cld_ops.ExecuteOperation(env, managedtokenpoolops.ExecuteOwnershipTransferToMcmsManagedTokenPoolOp, deps, *input.ManagedTokenPool)
+			if err != nil {
+				return ExecuteOwnershipTransferToMcmsSeqOutput{}, fmt.Errorf("failed to execute ownership transfer for ManagedTokenPool: %w", err)
+			}
+			results[ContractTypeManagedTokenPool] = report.Output.Digest
+			env.Logger.Infow("Successfully executed ownership transfer to MCMS for ManagedTokenPool",
+				"packageId", input.ManagedTokenPool.ManagedTokenPoolPackageId,
+				"to", input.ManagedTokenPool.To,
+				"digest", report.Output.Digest)
+		}
+
+		return ExecuteOwnershipTransferToMcmsSeqOutput{
+			Results: results,
+		}, nil
+	},
+)

--- a/deployment/ops/registry/op_registry.go
+++ b/deployment/ops/registry/op_registry.go
@@ -6,6 +6,7 @@ import (
 	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
 	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
 	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 )
 
 // Exports every operation available so they can be registered to be used in dynamic changesets
@@ -17,6 +18,9 @@ var AllOperations = func() []cld_ops.Operation[any, any, any] {
 	operations = append(operations, offrampops.AllOperationsOfframp...)
 	operations = append(operations, onrampops.AllOperationsOnramp...)
 	operations = append(operations, routerops.AllOperationsRouter...)
+
+	// MCMS Operations
+	operations = append(operations, mcmsops.AllOperationsMCMS...)
 
 	// Add more operation slices here as needed:
 	// operations = append(operations, anotherops.AllOperations...)

--- a/deployment/ops/registry/op_registry.go
+++ b/deployment/ops/registry/op_registry.go
@@ -3,6 +3,9 @@ package opregistry
 import (
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 )
 
 // Exports every operation available so they can be registered to be used in dynamic changesets
@@ -10,10 +13,10 @@ var AllOperations = func() []cld_ops.Operation[any, any, any] {
 	var operations []cld_ops.Operation[any, any, any]
 
 	// Add CCIP operations
-	operations = append(operations, ccipops.AllOperationsFeeQuoter...)
-	operations = append(operations, ccipops.AllOperationsStateObject...)
-	operations = append(operations, ccipops.AllOperationsTokenAdminRegistry...)
-	operations = append(operations, ccipops.AllOperationsUpgradeRegistry...)
+	operations = append(operations, ccipops.AllOperationsCCIP...)
+	operations = append(operations, offrampops.AllOperationsOfframp...)
+	operations = append(operations, onrampops.AllOperationsOnramp...)
+	operations = append(operations, routerops.AllOperationsRouter...)
 
 	// Add more operation slices here as needed:
 	// operations = append(operations, anotherops.AllOperations...)

--- a/deployment/ops/registry/op_registry.go
+++ b/deployment/ops/registry/op_registry.go
@@ -22,6 +22,7 @@ var AllOperations = func() []cld_ops.Operation[any, any, any] {
 	// MCMS Operations
 	operations = append(operations, mcmsops.AllOperationsMCMS...)
 
+	operations = append(operations, *mcmsops.AddModulesMCMSOp.AsUntyped())
 	// Add more operation slices here as needed:
 	// operations = append(operations, anotherops.AllOperations...)
 

--- a/deployment/state.go
+++ b/deployment/state.go
@@ -8,12 +8,24 @@ import (
 )
 
 type CCIPChainState struct {
-	CCIPRouterAddress            string
-	CCIPAddress                  string
-	CCIPObjectRef                string
-	CCIPOwnerCapObjectId         string
-	CCIPUpgradeCapObjectId       string
-	MCMsAddress                  string
+	// MCMS related
+	MCMSPackageID               string
+	MCMSStateObjectID           string
+	MCMSRegistryObjectID        string
+	MCMSAccountStateObjectID    string
+	MCMSAccountOwnerCapObjectID string
+	MCMSTimelockObjectID        string
+
+	// CCIP related
+	CCIPAddress            string
+	CCIPObjectRef          string
+	CCIPOwnerCapObjectId   string
+	CCIPUpgradeCapObjectId string
+
+	// CCIP Router related
+	CCIPRouterAddress       string
+	CCIPRouterStateObjectID string
+
 	TokenPoolAddress             string
 	LockReleaseAddress           string
 	LockReleaseStateId           string
@@ -66,6 +78,34 @@ func loadsuiChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) (C
 		// Parse addresss
 
 		switch typeAndVersion.Type {
+
+		// MCMS related
+		case SuiMcmsPackageIDType:
+			chainState.MCMSPackageID = addr
+
+		case SuiMcmsRegistryObjectIDType:
+			chainState.MCMSRegistryObjectID = addr
+
+		case SuiMcmsObjectIDType:
+			chainState.MCMSStateObjectID = addr
+
+		case SuiMcmsAccountStateObjectIDType:
+			chainState.MCMSAccountStateObjectID = addr
+
+		case SuiMcmsAccountOwnerCapObjectIDType:
+			chainState.MCMSAccountOwnerCapObjectID = addr
+
+		case SuiMcmsTimelockObjectIDType:
+			chainState.MCMSTimelockObjectID = addr
+
+		// CCIP Router related
+		case SuiCCIPRouterType:
+			chainState.CCIPRouterAddress = addr
+
+		case SuiCCIPRouterStateObjectType:
+			chainState.CCIPRouterStateObjectID = addr
+
+		// CCIP related
 		case SuiCCIPRouterType:
 			chainState.CCIPRouterAddress = addr
 
@@ -77,9 +117,6 @@ func loadsuiChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) (C
 
 		case SuiLockReleaseTPStateType:
 			chainState.LockReleaseStateId = addr
-
-		case SuiMcmsPackageIDType:
-			chainState.MCMsAddress = addr
 
 		case SuiCCIPObjectRefType:
 			chainState.CCIPObjectRef = addr
@@ -135,6 +172,7 @@ func loadsuiChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) (C
 		case SuiBnMTokenPoolOwnerIDType:
 			chainState.CCIPBurnMintTokenPoolOwnerId = addr
 		}
+
 		// Set address based on type
 	}
 	return chainState, nil

--- a/deployment/types.go
+++ b/deployment/types.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	SuiCCIPRouterType                deployment.ContractType = "SuiRouter"
+	SuiCCIPRouterStateObjectType     deployment.ContractType = "SuiRouterStateObjectID"
 	SuiCCIPType                      deployment.ContractType = "SuiCCIP"
 	SuiCCIPObjectRefType             deployment.ContractType = "SuiCCIPObjectRef"
 	SuiCCIPOwnerCapObjectIDType      deployment.ContractType = "SuiCCIPOwnerCapObjectID"

--- a/integration-tests/mcms/common.go
+++ b/integration-tests/mcms/common.go
@@ -155,6 +155,20 @@ func (s *MCMSTestSuite) SetupSuite() {
 
 	s.deps = deps
 	s.bundle = bundle
+
+	// Accept MCMS ownership to itself
+	acceptProposal := mcmsDeploymentReport.Output.AcceptOwnershipProposal
+	// Execute the proposal to accept ownership
+	s.ExecuteProposalE2e(&acceptProposal, s.proposerConfig, 0)
+
+	rep, err := cld_ops.ExecuteOperation(s.bundle, mcmsops.MCMSExecuteTransferOwnershipOp, s.deps, mcmsops.MCMSExecuteTransferOwnershipInput{
+		McmsPackageID:    s.mcmsPackageID,
+		OwnerCap:         s.ownerCapObj,
+		AccountObjectID:  s.accountObj,
+		RegistryObjectID: s.registryObj,
+	})
+	s.Require().NoError(err, "executing ownership transfer to self")
+	s.T().Logf("✅ Transferred ownership of MCMS to itself in tx: %s", rep.Output.Digest)
 }
 
 func (s *MCMSTestSuite) SignProposal(proposal *mcms.Proposal, roleConfig *RoleConfig) {

--- a/integration-tests/mcms/mcms_test.go
+++ b/integration-tests/mcms/mcms_test.go
@@ -4,6 +4,7 @@ package mcms
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"testing"
 
 	cselectors "github.com/smartcontractkit/chain-selectors"
@@ -14,6 +15,7 @@ import (
 	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
 	module_onramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/onramp"
 	module_router "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_router"
+	module_mcms_account "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms_account"
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
 	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
@@ -198,6 +200,59 @@ func (s *CCIPMCMSTestSuite) Test_CCIP_MCMS() {
 // TODO: For prod env, the initial deployment sequence should start the ownership transfer flow of every deployed contract
 func RunTestCCIPOwnershipTransfer(s *CCIPMCMSTestSuite) {
 	// 1a. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
+
+	// Transfer MCMS ownership to itself
+	{
+		mcmsAccount, err := module_mcms_account.NewMcmsAccount(s.mcmsPackageID, s.client)
+		s.Require().NoError(err, "creating MCMS account contract")
+		tx, err := mcmsAccount.TransferOwnershipToSelf(
+			s.T().Context(),
+			&bind.CallOpts{
+				Signer:           s.signer,
+				WaitForExecution: true,
+			},
+			bind.Object{Id: s.ownerCapObj},
+			bind.Object{Id: s.accountObj},
+		)
+		s.Require().NoError(err, "Failed to transfer ownership to self")
+		s.Require().NotEmpty(tx, "Transaction should not be empty")
+	}
+
+	// 0. Register CCIP module in MCMS registry
+	addModulesProposalInput := mcmsops.ProposalGenerateInput{
+		Defs: []cld_ops.Definition{
+			mcmsops.AddModulesMCMSOp.Def(),
+		},
+		Inputs: []any{
+			mcmsops.AddModulesMCMSInput{
+				MCMSPackageId:     s.mcmsPackageID,
+				MCMSRegistryObjId: s.registryObj,
+				AllowedModules:    []string{"ccip"},
+			},
+		},
+		// MCMS related
+		MmcsPackageID:  s.mcmsPackageID,
+		McmsStateObjID: s.mcmsObj,
+		TimelockObjID:  s.timelockObj,
+		AccountObjID:   s.accountObj,
+		RegistryObjID:  s.registryObj,
+
+		// Proposal
+		Role:          suisdk.TimelockRoleBypasser,
+		ChainSelector: uint64(s.chainSelector),
+	}
+	addModulesProposalReport, err := cld_ops.ExecuteSequence(s.bundle, mcmsops.MCMSDynamicProposalGenerateSeq, s.deps, addModulesProposalInput)
+	s.Require().NoError(err, "executing add modules proposal sequence")
+
+	addModulesProposal := addModulesProposalReport.Output
+
+	proposalJson, _ := json.MarshalIndent(addModulesProposal, "", "  ")
+	s.T().Logf("Add Modules Proposal: %s", string(proposalJson))
+
+	// Execute the proposal to add CCIP module to the registry
+	s.ExecuteProposalE2e(&addModulesProposal, s.bypasserConfig, 0)
+
+	// 1. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
 	ccipContract, err := module_state_object.NewStateObject(s.ccipPackageId, s.client)
 	require.NoError(s.T(), err, "creating ccip state object contract")
 

--- a/integration-tests/mcms/mcms_test.go
+++ b/integration-tests/mcms/mcms_test.go
@@ -6,12 +6,21 @@ import (
 	"encoding/hex"
 	"testing"
 
+	cselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	module_state_object "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/state_object"
+	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
+	module_onramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/onramp"
+	module_router "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_router"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
+	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
+	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 	linkops "github.com/smartcontractkit/chainlink-sui/deployment/ops/link"
-	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	ownershipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ownership"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/stretchr/testify/require"
 )
@@ -19,8 +28,21 @@ import (
 type CCIPMCMSTestSuite struct {
 	MCMSTestSuite
 
+	// CCIP
 	ccipPackageId string
 	ccipObjects   ccipops.DeployCCIPSeqObjects
+
+	// Router
+	ccipRouterPackageId string
+	ccipRouterObjects   routerops.DeployCCIPRouterObjects
+
+	// Onramp
+	ccipOnrampPackageId string
+	ccipOnrampObjects   onrampops.DeployCCIPOnRampSeqObjects
+
+	// offramp
+	ccipOfframpPackageId string
+	ccipOfframpObjects   offrampops.DeployCCIPOffRampSeqObjects
 }
 
 func (s *CCIPMCMSTestSuite) SetupSuite() {
@@ -51,7 +73,7 @@ func (s *CCIPMCMSTestSuite) SetupSuite() {
 	require.NoError(s.T(), err, "failed to decode public key 4")
 
 	// Use the same seq as in production deployment
-	report, err := cld_ops.ExecuteSequence(s.bundle, ccipops.DeployAndInitCCIPSequence, s.deps, ccipops.DeployAndInitCCIPSeqInput{
+	ccipReport, err := cld_ops.ExecuteSequence(s.bundle, ccipops.DeployAndInitCCIPSequence, s.deps, ccipops.DeployAndInitCCIPSeqInput{
 		LinkTokenCoinMetadataObjectId: linkReport.Output.Objects.CoinMetadataObjectId,
 		LocalChainSelector:            1,
 		DestChainSelector:             2,
@@ -98,10 +120,69 @@ func (s *CCIPMCMSTestSuite) SetupSuite() {
 		FSign:                       uint64(1),
 	})
 	require.NoError(s.T(), err, "failed to execute CCIP deploy sequence")
-	require.NotEmpty(s.T(), report.Output.CCIPPackageId, "CCIP package ID should not be empty")
+	require.NotEmpty(s.T(), ccipReport.Output.CCIPPackageId, "CCIP package ID should not be empty")
 
-	s.ccipPackageId = report.Output.CCIPPackageId
-	s.ccipObjects = report.Output.Objects
+	s.ccipPackageId = ccipReport.Output.CCIPPackageId
+	s.ccipObjects = ccipReport.Output.Objects
+
+	// Deploy Router
+	routerReport, err := cld_ops.ExecuteOperation(s.bundle, routerops.DeployCCIPRouterOp, s.deps, routerops.DeployCCIPRouterInput{
+		McmsPackageId: s.mcmsPackageID,
+		McmsOwner:     s.mcmsOwnerAddress,
+	})
+	require.NoError(s.T(), err, "failed to execute CCIP deploy sequence")
+
+	s.ccipRouterPackageId = routerReport.Output.PackageId
+	s.ccipRouterObjects = routerReport.Output.Objects
+
+	// Deploy Onramp
+	ccipOnRampSeqInput := deployment.DefaultOnRampSeqConfig
+	ccipOnRampSeqInput.DeployCCIPOnRampInput.CCIPPackageId = ccipReport.Output.CCIPPackageId
+	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSPackageId = s.mcmsPackageID
+	ccipOnRampSeqInput.DeployCCIPOnRampInput.MCMSOwnerPackageId = s.mcmsOwnerAddress
+	ccipOnRampSeqInput.OnRampInitializeInput.NonceManagerCapId = ccipReport.Output.Objects.NonceManagerCapObjectId
+	ccipOnRampSeqInput.OnRampInitializeInput.SourceTransferCapId = ccipReport.Output.Objects.SourceTransferCapObjectId
+	ccipOnRampSeqInput.OnRampInitializeInput.ChainSelector = uint64(s.chainSelector)
+	ccipOnRampSeqInput.OnRampInitializeInput.FeeAggregator = s.mcmsOwnerAddress
+	ccipOnRampSeqInput.OnRampInitializeInput.AllowListAdmin = s.mcmsOwnerAddress
+	ccipOnRampSeqInput.OnRampInitializeInput.DestChainSelectors = []uint64{cselectors.ETHEREUM_MAINNET.Selector}
+	ccipOnRampSeqInput.OnRampInitializeInput.DestChainRouters = []string{routerReport.Output.PackageId}
+	ccipOnRampSeqInput.ApplyDestChainConfigureOnRampInput.DestChainSelector = []uint64{cselectors.ETHEREUM_MAINNET.Selector}
+	ccipOnRampSeqInput.ApplyAllowListUpdatesInput.DestChainSelector = []uint64{cselectors.ETHEREUM_MAINNET.Selector}
+	ccipOnRampSeqInput.ApplyDestChainConfigureOnRampInput.DestChainRouters = []string{routerReport.Output.PackageId}
+	ccipOnRampSeqInput.ApplyDestChainConfigureOnRampInput.CCIPObjectRefId = ccipReport.Output.Objects.CCIPObjectRefObjectId
+
+	ccipOnRampSeqReport, err := operations.ExecuteSequence(s.bundle, onrampops.DeployAndInitCCIPOnRampSequence, s.deps, ccipOnRampSeqInput)
+	require.NoError(s.T(), err, "failed to execute CCIP OnRamp deploy sequence")
+
+	s.ccipOnrampPackageId = ccipOnRampSeqReport.Output.CCIPOnRampPackageId
+	s.ccipOnrampObjects = ccipOnRampSeqReport.Output.Objects
+
+	// Deploy offramp
+	ccipOffRampSeqInput := deployment.DefaultOffRampSeqConfig
+	// note: this is a regression, can't acess other chains state very cleanly
+	onRampBytes := [][]byte{
+		{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+	}
+
+	// Inject dynamic values for deployment
+	ccipOffRampSeqInput.CCIPObjectRefId = ccipReport.Output.Objects.CCIPObjectRefObjectId
+	ccipOffRampSeqInput.DeployCCIPOffRampInput.CCIPPackageId = ccipReport.Output.CCIPPackageId
+	ccipOffRampSeqInput.DeployCCIPOffRampInput.MCMSPackageId = s.mcmsPackageID
+
+	ccipOffRampSeqInput.InitializeOffRampInput.DestTransferCapId = ccipReport.Output.Objects.DestTransferCapObjectId
+	ccipOffRampSeqInput.InitializeOffRampInput.FeeQuoterCapId = ccipReport.Output.Objects.FeeQuoterCapObjectId
+	ccipOffRampSeqInput.InitializeOffRampInput.ChainSelector = uint64(s.chainSelector)
+	ccipOffRampSeqInput.InitializeOffRampInput.SourceChainSelectors = []uint64{
+		cselectors.ETHEREUM_MAINNET.Selector,
+	}
+	ccipOffRampSeqInput.InitializeOffRampInput.SourceChainsOnRamp = onRampBytes
+
+	ccipOffRampSeqReport, err := operations.ExecuteSequence(s.bundle, offrampops.DeployAndInitCCIPOffRampSequence, s.deps, ccipOffRampSeqInput)
+	require.NoError(s.T(), err, "failed to execute CCIP OffRamp deploy sequence")
+
+	s.ccipOfframpPackageId = ccipOffRampSeqReport.Output.CCIPOffRampPackageId
+	s.ccipOfframpObjects = ccipOffRampSeqReport.Output.Objects
 }
 
 func (s *CCIPMCMSTestSuite) Test_CCIP_MCMS() {
@@ -116,7 +197,7 @@ func (s *CCIPMCMSTestSuite) Test_CCIP_MCMS() {
 
 // TODO: For prod env, the initial deployment sequence should start the ownership transfer flow of every deployed contract
 func RunTestCCIPOwnershipTransfer(s *CCIPMCMSTestSuite) {
-	// 1. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
+	// 1a. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
 	ccipContract, err := module_state_object.NewStateObject(s.ccipPackageId, s.client)
 	require.NoError(s.T(), err, "creating ccip state object contract")
 
@@ -128,7 +209,6 @@ func RunTestCCIPOwnershipTransfer(s *CCIPMCMSTestSuite) {
 		},
 		bind.Object{Id: s.ccipObjects.CCIPObjectRefObjectId},
 		bind.Object{Id: s.ccipObjects.OwnerCapObjectId},
-		// TODO: not sure which address should be
 		s.mcmsPackageID,
 	)
 	require.NoError(s.T(), err, "transferring ownership of CCIP to MCMS")
@@ -136,30 +216,90 @@ func RunTestCCIPOwnershipTransfer(s *CCIPMCMSTestSuite) {
 
 	s.T().Logf("✅ Transferred ownership of CCIP to MCMS in tx: %s", tx.Digest)
 
-	// 2. Proposal execution with acceptance from MCMS (through proposer)
-	input := mcmsops.ProposalGenerateInput{
-		Defs: []cld_ops.Definition{
-			ccipops.AcceptOwnershipStateObjectOp.Def(),
+	// 1b. Transfer ownership of the CCIP Router to MCMS
+	ccipRouterContract, err := module_router.NewRouter(s.ccipRouterPackageId, s.client)
+	require.NoError(s.T(), err, "creating ccip router contract")
+
+	tx, err = ccipRouterContract.TransferOwnership(
+		s.T().Context(),
+		&bind.CallOpts{
+			Signer:           s.signer,
+			WaitForExecution: true,
 		},
-		Inputs: []any{
-			ccipops.AcceptOwnershipStateObjectInput{
-				CCIPPackageId:         s.ccipPackageId,
-				CCIPObjectRefObjectId: s.ccipObjects.CCIPObjectRefObjectId,
-			},
+		bind.Object{Id: s.ccipRouterObjects.RouterStateObjectId},
+		bind.Object{Id: s.ccipRouterObjects.OwnerCapObjectId},
+		s.mcmsPackageID,
+	)
+	require.NoError(s.T(), err, "transferring ownership of CCIP Router to MCMS")
+	require.NotEmpty(s.T(), tx, "Transaction should not be empty")
+
+	s.T().Logf("✅ Transferred ownership of CCIP Router to MCMS in tx: %s", tx.Digest)
+
+	// 1c. Transfer ownership of the CCIP OnRamp to MCMS
+	ccipOnRampContract, err := module_onramp.NewOnramp(s.ccipOnrampPackageId, s.client)
+	require.NoError(s.T(), err, "creating ccip onramp contract")
+
+	tx, err = ccipOnRampContract.TransferOwnership(
+		s.T().Context(),
+		&bind.CallOpts{
+			Signer:           s.signer,
+			WaitForExecution: true,
 		},
+		bind.Object{Id: s.ccipObjects.CCIPObjectRefObjectId},
+		bind.Object{Id: s.ccipOnrampObjects.StateObjectId},
+		bind.Object{Id: s.ccipOnrampObjects.OwnerCapObjectId},
+		s.mcmsPackageID,
+	)
+	require.NoError(s.T(), err, "transferring ownership of CCIP OnRamp to MCMS")
+	require.NotEmpty(s.T(), tx, "Transaction should not be empty")
+
+	s.T().Logf("✅ Transferred ownership of CCIP OnRamp to MCMS in tx: %s", tx.Digest)
+
+	// 1d. Transfer ownership of the CCIP OffRamp to MCMS
+	ccipOffRampContract, err := module_offramp.NewOfframp(s.ccipOfframpPackageId, s.client)
+	require.NoError(s.T(), err, "creating ccip offramp contract")
+
+	tx, err = ccipOffRampContract.TransferOwnership(
+		s.T().Context(),
+		&bind.CallOpts{
+			Signer:           s.signer,
+			WaitForExecution: true,
+		},
+		bind.Object{Id: s.ccipObjects.CCIPObjectRefObjectId},
+		bind.Object{Id: s.ccipOfframpObjects.StateObjectId},
+		bind.Object{Id: s.ccipOfframpObjects.OwnerCapId},
+		s.mcmsPackageID,
+	)
+	require.NoError(s.T(), err, "transferring ownership of CCIP OffRamp to MCMS")
+	require.NotEmpty(s.T(), tx, "Transaction should not be empty")
+
+	// 2. Proposal execution with acceptance from MCMS (through bypasser)
+	input := ownershipops.AcceptCCIPOwnershipInput{
 		// MCMS related
-		MmcsPackageID:  s.mcmsPackageID,
-		McmsStateObjID: s.mcmsObj,
-		TimelockObjID:  s.timelockObj,
-		AccountObjID:   s.accountObj,
-		RegistryObjID:  s.registryObj,
+		MCMSPackageId:     s.mcmsPackageID,
+		MCMSStateObjId:    s.mcmsObj,
+		MCMSTimelockObjId: s.timelockObj,
+		MCMSAccountObjId:  s.accountObj,
+		MCMSRegistryObjId: s.registryObj,
+
+		CCIPPackageId: s.ccipPackageId,
+		CCIPObjectRef: s.ccipObjects.CCIPObjectRefObjectId,
+
+		RouterPackageId:     s.ccipRouterPackageId,
+		RouterStateObjectId: s.ccipRouterObjects.RouterStateObjectId,
+
+		OnRampPackageId:     s.ccipOnrampPackageId,
+		OnRampStateObjectId: s.ccipOnrampObjects.StateObjectId,
+
+		OffRampPackageId:     s.ccipOfframpPackageId,
+		OffRampStateObjectId: s.ccipOfframpObjects.StateObjectId,
 
 		// Proposal
 		Role: suisdk.TimelockRoleBypasser,
 
 		ChainSelector: uint64(s.chainSelector),
 	}
-	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(s.bundle, mcmsops.MCMSDynamicProposalGenerateSeq, s.deps, input)
+	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(s.bundle, ownershipops.AcceptCCIPOwnershipSeq, s.deps, input)
 	s.Require().NoError(err, "executing ownership acceptance proposal sequence")
 
 	timelockProposal := acceptOwnershipProposalReport.Output

--- a/integration-tests/mcms/mcms_test.go
+++ b/integration-tests/mcms/mcms_test.go
@@ -4,7 +4,6 @@ package mcms
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"testing"
 
 	cselectors "github.com/smartcontractkit/chain-selectors"
@@ -15,7 +14,6 @@ import (
 	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
 	module_onramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_onramp/onramp"
 	module_router "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_router"
-	module_mcms_account "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms_account"
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
 	offrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
@@ -200,57 +198,6 @@ func (s *CCIPMCMSTestSuite) Test_CCIP_MCMS() {
 // TODO: For prod env, the initial deployment sequence should start the ownership transfer flow of every deployed contract
 func RunTestCCIPOwnershipTransfer(s *CCIPMCMSTestSuite) {
 	// 1a. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
-
-	// Transfer MCMS ownership to itself
-	{
-		mcmsAccount, err := module_mcms_account.NewMcmsAccount(s.mcmsPackageID, s.client)
-		s.Require().NoError(err, "creating MCMS account contract")
-		tx, err := mcmsAccount.TransferOwnershipToSelf(
-			s.T().Context(),
-			&bind.CallOpts{
-				Signer:           s.signer,
-				WaitForExecution: true,
-			},
-			bind.Object{Id: s.ownerCapObj},
-			bind.Object{Id: s.accountObj},
-		)
-		s.Require().NoError(err, "Failed to transfer ownership to self")
-		s.Require().NotEmpty(tx, "Transaction should not be empty")
-	}
-
-	// 0. Register CCIP module in MCMS registry
-	addModulesProposalInput := mcmsops.ProposalGenerateInput{
-		Defs: []cld_ops.Definition{
-			mcmsops.AddModulesMCMSOp.Def(),
-		},
-		Inputs: []any{
-			mcmsops.AddModulesMCMSInput{
-				MCMSPackageId:     s.mcmsPackageID,
-				MCMSRegistryObjId: s.registryObj,
-				AllowedModules:    []string{"ccip"},
-			},
-		},
-		// MCMS related
-		MmcsPackageID:  s.mcmsPackageID,
-		McmsStateObjID: s.mcmsObj,
-		TimelockObjID:  s.timelockObj,
-		AccountObjID:   s.accountObj,
-		RegistryObjID:  s.registryObj,
-
-		// Proposal
-		Role:          suisdk.TimelockRoleBypasser,
-		ChainSelector: uint64(s.chainSelector),
-	}
-	addModulesProposalReport, err := cld_ops.ExecuteSequence(s.bundle, mcmsops.MCMSDynamicProposalGenerateSeq, s.deps, addModulesProposalInput)
-	s.Require().NoError(err, "executing add modules proposal sequence")
-
-	addModulesProposal := addModulesProposalReport.Output
-
-	proposalJson, _ := json.MarshalIndent(addModulesProposal, "", "  ")
-	s.T().Logf("Add Modules Proposal: %s", string(proposalJson))
-
-	// Execute the proposal to add CCIP module to the registry
-	s.ExecuteProposalE2e(&addModulesProposal, s.bypasserConfig, 0)
 
 	// 1. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
 	ccipContract, err := module_state_object.NewStateObject(s.ccipPackageId, s.client)

--- a/integration-tests/mcms/mcms_test.go
+++ b/integration-tests/mcms/mcms_test.go
@@ -198,8 +198,6 @@ func (s *CCIPMCMSTestSuite) Test_CCIP_MCMS() {
 // TODO: For prod env, the initial deployment sequence should start the ownership transfer flow of every deployed contract
 func RunTestCCIPOwnershipTransfer(s *CCIPMCMSTestSuite) {
 	// 1a. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
-
-	// 1. Transfer OwnerCap of CCIP to MCMS (this should be done in the initial deployment sequence)
 	ccipContract, err := module_state_object.NewStateObject(s.ccipPackageId, s.client)
 	require.NoError(s.T(), err, "creating ccip state object contract")
 

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -20,9 +20,12 @@ go run bindgen/main.go --moveConfig ./contracts/ccip/ccip --input ./contracts/cc
 
 # CCIP - Onramp
 go run bindgen/main.go --moveConfig ./contracts/ccip/ccip_onramp --input ./contracts/ccip/ccip_onramp/sources/onramp.move --output ./bindings/generated/ccip/ccip_onramp/onramp
+go run bindgen/main.go --moveConfig ./contracts/ccip/ccip_onramp --input ./contracts/ccip/ccip_onramp/sources/ownable.move --output ./bindings/generated/ccip/ccip_onramp/ownable
+
 
 # CCIP - Offramp
 go run bindgen/main.go --moveConfig ./contracts/ccip/ccip_offramp --input ./contracts/ccip/ccip_offramp/sources/offramp.move --output ./bindings/generated/ccip/ccip_offramp/offramp
+
 
 # CCIP - LINK
 go run bindgen/main.go --moveConfig ./contracts/ccip/mock_link_token --input ./contracts/ccip/mock_link_token/sources/mock_link_token.move --output ./bindings/generated/ccip/mock_link_token/mock_link_token


### PR DESCRIPTION
- Update ownership ops of main CCIP contracts
- Add e2e tests from deployment to MCMS ownership execution transfer of main CCIP contracts
- Refactor changesets to make MCMS deployment independent. Add CSs for ownership management