### PR TITLE
fix(contracts): offramp::mcms_set_ocr3_configs decoding fix

### DIFF
--- a/contracts/ccip/ccip_offramp/sources/offramp.move
+++ b/contracts/ccip/ccip_offramp/sources/offramp.move
@@ -1599,13 +1599,13 @@ public fun mcms_set_ocr3_config(
         &mut stream,
     );
 
-    let config_digest = bcs_stream::deserialize_fixed_vector_u8(&mut stream, 32);
+    let config_digest = bcs_stream::deserialize_vector_u8(&mut stream);
     let ocr_plugin_type = bcs_stream::deserialize_u8(&mut stream);
     let big_f = bcs_stream::deserialize_u8(&mut stream);
     let is_signature_verification_enabled = bcs_stream::deserialize_bool(&mut stream);
     let signers = bcs_stream::deserialize_vector!(
         &mut stream,
-        |stream| bcs_stream::deserialize_fixed_vector_u8(stream, 32),
+        |stream| bcs_stream::deserialize_vector_u8(stream),
     );
     let transmitters = bcs_stream::deserialize_vector!(
         &mut stream,


### PR DESCRIPTION
# Summary
On `offramp::mcms_set_ocr3_config` we were deserializing config_digest as a fixed len vector, but since the `vector<u8>` type in golang translates into `[]uint8` in the bindings it's not supposed to be encoded as fixed length vector. Calling `offramp::mcms_set_ocr3_config` then fails.
This PR fixes decoding.