### PR TITLE
Fix: Update TXM broadcaster to check the status field of broadcast attempts

### DIFF
--- a/relayer/txm/broadcaster.go
+++ b/relayer/txm/broadcaster.go
@@ -89,13 +89,10 @@ func broadcastTransactions(loopCtx context.Context, txm *SuiTxm, transactions []
 			// In the case there is an error submitting
 			txm.lggr.Errorw("Failed to broadcast transaction", "txID", tx.TransactionID, "function inputs", tx.Functions, "error", err)
 
-			var newState TransactionState
-			if resp.Effects.Status.Status == "" {
-				// If there is no status reported, we assume the transaction failed due to a network error or
-				// an issue not related to the transaction itself. We mark it as retriable.
-				txm.lggr.Errorw("Transaction failed without a status", "txID", tx.TransactionID, "function inputs", tx.Functions)
-				newState = StateRetriable
-			} else if resp.TxDigest == "" {
+			// Default to retrying the transaction
+			newState := StateRetriable
+
+			if resp.Effects.Status.Status != "" && resp.TxDigest == "" {
 				// Update the transaction state to Failed if the digest is empty
 				// An empty digest indicates a total failure of the transaction
 				txm.lggr.Errorw("Transaction failed without a digest", "txID", tx.TransactionID, "function inputs", tx.Functions)

--- a/relayer/txm/broadcaster.go
+++ b/relayer/txm/broadcaster.go
@@ -88,14 +88,23 @@ func broadcastTransactions(loopCtx context.Context, txm *SuiTxm, transactions []
 		if err != nil {
 			// In the case there is an error submitting
 			txm.lggr.Errorw("Failed to broadcast transaction", "txID", tx.TransactionID, "function inputs", tx.Functions, "error", err)
-			// Update the transaction state to Failed if the digest is empty
-			// An empty digest indicates a total failure of the transaction
-			if resp.TxDigest == "" {
+
+			var newState TransactionState
+			if resp.Effects.Status.Status == "" {
+				// If there is no status reported, we assume the transaction failed due to a network error or
+				// an issue not related to the transaction itself. We mark it as retriable.
+				txm.lggr.Errorw("Transaction failed without a status", "txID", tx.TransactionID, "function inputs", tx.Functions)
+				newState = StateRetriable
+			} else if resp.TxDigest == "" {
+				// Update the transaction state to Failed if the digest is empty
+				// An empty digest indicates a total failure of the transaction
 				txm.lggr.Errorw("Transaction failed without a digest", "txID", tx.TransactionID, "function inputs", tx.Functions)
-				err = txm.transactionRepository.ChangeState(tx.TransactionID, StateFailed)
-				if err != nil {
-					txm.lggr.Errorw("Failed to change transaction state to Failed", "txID", tx.TransactionID, "error", err)
-				}
+				newState = StateFailed
+			}
+
+			err = txm.transactionRepository.ChangeState(tx.TransactionID, newState)
+			if err != nil {
+				txm.lggr.Errorw("Failed to change transaction state", "txID", tx.TransactionID, "error", err)
 			}
 
 			continue


### PR DESCRIPTION
This PR adds a change to check that the `Status` field of the response is empty which will be the case where errors are not related to an actual transaction failure.