### PR TITLE
Fix: update PTB client method for fetching coins

### DIFF
--- a/relayer/client/mocks/mock_ptb_client.go
+++ b/relayer/client/mocks/mock_ptb_client.go
@@ -19,8 +19,9 @@ import (
 	sui "github.com/block-vision/sui-go-sdk/sui"
 	transaction "github.com/block-vision/sui-go-sdk/transaction"
 	cache "github.com/patrickmn/go-cache"
-	client "github.com/smartcontractkit/chainlink-sui/relayer/client"
 	gomock "go.uber.org/mock/gomock"
+
+	client "github.com/smartcontractkit/chainlink-sui/relayer/client"
 )
 
 // MockSuiPTBClient is a mock of SuiPTBClient interface.
@@ -486,4 +487,19 @@ func (m *MockSuiPTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, 
 func (mr *MockSuiPTBClientMockRecorder) GetReferenceGasPrice(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReferenceGasPrice", reflect.TypeOf((*MockSuiPTBClient)(nil).GetReferenceGasPrice), ctx)
+}
+
+// QueryCoinsByAddress mocks base method.
+func (m *MockSuiPTBClient) QueryCoinsByAddress(ctx context.Context, address, coinType string) ([]models.CoinData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryCoinsByAddress", ctx, address, coinType)
+	ret0, _ := ret[0].([]models.CoinData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryCoinsByAddress indicates an expected call of QueryCoinsByAddress.
+func (mr *MockSuiPTBClientMockRecorder) QueryCoinsByAddress(ctx, address, coinType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryCoinsByAddress", reflect.TypeOf((*MockSuiPTBClient)(nil).QueryCoinsByAddress), ctx, address, coinType)
 }

--- a/relayer/client/ptb_client.go
+++ b/relayer/client/ptb_client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
+
 	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
 	suiSigner "github.com/smartcontractkit/chainlink-sui/relayer/signer"
 
@@ -55,6 +56,7 @@ type SuiPTBClient interface {
 	QueryTransactions(ctx context.Context, fromAddress string, cursor *string, limit *uint64) (models.SuiXQueryTransactionBlocksResponse, error)
 	GetTransactionStatus(ctx context.Context, digest string) (TransactionResult, error)
 	GetCoinsByAddress(ctx context.Context, address string) ([]models.CoinData, error)
+	QueryCoinsByAddress(ctx context.Context, address string, coinType string) ([]models.CoinData, error)
 	EstimateGas(ctx context.Context, txBytes string) (uint64, error)
 	GetReferenceGasPrice(ctx context.Context) (*big.Int, error)
 	FinishPTBAndSend(ctx context.Context, txnSigner *signer.Signer, tx *transaction.Transaction, requestType TransactionRequestType) (SuiTransactionBlockResponse, error)
@@ -718,13 +720,47 @@ func (c *PTBClient) GetCoinsByAddress(ctx context.Context, address string) ([]mo
 			Owner: address,
 			Limit: uint64(maxCoinsPageSize),
 		}
+		hasNextPage := true
 
-		response, err := c.client.SuiXGetAllCoins(ctx, coinsReq)
-		if err != nil {
-			return fmt.Errorf("failed to get coins: %w", err)
+		for hasNextPage {
+			response, err := c.client.SuiXGetAllCoins(ctx, coinsReq)
+			if err != nil {
+				return fmt.Errorf("failed to get coins: %w", err)
+			}
+
+			result = append(result, response.Data...)
+
+			hasNextPage = response.HasNextPage
+			coinsReq.Cursor = response.NextCursor
 		}
 
-		result = response.Data
+		return nil
+	})
+
+	return result, err
+}
+
+func (c *PTBClient) QueryCoinsByAddress(ctx context.Context, address string, coinType string) ([]models.CoinData, error) {
+	var result []models.CoinData
+	err := c.WithRateLimit(ctx, "QueryCoinsByAddress", func(ctx context.Context) error {
+		coinsReq := models.SuiXGetCoinsRequest{
+			Owner:    address,
+			CoinType: coinType,
+			Limit:    uint64(maxCoinsPageSize),
+		}
+		hasNextPage := true
+
+		for hasNextPage {
+			response, err := c.client.SuiXGetCoins(ctx, coinsReq)
+			if err != nil {
+				return fmt.Errorf("failed to get coins: %w", err)
+			}
+
+			result = append(result, response.Data...)
+
+			hasNextPage = response.HasNextPage
+			coinsReq.Cursor = response.NextCursor
+		}
 
 		return nil
 	})

--- a/relayer/client/ptb_client_test.go
+++ b/relayer/client/ptb_client_test.go
@@ -484,6 +484,45 @@ func TestPTBClient(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, latestPackageId, packageId)
 	})
+
+	t.Run("QueryCoinsByAddress", func(t *testing.T) {
+		// Create and send random coins to the account address for testing
+		// This ensures we have coins to query
+		coinAmount := uint64(1000000) // 1 SUI
+
+		// Create a coin transfer transaction to send SUI to the account
+		transferReq := client.MoveCallRequest{
+			Signer:          accountAddress,
+			PackageObjectId: "0x2",
+			Module:          "pay",
+			Function:        "split_and_transfer",
+			Arguments:       []any{coinAmount, accountAddress},
+			GasBudget:       1000000000,
+		}
+
+		// Execute the coin transfer
+		txnMetadata, err := relayerClient.MoveCall(context.Background(), transferReq)
+		if err == nil && txnMetadata.TxBytes != "" {
+			_, err = relayerClient.SignAndSendTransaction(
+				context.Background(),
+				txnMetadata.TxBytes,
+				publicKeyBytes,
+				"WaitForLocalExecution",
+			)
+			// Ignore errors as this is just setup for the test
+		}
+
+		coins, err := relayerClient.QueryCoinsByAddress(context.Background(), accountAddress, "0x2::sui::SUI")
+		require.NoError(t, err)
+		require.NotNil(t, coins)
+
+		require.True(t, len(coins) > 0)
+		for _, coin := range coins {
+			require.Equal(t, "0x2::sui::SUI", coin.CoinType)
+		}
+
+		utils.PrettyPrint(coins)
+	})
 }
 
 func IncrementCounterWithMoveCall(t *testing.T, relayerClient *client.PTBClient, packageId string, counterObjectId string, accountAddress string, signerPublicKey []byte) string {

--- a/relayer/testutils/fake_client.go
+++ b/relayer/testutils/fake_client.go
@@ -171,6 +171,10 @@ func (c *FakeSuiPTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, 
 	return big.NewInt(1000), nil
 }
 
+func (c *FakeSuiPTBClient) QueryCoinsByAddress(ctx context.Context, address string, coinType string) ([]models.CoinData, error) {
+	return []models.CoinData{}, nil
+}
+
 // StatefulFakeSuiPTBClient is a more sophisticated fake client that can change behavior
 // based on gas budget and track call counts for testing gas bump scenarios
 type StatefulFakeSuiPTBClient struct {
@@ -337,4 +341,8 @@ func (c *StatefulFakeSuiPTBClient) GetCCIPPackageID(ctx context.Context, offRamp
 
 func (c *StatefulFakeSuiPTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(1000), nil
+}
+
+func (c *StatefulFakeSuiPTBClient) QueryCoinsByAddress(ctx context.Context, address string, coinType string) ([]models.CoinData, error) {
+	return []models.CoinData{}, nil
 }


### PR DESCRIPTION
This PR updates the PTB client to ensure the following points:

1. Getting all the coins owned by an account makes multiple RPC calls to get around the 50 coins response limit. This solves the edge case of having too many coins.
2. A new method to query for a specific coin type rather than getting all of the owned coins by the account.