### PR TITLE
Fix mcms user contracts and tests

### DIFF
--- a/contracts/mcms/mcms_test/sources/mcms_user.move
+++ b/contracts/mcms/mcms_test/sources/mcms_user.move
@@ -77,7 +77,7 @@ public fun register_mcms_entrypoint(
     assert_valid_owner_cap(user_data, &owner_cap);
 
     // Transfer owner_cap to MCMS
-    mcms_registry::register_entrypoint(registry, SampleMcmsCallback {}, owner_cap, ctx);
+    mcms_registry::register_entrypoint(registry, SampleMcmsCallback {}, owner_cap, vector[b"mcms_user"], ctx);
 }
 
 public fun register_upgrade_cap(

--- a/contracts/mcms/mcms_test/sources/ownable.move
+++ b/contracts/mcms/mcms_test/sources/ownable.move
@@ -219,6 +219,7 @@ public fun execute_ownership_transfer_to_mcms<T: drop>(
         registry,
         proof,
         owner_cap,
+        vector[b"mcms_user"],
         ctx,
     );
 

--- a/contracts/mcms/mcms_test/tests/mcms_user_test.move
+++ b/contracts/mcms/mcms_test/tests/mcms_user_test.move
@@ -3,10 +3,11 @@ module mcms_test::mcms_user_test;
 
 use mcms::mcms_deployer::{Self, DeployerState};
 use mcms::mcms_registry::{Self, Registry};
-use mcms_test::mcms_user::{Self, UserData};
+use mcms_test::mcms_user::{Self, UserData, SampleMcmsCallback};
 use mcms_test::ownable::{OwnerCap};
 
 use std::string;
+use std::type_name;
 use sui::bcs;
 use sui::package;
 use sui::test_scenario::{Self as ts, Scenario};
@@ -152,6 +153,7 @@ fun test_mcms_function_one() {
             x"0000000000000000000000000000000000000000000000000000000000000001", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         // Command 2: Call mcms_function_one with params hot potato
@@ -208,6 +210,7 @@ fun test_mcms_function_two() {
             x"0000000000000000000000000000000000000000000000000000000000000001", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         // Command 2: Call mcms_function_two
@@ -254,6 +257,7 @@ fun test_mcms_function_one_invalid_function() {
             x"0000000000000000000000000000000000000000000000000000000000000001", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         let ctx = ts::ctx(&mut scenario);
@@ -273,7 +277,7 @@ fun test_mcms_function_one_invalid_function() {
 }
 
 #[test]
-#[expected_failure(abort_code = mcms_registry::EModuleNameMismatch)]
+#[expected_failure(abort_code = mcms_registry::EModuleNotAllowed)]
 fun test_mcms_entrypoint_wrong_module_name() {
     let mut scenario = create_test_scenario();
 
@@ -296,6 +300,7 @@ fun test_mcms_entrypoint_wrong_module_name() {
             x"0000000000000000000000000000000000000000000000000000000000000001", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         let ctx = ts::ctx(&mut scenario);
@@ -349,6 +354,7 @@ fun test_sequential_function_calls() {
             x"0000000000000000000000000000000000000000000000000000000000000001", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         // Command 2: Call mcms_function_one
@@ -392,6 +398,7 @@ fun test_sequential_function_calls() {
             x"0000000000000000000000000000000000000000000000000000000000000002", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         let ctx = ts::ctx(&mut scenario);
@@ -453,6 +460,7 @@ fun test_call_function_with_invalid_user_data() {
             x"0000000000000000000000000000000000000000000000000000000000000001", // batch_id
             0, // sequence_number
             1, // total_in_batch
+            type_name::with_original_ids<SampleMcmsCallback>(),
         );
 
         // Command 2: This should fail because we provide an unregistered user_data

--- a/contracts/mcms/mcms_test_v2/sources/mcms_user.move
+++ b/contracts/mcms/mcms_test_v2/sources/mcms_user.move
@@ -72,7 +72,7 @@ public fun register_mcms_entrypoint(
     assert_valid_owner_cap(user_data, &owner_cap);
 
     // Transfer owner_cap to MCMS
-    mcms_registry::register_entrypoint(registry, SampleMcmsCallback {}, owner_cap, ctx);
+    mcms_registry::register_entrypoint(registry, SampleMcmsCallback {}, owner_cap, vector[b"mcms_user"], ctx);
 }
 
 public fun register_upgrade_cap(

--- a/contracts/scripts/test.sh
+++ b/contracts/scripts/test.sh
@@ -9,6 +9,8 @@ sui move test --path ccip/ccip_token_pools/managed_token_pool
 sui move test --path ccip/ccip_token_pools/lock_release_token_pool
 sui move test --path ccip/ccip_token_pools/burn_mint_token_pool
 sui move test --path mcms/mcms
+sui move test --path mcms/mcms_test
+sui move test --path mcms/mcms_test_v2
 sui move test --path ccip/ccip_onramp
 sui move test --path ccip/ccip_offramp
 sui move test --path ccip/managed_token


### PR DESCRIPTION
### Why
`mcms_user` contracts were not compiling. CI didn't catch it as they are not tested

### What
- Fix the `mcms_user` contracts
- Adds them to the contracts test script