### PR TITLE
Add message and metadata hash tests

### DIFF
--- a/contracts/ccip/ccip_offramp/tests/offramp_test.move
+++ b/contracts/ccip/ccip_offramp/tests/offramp_test.move
@@ -849,3 +849,181 @@ public fun test_release_cap_should_fail_with_proof_type_not_registered() {
     tear_down(env);
     transfer::public_transfer(extracted_owner_cap, EXPLOITER);
 }
+
+#[test]
+public fun test_calculate_message_hash() {
+    let (env, owner_cap, fee_quoter_cap, dest_transfer_cap) = setup();
+    
+    // Expected hash values
+    let expected_hash_no_tokens = x"9f9be87e216efa0b1571131d9295e3802c5c9a3d6e369d230c72520a2e854a9e";
+    let expected_hash_with_tokens = x"d183d22cb0b713da1b6b42d9c35cc9e1268257ff703c6579d6aa68fdfb1ff4b2";
+    
+    // Test with no tokens
+    let message_id = x"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    let source_chain_selector = 123456789u64;
+    let dest_chain_selector = 987654321u64;
+    let sequence_number = 42u64;
+    let nonce = 0u64; // Must be 0 for out of order execution
+    let sender = x"8765432109fedcba8765432109fedcba87654321";
+    let receiver = @0x1234;
+    let on_ramp = b"source-onramp-address";
+    let data = b"sample message data";
+    let gas_limit = 500000u256;
+    let token_receiver = @0x0; // No tokens
+    let source_pool_addresses = vector<vector<u8>>[];
+    let dest_token_addresses = vector<address>[];
+    let dest_gas_amounts = vector<u32>[];
+    let extra_datas = vector<vector<u8>>[];
+    let amounts = vector<u256>[];
+
+    let hash_no_tokens = offramp::calculate_message_hash(
+        &env.ref,
+        message_id,
+        source_chain_selector,
+        dest_chain_selector,
+        sequence_number,
+        nonce,
+        sender,
+        receiver,
+        on_ramp,
+        data,
+        gas_limit,
+        token_receiver,
+        source_pool_addresses,
+        dest_token_addresses,
+        dest_gas_amounts,
+        extra_datas,
+        amounts,
+    );
+
+    // Verify hash is 32 bytes
+    assert!(hash_no_tokens.length() == 32, 0);
+    // Verify hash matches expected value
+    assert!(hash_no_tokens == expected_hash_no_tokens, 1);
+
+    // Test with tokens
+    let token_receiver = @0x5678;
+    let source_pool_addresses = vector[
+        x"abcdef1234567890abcdef1234567890abcdef12",
+        x"123456789abcdef123456789abcdef123456789a",
+    ];
+    let dest_token_addresses = vector[@0x5678, @0x9abc];
+    let dest_gas_amounts = vector[10000u32, 20000u32];
+    let extra_datas = vector[x"00112233", x"ffeeddcc"];
+    let amounts = vector[1000000u256, 5000000u256];
+
+    let hash_with_tokens = offramp::calculate_message_hash(
+        &env.ref,
+        message_id,
+        source_chain_selector,
+        dest_chain_selector,
+        sequence_number,
+        nonce,
+        sender,
+        receiver,
+        on_ramp,
+        data,
+        gas_limit,
+        token_receiver,
+        source_pool_addresses,
+        dest_token_addresses,
+        dest_gas_amounts,
+        extra_datas,
+        amounts,
+    );
+
+    // Verify hash is 32 bytes
+    assert!(hash_with_tokens.length() == 32, 2);
+    // Verify hash matches expected value
+    assert!(hash_with_tokens == expected_hash_with_tokens, 3);
+    
+    // Hashes should be different when tokens are included
+    assert!(hash_no_tokens != hash_with_tokens, 4);
+
+    // Test that changing any parameter changes the hash
+    let different_sequence = offramp::calculate_message_hash(
+        &env.ref,
+        message_id,
+        source_chain_selector,
+        dest_chain_selector,
+        sequence_number + 1, // Changed
+        nonce,
+        sender,
+        receiver,
+        on_ramp,
+        data,
+        gas_limit,
+        token_receiver,
+        source_pool_addresses,
+        dest_token_addresses,
+        dest_gas_amounts,
+        extra_datas,
+        amounts,
+    );
+    assert!(hash_with_tokens != different_sequence, 5);
+
+    tear_down(env);
+    ts::return_to_address(OWNER, owner_cap);
+    transfer::public_transfer(fee_quoter_cap, OWNER);
+    transfer::public_transfer(dest_transfer_cap, OWNER);
+}
+
+#[test]
+public fun test_calculate_metadata_hash() {
+    let (env, owner_cap, fee_quoter_cap, dest_transfer_cap) = setup();
+
+    // Expected hash values
+    let expected_metadata_hash = x"b62ec658417caa5bcc6ff1d8c45f8b1cb52e1b0ed71603a04b250b107ed836d9";
+    let expected_metadata_hash_different_source = x"89da72ab93f7bd546d60b58a1e1b5f628fd456fe163614ff1e31a2413ca1b55a";
+
+    let source_chain_selector = 123456789u64;
+    let dest_chain_selector = 987654321u64;
+    let on_ramp = b"source-onramp-address";
+
+    let metadata_hash = offramp::calculate_metadata_hash(
+        &env.ref,
+        source_chain_selector,
+        dest_chain_selector,
+        on_ramp,
+    );
+
+    // Verify hash is 32 bytes
+    assert!(metadata_hash.length() == 32, 0);
+    // Verify hash matches expected value
+    assert!(metadata_hash == expected_metadata_hash, 1);
+
+    // Test that changing source chain selector produces different hash
+    let metadata_hash_different_source = offramp::calculate_metadata_hash(
+        &env.ref,
+        source_chain_selector + 1,
+        dest_chain_selector,
+        on_ramp,
+    );
+    
+    assert!(metadata_hash != metadata_hash_different_source, 2);
+    // Verify the different hash matches expected value
+    assert!(metadata_hash_different_source == expected_metadata_hash_different_source, 3);
+
+    // Test that changing destination chain selector produces different hash
+    let metadata_hash_different_dest = offramp::calculate_metadata_hash(
+        &env.ref,
+        source_chain_selector,
+        dest_chain_selector + 1,
+        on_ramp,
+    );
+    assert!(metadata_hash != metadata_hash_different_dest, 4);
+
+    // Test that changing on_ramp produces different hash
+    let metadata_hash_different_onramp = offramp::calculate_metadata_hash(
+        &env.ref,
+        source_chain_selector,
+        dest_chain_selector,
+        b"different-onramp-address",
+    );
+    assert!(metadata_hash != metadata_hash_different_onramp, 5);
+
+    tear_down(env);
+    ts::return_to_address(OWNER, owner_cap);
+    transfer::public_transfer(fee_quoter_cap, OWNER);
+    transfer::public_transfer(dest_transfer_cap, OWNER);
+}

--- a/relayer/chainreader/chainreader_util/hasher_test.go
+++ b/relayer/chainreader/chainreader_util/hasher_test.go
@@ -1,0 +1,250 @@
+package chainreaderutil
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageHasherV1_MetadataHash(t *testing.T) {
+	t.Run("should match expected metadata hash", func(t *testing.T) {
+		sourceChainSelector := uint64(123456789)
+		destChainSelector := uint64(987654321)
+		onRamp := []byte("source-onramp-address")
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		expectedMetadataHash := "b62ec658417caa5bcc6ff1d8c45f8b1cb52e1b0ed71603a04b250b107ed836d9"
+		actualMetadataHash := hex.EncodeToString(metadataHash[:])
+
+		assert.Equal(t, expectedMetadataHash, actualMetadataHash)
+	})
+
+	t.Run("should produce different hash when source chain selector changes", func(t *testing.T) {
+		sourceChainSelector := uint64(123456789)
+		destChainSelector := uint64(987654321)
+		onRamp := []byte("source-onramp-address")
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		metadataHashDifferentSource, err := computeMetadataHash(sourceChainSelector+1, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, metadataHash, metadataHashDifferentSource)
+
+		expectedMetadataHashDifferentSource := "89da72ab93f7bd546d60b58a1e1b5f628fd456fe163614ff1e31a2413ca1b55a"
+		actualMetadataHashDifferentSource := hex.EncodeToString(metadataHashDifferentSource[:])
+
+		assert.Equal(t, expectedMetadataHashDifferentSource, actualMetadataHashDifferentSource)
+	})
+
+	t.Run("should produce different hash when destination chain selector changes", func(t *testing.T) {
+		sourceChainSelector := uint64(123456789)
+		destChainSelector := uint64(987654321)
+		onRamp := []byte("source-onramp-address")
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		metadataHashDifferentDest, err := computeMetadataHash(sourceChainSelector, destChainSelector+1, onRamp)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, metadataHash, metadataHashDifferentDest)
+	})
+
+	t.Run("should produce different hash when on_ramp changes", func(t *testing.T) {
+		sourceChainSelector := uint64(123456789)
+		destChainSelector := uint64(987654321)
+		onRamp := []byte("source-onramp-address")
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		differentOnRamp := []byte("different-onramp-address")
+		metadataHashDifferentOnRamp, err := computeMetadataHash(sourceChainSelector, destChainSelector, differentOnRamp)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, metadataHash, metadataHashDifferentOnRamp)
+	})
+}
+
+func TestMessageHasherV1_MessageHash(t *testing.T) {
+	messageIDHex := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	sourceChainSelector := uint64(123456789)
+	destChainSelector := uint64(987654321)
+	sequenceNumber := uint64(42)
+	nonce := uint64(0)
+	senderHex := "8765432109fedcba8765432109fedcba87654321"
+	receiverHex := "0000000000000000000000000000000000000000000000000000000000001234"
+	onRamp := []byte("source-onramp-address")
+	data := []byte("sample message data")
+	gasLimit := big.NewInt(500000)
+
+	t.Run("should match expected message hash with no tokens", func(t *testing.T) {
+		tokenReceiverHex := "0000000000000000000000000000000000000000000000000000000000000000"
+
+		messageID := hexTo32Bytes(t, messageIDHex)
+		receiver := hexTo32Bytes(t, receiverHex)
+		sender, err := hex.DecodeString(senderHex)
+		require.NoError(t, err)
+		tokenReceiver := hexTo32Bytes(t, tokenReceiverHex)
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		messageHash, err := computeMessageDataHash(
+			metadataHash,
+			messageID,
+			receiver,
+			sequenceNumber,
+			gasLimit,
+			tokenReceiver,
+			nonce,
+			sender,
+			data,
+			[]any2SuiTokenTransfer{},
+		)
+		require.NoError(t, err)
+
+		expectedHashNoTokens := "9f9be87e216efa0b1571131d9295e3802c5c9a3d6e369d230c72520a2e854a9e"
+		actualHashNoTokens := hex.EncodeToString(messageHash[:])
+
+		assert.Equal(t, expectedHashNoTokens, actualHashNoTokens)
+	})
+
+	t.Run("should match expected message hash with tokens", func(t *testing.T) {
+		tokenReceiverHex := "0000000000000000000000000000000000000000000000000000000000005678"
+
+		messageID := hexTo32Bytes(t, messageIDHex)
+		receiver := hexTo32Bytes(t, receiverHex)
+		sender, err := hex.DecodeString(senderHex)
+		require.NoError(t, err)
+		tokenReceiver := hexTo32Bytes(t, tokenReceiverHex)
+
+		sourcePoolAddress1, err := hex.DecodeString("abcdef1234567890abcdef1234567890abcdef12")
+		require.NoError(t, err)
+		destTokenAddress1 := hexTo32Bytes(t, "0000000000000000000000000000000000000000000000000000000000005678")
+		extraData1, err := hex.DecodeString("00112233")
+		require.NoError(t, err)
+
+		sourcePoolAddress2, err := hex.DecodeString("123456789abcdef123456789abcdef123456789a")
+		require.NoError(t, err)
+		destTokenAddress2 := hexTo32Bytes(t, "0000000000000000000000000000000000000000000000000000000000009abc")
+		extraData2, err := hex.DecodeString("ffeeddcc")
+		require.NoError(t, err)
+
+		tokenAmounts := []any2SuiTokenTransfer{
+			{
+				SourcePoolAddress: sourcePoolAddress1,
+				DestTokenAddress:  destTokenAddress1,
+				DestGasAmount:     10000,
+				ExtraData:         extraData1,
+				Amount:            big.NewInt(1000000),
+			},
+			{
+				SourcePoolAddress: sourcePoolAddress2,
+				DestTokenAddress:  destTokenAddress2,
+				DestGasAmount:     20000,
+				ExtraData:         extraData2,
+				Amount:            big.NewInt(5000000),
+			},
+		}
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		messageHash, err := computeMessageDataHash(
+			metadataHash,
+			messageID,
+			receiver,
+			sequenceNumber,
+			gasLimit,
+			tokenReceiver,
+			nonce,
+			sender,
+			data,
+			tokenAmounts,
+		)
+		require.NoError(t, err)
+
+		expectedHashWithTokens := "d183d22cb0b713da1b6b42d9c35cc9e1268257ff703c6579d6aa68fdfb1ff4b2"
+		actualHashWithTokens := hex.EncodeToString(messageHash[:])
+
+		assert.Equal(t, expectedHashWithTokens, actualHashWithTokens)
+	})
+
+	t.Run("hashes should be different when tokens are included", func(t *testing.T) {
+		tokenReceiverNoTokens := hexTo32Bytes(t, "0000000000000000000000000000000000000000000000000000000000000000")
+		tokenReceiverWithTokens := hexTo32Bytes(t, "0000000000000000000000000000000000000000000000000000000000005678")
+
+		messageID := hexTo32Bytes(t, messageIDHex)
+		receiver := hexTo32Bytes(t, receiverHex)
+		sender, err := hex.DecodeString(senderHex)
+		require.NoError(t, err)
+
+		metadataHash, err := computeMetadataHash(sourceChainSelector, destChainSelector, onRamp)
+		require.NoError(t, err)
+
+		hashNoTokens, err := computeMessageDataHash(
+			metadataHash,
+			messageID,
+			receiver,
+			sequenceNumber,
+			gasLimit,
+			tokenReceiverNoTokens,
+			nonce,
+			sender,
+			data,
+			[]any2SuiTokenTransfer{},
+		)
+		require.NoError(t, err)
+
+		sourcePoolAddress1, err := hex.DecodeString("abcdef1234567890abcdef1234567890abcdef12")
+		require.NoError(t, err)
+		destTokenAddress1 := hexTo32Bytes(t, "0000000000000000000000000000000000000000000000000000000000005678")
+		extraData1, err := hex.DecodeString("00112233")
+		require.NoError(t, err)
+
+		tokenAmounts := []any2SuiTokenTransfer{
+			{
+				SourcePoolAddress: sourcePoolAddress1,
+				DestTokenAddress:  destTokenAddress1,
+				DestGasAmount:     10000,
+				ExtraData:         extraData1,
+				Amount:            big.NewInt(1000000),
+			},
+		}
+
+		hashWithTokens, err := computeMessageDataHash(
+			metadataHash,
+			messageID,
+			receiver,
+			sequenceNumber,
+			gasLimit,
+			tokenReceiverWithTokens,
+			nonce,
+			sender,
+			data,
+			tokenAmounts,
+		)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, hashNoTokens, hashWithTokens)
+	})
+}
+
+// Helper function to convert hex string to [32]byte array
+func hexTo32Bytes(t *testing.T, hexStr string) [32]byte {
+	bytes, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	require.Len(t, bytes, 32, "hex string must decode to exactly 32 bytes")
+
+	var result [32]byte
+	copy(result[:], bytes)
+	return result
+}

--- a/sui.nix
+++ b/sui.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = if stdenv.hostPlatform.isDarwin then
     pkgs.fetchzip {
       url = "https://github.com/MystenLabs/sui/releases/download/mainnet-v${version}/sui-mainnet-v${version}-macos-arm64.tgz"; # Assume is a M1 Mac
-      sha256 = "sha256-Kj3eNvkeRT+mpeRQ1sVNfqRyJFupqdMdoLPO6R541FU=";  # Should be replaced when bumping versions
+      sha256 = "sha256-uofVxuUt04lHUkwmTCCuVpHl4HcessJLP1nnFQU9+Mw=";  # Should be replaced when bumping versions
       stripRoot = false;
     }
     else if stdenv.isLinux then


### PR DESCRIPTION
### What
- Add unit tests in message hashing computation in onchain and offchain components

### Why
- verify compatibility between onchain and offchain implementations
- Will serve as reference for other implementations (likely [ccip tools ts](https://github.com/smartcontractkit/ccip-tools-ts/pull/59))