### PR TITLE
Enhancement: Add generics support in pointer tags

### DIFF
--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -641,8 +641,35 @@ func (s *suiChainReader) fetchGenericDependency(ctx context.Context, signerAddre
 		// Try to get the CCIP / TokenAdminRegistry package address from the package resolver (requires that it has been bound to CR)
 		ccipPackageAddress, err := s.packageResolver.ResolvePackageAddress("token_admin_registry")
 		if err != nil {
-			return "", fmt.Errorf("get_token_pool_state_type requires that the CCIP / TokenAdminRegistry package has been bound to ChainReader: %w", err)
+			// Attempt getting the ccip package address via the offramp binding as a fallback
+			offrampPackageAddress, err := s.packageResolver.ResolvePackageAddress("offramp")
+			if err != nil {
+				return "", fmt.Errorf("get_token_pool_state_type requires that the OffRamp package has been bound to ChainReader: %w", err)
+			}
+
+			s.logger.Debugw("get_token_pool_state_type falling back to OffRamp package", "offrampPackageAddress", offrampPackageAddress)
+
+			ccipPackageAddress, err = s.client.GetCCIPPackageID(ctx, offrampPackageAddress, signerAddress)
+			if err != nil {
+				return "", fmt.Errorf("failed to get CCIP package ID from offramp package address in fetchGenericDependency: %w", err)
+			}
+
+			latestCcipPackageAddress, err := s.client.GetLatestPackageId(ctx, ccipPackageAddress, "state_object", signerAddress)
+			if err != nil {
+				return "", fmt.Errorf("failed to get latest CCIP package address from offramp package address in fetchGenericDependency: %w", err)
+			}
+
+			s.logger.Debugw("get_token_pool_state_type using latest CCIP package address", "latestCcipPackageAddress", latestCcipPackageAddress)
+
+			ccipPackageAddress = latestCcipPackageAddress
+
+			if ccipPackageAddress == "" {
+				return "", fmt.Errorf("get_token_pool_state_type requires that the CCIP / TokenAdminRegistry package has been bound to ChainReader: %w", err)
+			}
 		}
+
+		s.logger.Warnw("get_token_pool_state_type using CCIP package address", "ccipPackageAddress", ccipPackageAddress)
+
 		tokenConfig, err := s.client.GetTokenPoolConfigByPackageAddress(ctx, signerAddress, parsed.address, ccipPackageAddress)
 		if err != nil {
 			return "", fmt.Errorf("failed to get token pool state type: %w", err)

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -669,6 +669,11 @@ func (s *suiChainReader) parseParams(params any, functionConfig *config.ChainRea
 		return nil, fmt.Errorf("failed to decode parameters: %w", err)
 	}
 
+	// Ensure that the argMap is not nil
+	if len(argMap) == 0 {
+		argMap = make(map[string]any)
+	}
+
 	return argMap, nil
 }
 

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -581,7 +581,7 @@ func (s *suiChainReader) callFunction(ctx context.Context, parsed *readIdentifie
 	}
 
 	// Extract generic type tags from function params
-	typeArgs, err := s.extractGenericTypeTags(functionConfig)
+	typeArgs, err := s.extractGenericTypeTags(ctx, parsed, functionConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract generic type tags: %w", err)
 	}
@@ -595,7 +595,7 @@ func (s *suiChainReader) callFunction(ctx context.Context, parsed *readIdentifie
 }
 
 // Helper function to extract generic type tags
-func (s *suiChainReader) extractGenericTypeTags(functionConfig *config.ChainReaderFunction) ([]string, error) {
+func (s *suiChainReader) extractGenericTypeTags(ctx context.Context, parsed *readIdentifier, functionConfig *config.ChainReaderFunction) ([]string, error) {
 	if functionConfig.Params == nil {
 		return []string{}, nil
 	}
@@ -612,10 +612,41 @@ func (s *suiChainReader) extractGenericTypeTags(functionConfig *config.ChainRead
 				keyOrder = append(keyOrder, genericType)
 				uniqueTags[genericType] = struct{}{}
 			}
+		} else if param.GenericDependency != nil && *param.GenericDependency != "" {
+			genericType, err := s.fetchGenericDependency(ctx, functionConfig.SignerAddress, parsed, &param)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch generic dependency: %w", err)
+			}
+			if _, exists := uniqueTags[genericType]; !exists {
+				keyOrder = append(keyOrder, genericType)
+				uniqueTags[genericType] = struct{}{}
+			}
 		}
 	}
 
 	return keyOrder, nil
+}
+
+func (s *suiChainReader) fetchGenericDependency(ctx context.Context, signerAddress string, parsed *readIdentifier, param *codec.SuiFunctionParam) (string, error) {
+	if param == nil || param.GenericDependency == nil || *param.GenericDependency == "" {
+		return "", fmt.Errorf("generic dependency is not set")
+	}
+
+	switch *param.GenericDependency {
+	case "get_token_pool_state_type":
+		// Try to get the CCIP / TokenAdminRegistry package address from the package resolver (requires that it has been bound to CR)
+		ccipPackageAddress, err := s.packageResolver.ResolvePackageAddress("token_admin_registry")
+		if err != nil {
+			return "", fmt.Errorf("get_token_pool_state_type requires that the CCIP / TokenAdminRegistry package has been bound to ChainReader: %w", err)
+		}
+		tokenConfig, err := s.client.GetTokenPoolConfigByPackageAddress(ctx, signerAddress, parsed.address, ccipPackageAddress)
+		if err != nil {
+			return "", fmt.Errorf("failed to get token pool state type: %w", err)
+		}
+		return tokenConfig.TokenType, nil
+	default:
+		return "", fmt.Errorf("unknown generic dependency: %s", *param.GenericDependency)
+	}
 }
 
 // parseParams parses input parameters based on whether we're running as a LOOP plugin

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -258,6 +258,10 @@ func (s *suiChainReader) GetLatestValue(ctx context.Context, readIdentifier stri
 		return err
 	}
 
+	if params == nil {
+		params = make(map[string]any)
+	}
+
 	// this ensures we are using values from chain-reader config set in core
 	moduleConfig, ok := s.config.Modules[contractName]
 	if !ok {

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -258,7 +258,7 @@ func (s *suiChainReader) GetLatestValue(ctx context.Context, readIdentifier stri
 		return err
 	}
 
-	if params == nil {
+	if params == nil || reflect.ValueOf(params).IsNil() {
 		params = make(map[string]any)
 	}
 

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -580,12 +580,42 @@ func (s *suiChainReader) callFunction(ctx context.Context, parsed *readIdentifie
 		return nil, fmt.Errorf("failed to prepare arguments: %w", err)
 	}
 
-	responseValues, err := s.executeFunction(ctx, parsed, functionConfig, args, argTypes)
+	// Extract generic type tags from function params
+	typeArgs, err := s.extractGenericTypeTags(functionConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract generic type tags: %w", err)
+	}
+
+	responseValues, err := s.executeFunction(ctx, parsed, functionConfig, args, argTypes, typeArgs)
 	if err != nil {
 		return nil, err
 	}
 
 	return responseValues, nil
+}
+
+// Helper function to extract generic type tags
+func (s *suiChainReader) extractGenericTypeTags(functionConfig *config.ChainReaderFunction) ([]string, error) {
+	if functionConfig.Params == nil {
+		return []string{}, nil
+	}
+
+	// Use a map to track unique type tags and preserve order
+	uniqueTags := make(map[string]struct{})
+	keyOrder := make([]string, 0)
+
+	for _, param := range functionConfig.Params {
+		if param.GenericType != nil && *param.GenericType != "" {
+			genericType := *param.GenericType
+			// Only add if not already present
+			if _, exists := uniqueTags[genericType]; !exists {
+				keyOrder = append(keyOrder, genericType)
+				uniqueTags[genericType] = struct{}{}
+			}
+		}
+	}
+
+	return keyOrder, nil
 }
 
 // parseParams parses input parameters based on whether we're running as a LOOP plugin
@@ -772,13 +802,14 @@ func (s *suiChainReader) prepareArguments(ctx context.Context, argMap map[string
 }
 
 // executeFunction executes the actual function call
-func (s *suiChainReader) executeFunction(ctx context.Context, parsed *readIdentifier, functionConfig *config.ChainReaderFunction, args []any, argTypes []string) ([]any, error) {
+func (s *suiChainReader) executeFunction(ctx context.Context, parsed *readIdentifier, functionConfig *config.ChainReaderFunction, args []any, argTypes []string, typeArgs []string) ([]any, error) {
 	s.logger.Debugw("Calling ReadFunction",
 		"address", parsed.address,
 		"module", parsed.contractName,
 		"method", parsed.readName,
 		"encodedArgs", args,
 		"argTypes", argTypes,
+		"typeArgs", typeArgs,
 	)
 
 	// Override the package ID with the latest package ID of the module being called.
@@ -791,7 +822,7 @@ func (s *suiChainReader) executeFunction(ctx context.Context, parsed *readIdenti
 	// this is the upgraded pkgID
 	parsed.address = latestPackageId
 
-	values, err := s.client.ReadFunction(ctx, functionConfig.SignerAddress, parsed.address, parsed.contractName, parsed.readName, args, argTypes)
+	values, err := s.client.ReadFunction(ctx, functionConfig.SignerAddress, parsed.address, parsed.contractName, parsed.readName, args, argTypes, typeArgs)
 	if err != nil {
 		s.logger.Errorw("ReadFunction failed",
 			"error", err,
@@ -800,6 +831,7 @@ func (s *suiChainReader) executeFunction(ctx context.Context, parsed *readIdenti
 			"method", parsed.readName,
 			"args", args,
 			"argTypes", argTypes,
+			"typeArgs", typeArgs,
 		)
 
 		return nil, fmt.Errorf("failed to call function %s: %w", parsed.readName, err)

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -4,6 +4,10 @@ package reader
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -26,12 +30,20 @@ func TestChainReaderTestnet(t *testing.T) {
 	log := logger.Test(t)
 	rpcUrl := testutils.TestnetUrl
 
+	offrampContractName := "OffRamp"
+	offrampPackageId := "0x50ff1c5a49f012f9360de2fa5065efe7185c22bbeee6254e68ef695b0b0d0f40"
+
 	tokenAdminRegistryContractName := "TokenAdminRegistry"
 	tokenAdminRegistryPackageId := "0x9de8a33d158e26f0b51f199da8be1a22e9755510b705cfb88230b257187da733"
 
 	burnMintTokenPoolContractName := "BurnMintTokenPool"
 	burnMintTokenPoolPackageId := "0xfeff675b624e55da49f80fda3b676fe1ef5a957a8334cb675ca35de8918f612d"
 	burnMintTokenPoolIdentifier := strings.Join([]string{burnMintTokenPoolPackageId, burnMintTokenPoolContractName, "get_token"}, "-")
+	burnMintTokenPoolGetSupportedChainsIdentifier := strings.Join([]string{burnMintTokenPoolPackageId, burnMintTokenPoolContractName, "get_supported_chains"}, "-")
+	burnMintTokenPoolGetRemotePoolsIdentifier := strings.Join([]string{burnMintTokenPoolPackageId, burnMintTokenPoolContractName, "get_remote_pools"}, "-")
+	burnMintTokenPoolGetCurrentInboundRateLimiterStateIdentifier := strings.Join([]string{
+		burnMintTokenPoolPackageId, burnMintTokenPoolContractName, "get_current_inbound_rate_limiter_state",
+	}, "-")
 
 	t.Helper()
 	ctx := context.Background()
@@ -39,7 +51,13 @@ func TestChainReaderTestnet(t *testing.T) {
 	keystoreInstance := testutils.NewTestKeystore(t)
 	accountAddress, _ := testutils.GetAccountAndKeyFromSui(keystoreInstance)
 
-	relayerClient, clientErr := client.NewPTBClient(log, rpcUrl, nil, 10*time.Second, keystoreInstance, 5, "WaitForLocalExecution")
+	clientMaxConcurrentRequests := int64(10)
+	if envClientMaxConcurrentRequests := os.Getenv("MAX_CONCURRENT_REQUESTS"); envClientMaxConcurrentRequests != "" {
+		if parsed, err := strconv.Atoi(envClientMaxConcurrentRequests); err == nil {
+			clientMaxConcurrentRequests = int64(parsed)
+		}
+	}
+	relayerClient, clientErr := client.NewPTBClient(log, rpcUrl, nil, 120*time.Second, keystoreInstance, clientMaxConcurrentRequests, "WaitForLocalExecution")
 	require.NoError(t, clientErr)
 
 	chainReaderConfig := config.ChainReaderConfig{
@@ -55,6 +73,10 @@ func TestChainReaderTestnet(t *testing.T) {
 		Modules: map[string]*config.ChainReaderModule{
 			tokenAdminRegistryContractName: {
 				Name:      "token_admin_registry",
+				Functions: map[string]*config.ChainReaderFunction{},
+			},
+			offrampContractName: {
+				Name:      "offramp",
 				Functions: map[string]*config.ChainReaderFunction{},
 			},
 			burnMintTokenPoolContractName: {
@@ -103,6 +125,60 @@ func TestChainReaderTestnet(t *testing.T) {
 							},
 						},
 					},
+					"get_remote_pools": {
+						Name:          "get_remote_pools",
+						SignerAddress: accountAddress,
+						Params: []codec.SuiFunctionParam{
+							{
+								Type:              "object_id",
+								Name:              "state_pointer",
+								GenericDependency: testutils.StringPointer("get_token_pool_state_type"),
+								PointerTag: &codec.PointerTag{
+									Module:        "burn_mint_token_pool",
+									PointerName:   "BurnMintTokenPoolStatePointer",
+									DerivationKey: "BurnMintTokenPoolState",
+									FieldName:     "burn_mint_token_pool_object_id",
+								},
+								Required:  true,
+								IsMutable: testutils.BoolPointer(true),
+							},
+							{
+								Type:     "u64",
+								Name:     "remote_chain_selector",
+								Required: true,
+							},
+						},
+					},
+					"get_current_inbound_rate_limiter_state": {
+						Name:          "get_current_inbound_rate_limiter_state",
+						SignerAddress: accountAddress,
+						Params: []codec.SuiFunctionParam{
+							{
+								Type:         "object_id",
+								Name:         "clock",
+								Required:     false,
+								DefaultValue: "0x06",
+							},
+							{
+								Type:              "object_id",
+								Name:              "state_pointer",
+								GenericDependency: testutils.StringPointer("get_token_pool_state_type"),
+								PointerTag: &codec.PointerTag{
+									Module:        "burn_mint_token_pool",
+									PointerName:   "BurnMintTokenPoolStatePointer",
+									DerivationKey: "BurnMintTokenPoolState",
+									FieldName:     "burn_mint_token_pool_object_id",
+								},
+								Required:  true,
+								IsMutable: testutils.BoolPointer(true),
+							},
+							{
+								Type:     "u64",
+								Name:     "remote_chain_selector",
+								Required: true,
+							},
+						},
+					},
 				},
 				Events: map[string]*config.ChainReaderEvent{},
 			},
@@ -142,38 +218,101 @@ func TestChainReaderTestnet(t *testing.T) {
 	require.NoError(t, err)
 
 	err = chainReader.Bind(context.Background(), []types.BoundContract{{
-		Name:    tokenAdminRegistryContractName,
-		Address: tokenAdminRegistryPackageId,
+		Name:    offrampContractName,
+		Address: offrampPackageId,
 	}, {
 		Name:    burnMintTokenPoolContractName,
 		Address: burnMintTokenPoolPackageId,
+	}, {
+		Name:    tokenAdminRegistryContractName,
+		Address: tokenAdminRegistryPackageId,
 	}})
 	require.NoError(t, err)
 
-	var retAddress string
-	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress)
-	require.NoError(t, err)
-	require.Equal(t, len(retAddress), 66)
+	t.Run("get_token_pool_state_type generic dependency for BurnMintTokenPool", func(t *testing.T) {
+		var retAddress string
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress)
+		require.NoError(t, err)
+		require.Equal(t, len(retAddress), 66)
 
-	var retAddress2 string
-	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress2)
-	require.NoError(t, err)
-	require.Equal(t, len(retAddress2), 66)
+		var retAddress2 string
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress2)
+		require.NoError(t, err)
+		require.Equal(t, len(retAddress2), 66)
 
-	var retAddress3 string
-	nilParams := make(map[string]any)
-	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &nilParams, &retAddress3)
-	require.NoError(t, err)
-	require.Equal(t, len(retAddress3), 66)
+		var retAddress3 string
+		nilParams := make(map[string]any)
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &nilParams, &retAddress3)
+		require.NoError(t, err)
+		require.Equal(t, len(retAddress3), 66)
 
-	var retAddress4 string
-	var params map[string]any
-	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &params, &retAddress4)
-	require.NoError(t, err)
-	require.Equal(t, len(retAddress4), 66)
+		var retAddress4 string
+		var params map[string]any
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &params, &retAddress4)
+		require.NoError(t, err)
+		require.Equal(t, len(retAddress4), 66)
 
-	var retSupportedChains string
-	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retSupportedChains)
-	require.NoError(t, err)
-	testutils.PrettyPrintDebug(log, retSupportedChains, "retSupportedChains")
+		var retSupportedChains []uint64
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolGetSupportedChainsIdentifier, primitives.Finalized, nil, &retSupportedChains)
+		require.NoError(t, err)
+		testutils.PrettyPrintDebug(log, retSupportedChains, "retSupportedChains")
+
+		var retRemotePools any
+		params = map[string]any{
+			"remote_chain_selector": uint64(14767482510784806043),
+		}
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolGetRemotePoolsIdentifier, primitives.Finalized, &params, &retRemotePools)
+		require.NoError(t, err)
+		testutils.PrettyPrintDebug(log, retRemotePools, "retRemotePools")
+
+		var retCurrentInboundRateLimiterState any
+		params = map[string]any{
+			"remote_chain_selector": uint64(14767482510784806043),
+		}
+		err = chainReader.GetLatestValue(ctx, burnMintTokenPoolGetCurrentInboundRateLimiterStateIdentifier, primitives.Finalized, &params, &retCurrentInboundRateLimiterState)
+		require.NoError(t, err)
+		testutils.PrettyPrintDebug(log, retCurrentInboundRateLimiterState, "retCurrentInboundRateLimiterState")
+	})
+
+	t.Run("high load test", func(t *testing.T) {
+		numRequests := 10
+		if envNumRequests := os.Getenv("NUM_REQUESTS"); envNumRequests != "" {
+			if parsed, err := strconv.Atoi(envNumRequests); err == nil {
+				numRequests = parsed
+			}
+		}
+		errChan := make(chan error, numRequests)
+
+		for i := range numRequests {
+			go func() {
+				var retAddress string
+
+				// Random sleep to simulate real-world load
+				sleepDuration := time.Duration(100+rand.Intn(1500)) * time.Millisecond
+				time.Sleep(sleepDuration)
+
+				err := chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to get value at request %d: %w", i, err)
+					return
+				}
+
+				errChan <- nil
+			}()
+		}
+
+		// Collect all results
+		errorCount := 0
+		processedCount := 0
+		for range numRequests {
+			err := <-errChan
+			if err != nil {
+				errorCount++
+				log.Errorw("Error", "error", err)
+			}
+			processedCount++
+		}
+
+		log.Infof("Completed %d requests, %d errors", processedCount, errorCount)
+	})
 }

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -4,7 +4,6 @@ package reader
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -27,6 +26,9 @@ import (
 func TestChainReaderTestnet(t *testing.T) {
 	log := logger.Test(t)
 	rpcUrl := testutils.TestnetUrl
+
+	tokenAdminRegistryContractName := "TokenAdminRegistry"
+	tokenAdminRegistryPackageId := "0x9de8a33d158e26f0b51f199da8be1a22e9755510b705cfb88230b257187da733"
 
 	burnMintTokenPoolContractName := "BurnMintTokenPool"
 	burnMintTokenPoolPackageId := "0xfeff675b624e55da49f80fda3b676fe1ef5a957a8334cb675ca35de8918f612d"
@@ -52,6 +54,10 @@ func TestChainReaderTestnet(t *testing.T) {
 			SyncTimeout:     10 * time.Second,
 		},
 		Modules: map[string]*config.ChainReaderModule{
+			tokenAdminRegistryContractName: {
+				Name:      "token_admin_registry",
+				Functions: map[string]*config.ChainReaderFunction{},
+			},
 			burnMintTokenPoolContractName: {
 				Name: "burn_mint_token_pool",
 				Functions: map[string]*config.ChainReaderFunction{
@@ -60,17 +66,17 @@ func TestChainReaderTestnet(t *testing.T) {
 						SignerAddress: accountAddress,
 						Params: []codec.SuiFunctionParam{
 							{
-								Type: "object_id",
-								Name: "state_pointer",
+								Type:              "object_id",
+								Name:              "state_pointer",
+								GenericDependency: testutils.StringPointer("get_token_pool_state_type"),
 								PointerTag: &codec.PointerTag{
 									Module:        "burn_mint_token_pool",
 									PointerName:   "BurnMintTokenPoolStatePointer",
 									DerivationKey: "BurnMintTokenPoolState",
 									FieldName:     "burn_mint_token_pool_object_id",
 								},
-								Required:    true,
-								IsMutable:   testutils.BoolPointer(true),
-								GenericType: testutils.StringPointer("0x406964d837bc10f14e26a40b4462c58cce0b9e57fc5265a6272dd2aba57e15a4::link::LINK"),
+								Required:  true,
+								IsMutable: testutils.BoolPointer(true),
 							},
 						},
 					},
@@ -121,6 +127,9 @@ func TestChainReaderTestnet(t *testing.T) {
 	require.NoError(t, err)
 
 	err = chainReader.Bind(context.Background(), []types.BoundContract{{
+		Name:    tokenAdminRegistryContractName,
+		Address: tokenAdminRegistryPackageId,
+	}, {
 		Name:    burnMintTokenPoolContractName,
 		Address: burnMintTokenPoolPackageId,
 	}})
@@ -129,6 +138,5 @@ func TestChainReaderTestnet(t *testing.T) {
 	var retAddress string
 	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, map[string]any{}, &retAddress)
 	require.NoError(t, err)
-
-	fmt.Println(retAddress)
+	require.Equal(t, len(retAddress), 66)
 }

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -4,7 +4,6 @@ package reader
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -86,15 +85,7 @@ func TestChainReaderTestnet(t *testing.T) {
 		},
 	}
 
-	datastoreUrl := os.Getenv("TEST_DB_URL")
-	if datastoreUrl == "" {
-		t.Skip("Skipping persistent tests as TEST_DB_URL is not set in CI")
-	}
-	db := sqltest.NewDB(t, datastoreUrl)
-
-	// attempt to connect
-	_, err := db.Connx(ctx)
-	require.NoError(t, err)
+	db := sqltest.NewNoOpDataSource()
 
 	// Create the indexers
 	txnIndexer := indexer.NewTransactionsIndexer(

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -135,4 +135,10 @@ func TestChainReaderTestnet(t *testing.T) {
 	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress2)
 	require.NoError(t, err)
 	require.Equal(t, len(retAddress2), 66)
+
+	var retAddress3 string
+	nilParams := make(map[string]any)
+	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &nilParams, &retAddress3)
+	require.NoError(t, err)
+	require.Equal(t, len(retAddress3), 66)
 }

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -127,7 +127,7 @@ func TestChainReaderTestnet(t *testing.T) {
 	require.NoError(t, err)
 
 	var retAddress string
-	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, map[string]any{}, &retAddress)
+	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress)
 	require.NoError(t, err)
 	require.Equal(t, len(retAddress), 66)
 }

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -79,6 +79,30 @@ func TestChainReaderTestnet(t *testing.T) {
 							},
 						},
 					},
+					"type_and_version": {
+						Name:          "type_and_version",
+						SignerAddress: accountAddress,
+						Params:        []codec.SuiFunctionParam{},
+					},
+					"get_supported_chains": {
+						Name:          "get_supported_chains",
+						SignerAddress: accountAddress,
+						Params: []codec.SuiFunctionParam{
+							{
+								Type:              "object_id",
+								Name:              "state_pointer",
+								GenericDependency: testutils.StringPointer("get_token_pool_state_type"),
+								PointerTag: &codec.PointerTag{
+									Module:        "burn_mint_token_pool",
+									PointerName:   "BurnMintTokenPoolStatePointer",
+									DerivationKey: "BurnMintTokenPoolState",
+									FieldName:     "burn_mint_token_pool_object_id",
+								},
+								Required:  true,
+								IsMutable: testutils.BoolPointer(true),
+							},
+						},
+					},
 				},
 				Events: map[string]*config.ChainReaderEvent{},
 			},
@@ -141,4 +165,15 @@ func TestChainReaderTestnet(t *testing.T) {
 	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &nilParams, &retAddress3)
 	require.NoError(t, err)
 	require.Equal(t, len(retAddress3), 66)
+
+	var retAddress4 string
+	var params map[string]any
+	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, &params, &retAddress4)
+	require.NoError(t, err)
+	require.Equal(t, len(retAddress4), 66)
+
+	var retSupportedChains string
+	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retSupportedChains)
+	require.NoError(t, err)
+	testutils.PrettyPrintDebug(log, retSupportedChains, "retSupportedChains")
 }

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -1,0 +1,134 @@
+//go:build testnet
+
+package reader
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
+
+	"github.com/smartcontractkit/chainlink-sui/relayer/chainreader/config"
+	"github.com/smartcontractkit/chainlink-sui/relayer/chainreader/indexer"
+	"github.com/smartcontractkit/chainlink-sui/relayer/client"
+	"github.com/smartcontractkit/chainlink-sui/relayer/codec"
+	"github.com/smartcontractkit/chainlink-sui/relayer/testutils"
+)
+
+func TestChainReaderTestnet(t *testing.T) {
+	log := logger.Test(t)
+	rpcUrl := testutils.TestnetUrl
+
+	burnMintTokenPoolContractName := "BurnMintTokenPool"
+	burnMintTokenPoolPackageId := "0xfeff675b624e55da49f80fda3b676fe1ef5a957a8334cb675ca35de8918f612d"
+	burnMintTokenPoolIdentifier := strings.Join([]string{burnMintTokenPoolPackageId, burnMintTokenPoolContractName, "get_token"}, "-")
+
+	t.Helper()
+	ctx := context.Background()
+
+	keystoreInstance := testutils.NewTestKeystore(t)
+	accountAddress, _ := testutils.GetAccountAndKeyFromSui(keystoreInstance)
+
+	relayerClient, clientErr := client.NewPTBClient(log, rpcUrl, nil, 10*time.Second, keystoreInstance, 5, "WaitForLocalExecution")
+	require.NoError(t, clientErr)
+
+	chainReaderConfig := config.ChainReaderConfig{
+		IsLoopPlugin: false,
+		EventsIndexer: config.EventsIndexerConfig{
+			PollingInterval: 10 * time.Second,
+			SyncTimeout:     10 * time.Second,
+		},
+		TransactionsIndexer: config.TransactionsIndexerConfig{
+			PollingInterval: 10 * time.Second,
+			SyncTimeout:     10 * time.Second,
+		},
+		Modules: map[string]*config.ChainReaderModule{
+			burnMintTokenPoolContractName: {
+				Name: "burn_mint_token_pool",
+				Functions: map[string]*config.ChainReaderFunction{
+					"get_token": {
+						Name:          "get_token",
+						SignerAddress: accountAddress,
+						Params: []codec.SuiFunctionParam{
+							{
+								Type: "object_id",
+								Name: "state_pointer",
+								PointerTag: &codec.PointerTag{
+									Module:        "burn_mint_token_pool",
+									PointerName:   "BurnMintTokenPoolStatePointer",
+									DerivationKey: "BurnMintTokenPoolState",
+									FieldName:     "burn_mint_token_pool_object_id",
+								},
+								Required:    true,
+								IsMutable:   testutils.BoolPointer(true),
+								GenericType: testutils.StringPointer("0x406964d837bc10f14e26a40b4462c58cce0b9e57fc5265a6272dd2aba57e15a4::link::LINK"),
+							},
+						},
+					},
+				},
+				Events: map[string]*config.ChainReaderEvent{},
+			},
+		},
+	}
+
+	datastoreUrl := os.Getenv("TEST_DB_URL")
+	if datastoreUrl == "" {
+		t.Skip("Skipping persistent tests as TEST_DB_URL is not set in CI")
+	}
+	db := sqltest.NewDB(t, datastoreUrl)
+
+	// attempt to connect
+	_, err := db.Connx(ctx)
+	require.NoError(t, err)
+
+	// Create the indexers
+	txnIndexer := indexer.NewTransactionsIndexer(
+		db,
+		log,
+		relayerClient,
+		chainReaderConfig.TransactionsIndexer.PollingInterval,
+		chainReaderConfig.TransactionsIndexer.SyncTimeout,
+		// start without any configs, they will be set when ChainReader is initialized and gets a reference
+		// to the transaction indexer to avoid having to reading ChainReader configs here as well
+		map[string]*config.ChainReaderEvent{},
+	)
+	evIndexer := indexer.NewEventIndexer(
+		db,
+		log,
+		relayerClient,
+		// start without any selectors, they will be added during .Bind() calls on ChainReader
+		[]*client.EventSelector{},
+		chainReaderConfig.EventsIndexer.PollingInterval,
+		chainReaderConfig.EventsIndexer.SyncTimeout,
+	)
+	indexerInstance := indexer.NewIndexer(
+		log,
+		evIndexer,
+		txnIndexer,
+	)
+
+	// ChainReader in non-loop mode
+	chainReader, err := NewChainReader(ctx, log, relayerClient, chainReaderConfig, db, indexerInstance)
+	require.NoError(t, err)
+
+	err = chainReader.Bind(context.Background(), []types.BoundContract{{
+		Name:    burnMintTokenPoolContractName,
+		Address: burnMintTokenPoolPackageId,
+	}})
+	require.NoError(t, err)
+
+	var retAddress string
+	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, map[string]any{}, &retAddress)
+	require.NoError(t, err)
+
+	fmt.Println(retAddress)
+}

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -130,4 +130,9 @@ func TestChainReaderTestnet(t *testing.T) {
 	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress)
 	require.NoError(t, err)
 	require.Equal(t, len(retAddress), 66)
+
+	var retAddress2 string
+	err = chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress2)
+	require.NoError(t, err)
+	require.Equal(t, len(retAddress2), 66)
 }

--- a/relayer/chainreader/reader/chainreader_testnet_test.go
+++ b/relayer/chainreader/reader/chainreader_testnet_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestChainReaderTestnet(t *testing.T) {
 	log := logger.Test(t)
-	rpcUrl := testutils.TestnetUrl
+	rpcUrl := "https://sui-testnet-rpc.publicnode.com" // testutils.TestnetUrl
 
 	offrampContractName := "OffRamp"
 	offrampPackageId := "0x50ff1c5a49f012f9360de2fa5065efe7185c22bbeee6254e68ef695b0b0d0f40"
@@ -274,7 +274,54 @@ func TestChainReaderTestnet(t *testing.T) {
 		testutils.PrettyPrintDebug(log, retCurrentInboundRateLimiterState, "retCurrentInboundRateLimiterState")
 	})
 
-	t.Run("high load test", func(t *testing.T) {
+	t.Run("client load test GetObjectId", func(t *testing.T) {
+		numRequests := 10
+		if envNumRequests := os.Getenv("NUM_REQUESTS"); envNumRequests != "" {
+			if parsed, err := strconv.Atoi(envNumRequests); err == nil {
+				numRequests = parsed
+			}
+		}
+		errChan := make(chan error, numRequests)
+
+		for i := range numRequests {
+			go func() {
+				// Random sleep to simulate real-world load
+				sleepDuration := time.Duration(100+rand.Intn(1500)) * time.Millisecond
+				time.Sleep(sleepDuration)
+
+				start := time.Now()
+				response, err := relayerClient.ReadObjectId(ctx, burnMintTokenPoolPackageId)
+				if err != nil {
+					elapsed := time.Since(start)
+					log.Infow("Request completed", "request", i, "elapsed", elapsed)
+
+					errChan <- fmt.Errorf("failed to get value at request %d: %w", i, err)
+					return
+				}
+
+				elapsed := time.Since(start)
+				log.Infow("Request completed", "request", i, "elapsed", elapsed, "response", response.ObjectId)
+
+				errChan <- nil
+			}()
+		}
+
+		// Collect all results
+		errorCount := 0
+		processedCount := 0
+		for range numRequests {
+			err := <-errChan
+			if err != nil {
+				errorCount++
+				log.Errorw("ReadObjectId Test Error", "error", err)
+			}
+			processedCount++
+		}
+
+		log.Infof("Completed %d requests, %d errors", processedCount, errorCount)
+	})
+
+	t.Run("chainreader load test GetLatestValue", func(t *testing.T) {
 		numRequests := 10
 		if envNumRequests := os.Getenv("NUM_REQUESTS"); envNumRequests != "" {
 			if parsed, err := strconv.Atoi(envNumRequests); err == nil {
@@ -291,11 +338,18 @@ func TestChainReaderTestnet(t *testing.T) {
 				sleepDuration := time.Duration(100+rand.Intn(1500)) * time.Millisecond
 				time.Sleep(sleepDuration)
 
+				start := time.Now()
 				err := chainReader.GetLatestValue(ctx, burnMintTokenPoolIdentifier, primitives.Finalized, nil, &retAddress)
 				if err != nil {
+					elapsed := time.Since(start)
+					log.Infow("Request completed", "request", i, "elapsed", elapsed)
+
 					errChan <- fmt.Errorf("failed to get value at request %d: %w", i, err)
 					return
 				}
+
+				elapsed := time.Since(start)
+				log.Infow("Request completed", "request", i, "elapsed", elapsed)
 
 				errChan <- nil
 			}()

--- a/relayer/client/mocks/mock_ptb_client.go
+++ b/relayer/client/mocks/mock_ptb_client.go
@@ -376,18 +376,18 @@ func (mr *MockSuiPTBClientMockRecorder) ReadFilterOwnedObjectIds(ctx, ownerAddre
 }
 
 // ReadFunction mocks base method.
-func (m *MockSuiPTBClient) ReadFunction(ctx context.Context, signerAddress, packageId, module, function string, args []any, argTypes []string) ([]any, error) {
+func (m *MockSuiPTBClient) ReadFunction(ctx context.Context, signerAddress, packageId, module, function string, args []any, argTypes []string, typeArgs []string) ([]any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadFunction", ctx, signerAddress, packageId, module, function, args, argTypes)
+	ret := m.ctrl.Call(m, "ReadFunction", ctx, signerAddress, packageId, module, function, args, argTypes, typeArgs)
 	ret0, _ := ret[0].([]any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadFunction indicates an expected call of ReadFunction.
-func (mr *MockSuiPTBClientMockRecorder) ReadFunction(ctx, signerAddress, packageId, module, function, args, argTypes any) *gomock.Call {
+func (mr *MockSuiPTBClientMockRecorder) ReadFunction(ctx, signerAddress, packageId, module, function, args, argTypes, typeArgs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFunction", reflect.TypeOf((*MockSuiPTBClient)(nil).ReadFunction), ctx, signerAddress, packageId, module, function, args, argTypes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFunction", reflect.TypeOf((*MockSuiPTBClient)(nil).ReadFunction), ctx, signerAddress, packageId, module, function, args, argTypes, typeArgs)
 }
 
 // ReadObjectId mocks base method.

--- a/relayer/client/mocks/mock_ptb_client.go
+++ b/relayer/client/mocks/mock_ptb_client.go
@@ -21,6 +21,7 @@ import (
 	cache "github.com/patrickmn/go-cache"
 	gomock "go.uber.org/mock/gomock"
 
+	module_token_admin_registry "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/token_admin_registry"
 	client "github.com/smartcontractkit/chainlink-sui/relayer/client"
 )
 
@@ -502,4 +503,19 @@ func (m *MockSuiPTBClient) QueryCoinsByAddress(ctx context.Context, address, coi
 func (mr *MockSuiPTBClientMockRecorder) QueryCoinsByAddress(ctx, address, coinType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryCoinsByAddress", reflect.TypeOf((*MockSuiPTBClient)(nil).QueryCoinsByAddress), ctx, address, coinType)
+}
+
+// GetTokenPoolConfigByPackageAddress mocks base method.
+func (m *MockSuiPTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, accountAddress string, tokenPoolAddress string, ccipPackageAddress string) (module_token_admin_registry.TokenConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTokenPoolConfigByPackageAddress", ctx, accountAddress, tokenPoolAddress, ccipPackageAddress)
+	ret0, _ := ret[0].(module_token_admin_registry.TokenConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTokenPoolConfigByPackageAddress indicates an expected call of GetTokenPoolConfigByPackageAddress.
+func (mr *MockSuiPTBClientMockRecorder) GetTokenPoolConfigByPackageAddress(ctx, accountAddress, tokenPoolAddress, ccipPackageAddress any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokenPoolConfigByPackageAddress", reflect.TypeOf((*MockSuiPTBClient)(nil).GetTokenPoolConfigByPackageAddress), ctx, accountAddress, tokenPoolAddress, ccipPackageAddress)
 }

--- a/relayer/client/ptb_client.go
+++ b/relayer/client/ptb_client.go
@@ -50,7 +50,7 @@ type SuiPTBClient interface {
 	ReadOwnedObjects(ctx context.Context, ownerAddress string, cursor *models.ObjectId) ([]models.SuiObjectResponse, error)
 	ReadFilterOwnedObjectIds(ctx context.Context, ownerAddress string, structType string, limit *uint) ([]models.SuiObjectData, error)
 	ReadObjectId(ctx context.Context, objectId string) (models.SuiObjectData, error)
-	ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string) ([]any, error)
+	ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string, typeArgs []string) ([]any, error)
 	SignAndSendTransaction(ctx context.Context, txBytesRaw string, signerPublicKey []byte, executionRequestType TransactionRequestType) (SuiTransactionBlockResponse, error)
 	QueryEvents(ctx context.Context, filter EventFilterByMoveEventModule, limit *uint, cursor *EventId, sortOptions *QuerySortOptions) (*models.PaginatedEventsResponse, error)
 	QueryTransactions(ctx context.Context, fromAddress string, cursor *string, limit *uint64) (models.SuiXQueryTransactionBlocksResponse, error)
@@ -393,13 +393,23 @@ func (c *PTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, error) 
 	return result, err
 }
 
-func (c *PTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string) ([]any, error) {
+func (c *PTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string, typeArgs []string) ([]any, error) {
 	var results []any
 	err := c.WithRateLimit(ctx, "ReadFunction", func(ctx context.Context) error {
 		txn := transaction.NewTransaction()
 
 		var txnArgs []transaction.Argument
 		var txnTypeArgs []transaction.TypeTag
+
+		// Process type arguments
+		for _, typeArg := range typeArgs {
+			typeTag, err := c.createTypeTag(typeArg)
+			if err != nil {
+				return fmt.Errorf("failed to create type tag for %s: %w", typeArg, err)
+			}
+			txnTypeArgs = append(txnTypeArgs, typeTag)
+		}
+
 		for i, arg := range args {
 			argType, ok := common.ValueAt(argTypes, i)
 			if !ok {
@@ -1167,4 +1177,40 @@ func (c *PTBClient) GetParentObjectID(ctx context.Context, packageID string, mod
 	}
 
 	return "", fmt.Errorf("pointer object %s not found in package %s", qualifiedName, packageID)
+}
+
+// Add helper method to create type tags
+func (c *PTBClient) createTypeTag(typeStr string) (transaction.TypeTag, error) {
+	if typeStr == "" {
+		return transaction.TypeTag{}, fmt.Errorf("type string cannot be empty")
+	}
+
+	// Handle struct types (package::module::name)
+	if strings.Contains(typeStr, "::") {
+		parts := strings.Split(typeStr, "::")
+		if len(parts) != 3 {
+			return transaction.TypeTag{}, fmt.Errorf("invalid struct type format %q, expected package::module::name", typeStr)
+		}
+
+		packageID, module, name := parts[0], parts[1], parts[2]
+
+		// Convert package ID to address bytes
+		packageAddr := models.SuiAddress(packageID)
+		addressBytes, err := transaction.ConvertSuiAddressStringToBytes(packageAddr)
+		if err != nil {
+			return transaction.TypeTag{}, fmt.Errorf("failed to convert package address %q: %w", packageID, err)
+		}
+
+		return transaction.TypeTag{
+			Struct: &transaction.StructTag{
+				Address:    *addressBytes,
+				Module:     module,
+				Name:       name,
+				TypeParams: []*transaction.TypeTag{},
+			},
+		}, nil
+	}
+
+	// TODO: Handle primitive types if needed
+	return transaction.TypeTag{}, fmt.Errorf("unsupported type format: %s", typeStr)
 }

--- a/relayer/client/ptb_client.go
+++ b/relayer/client/ptb_client.go
@@ -39,8 +39,38 @@ const (
 	DefaultGasBudget            uint64        = 1_000_000_000
 	DefaultCacheExpiration      time.Duration = 120 * time.Minute
 	DefaultCacheCleanupInterval time.Duration = 240 * time.Minute
-	DefaultHTTPTimeout          time.Duration = 120 * time.Second
+	DefaultHTTPTimeout          time.Duration = 30 * time.Second
 )
+
+var RateLimitWeights = map[string]int64{
+	"MoveCall":                             1,
+	"SendTransaction":                      1,
+	"ReadFunction":                         1,
+	"SignAndSendTransaction":               1,
+	"QueryEvents":                          1,
+	"QueryTransactions":                    1,
+	"GetCoinsByAddress":                    1,
+	"QueryCoinsByAddress":                  1,
+	"EstimateGas":                          1,
+	"GetTransactionStatus":                 1,
+	"GetBlockById":                         1,
+	"GetNormalizedModule":                  1,
+	"GetSUIBalance":                        1,
+	"GetValuesFromPackageOwnedObjectField": 1,
+	"GetReferenceGasPrice":                 1,
+	"FinishPTBAndSend":                     1,
+	"BlockByDigest":                        1,
+	// Keep 0, these methods are often called at the same time as ReadFunction
+	// from ChainReader, high load of GetLatestValue calls could cause a deadlock.
+	"ReadFilterOwnedObjectIds":           0,
+	"ReadOwnedObjects":                   0,
+	"ReadObjectId":                       0,
+	"GetLatestPackageId":                 0,
+	"LoadModulePackageIds":               0,
+	"GetParentObjectID":                  0,
+	"GetCCIPPackageID":                   0,
+	"GetTokenPoolConfigByPackageAddress": 0,
+}
 
 // var since it's passed via pointer
 var maxPageSize uint = 50
@@ -140,47 +170,38 @@ func NewPTBClient(
 func (c *PTBClient) WithRateLimit(ctx context.Context, methodName string, f func(ctx context.Context) error) error {
 	start := time.Now()
 
-	// Keep track of the number of times WithRateLimit is called
-	_, ok := c.cache.Get("WithRateLimitCount")
-	if !ok {
-		c.cache.SetDefault("WithRateLimitCount", uint(0))
+	weight := int64(1)
+	if weightValue, ok := RateLimitWeights[methodName]; ok {
+		weight = weightValue
 	}
-	newCount, err := c.cache.IncrementUint("WithRateLimitCount", 1)
-	c.log.Debugw("WithRateLimit count", "count", newCount, "error", err)
-	c.log.Debugw("WithRateLimit starting", "methodName", methodName, "timestamp", start.Format(time.RFC3339))
 
-	// the work itself should time out by transactionTimeout
-	timeoutCtx, cancel := context.WithTimeout(ctx, c.transactionTimeout)
+	// If rate limiter is disabled or weight is 0, skip semaphore entirely.
+	// This will skip adding to the semaphore queue and prevent unnecessary queuing.
+	if c.rateLimiter == nil || weight == 0 {
+		workCtx, cancel := context.WithTimeout(ctx, c.transactionTimeout)
+		defer cancel()
+		return f(workCtx)
+	}
+
+	workCtx, cancel := context.WithTimeout(ctx, c.transactionTimeout)
 	defer cancel()
 
-	if c.rateLimiter == nil {
-		c.log.Debugw("WithRateLimit no rate limiter", "methodName", methodName, "timestamp", time.Now().Format(time.RFC3339), "duration", time.Since(start))
-		return f(timeoutCtx)
-	}
-
 	// acquire with the timeout context so it can't hang forever
-	if err := c.rateLimiter.Acquire(timeoutCtx, 1); err != nil {
+	if err := c.rateLimiter.Acquire(ctx, weight); err != nil {
 		return fmt.Errorf("failed to acquire rate limit for %s: %w", methodName, err)
 	}
 
-	// ensure cleanup on exit and panic recovery
+	// ensure cleanup on exit
 	defer func() {
-		c.rateLimiter.Release(1)
-		c.log.Debugw("WithRateLimit released", "methodName", methodName, "timestamp", time.Now().Format(time.RFC3339), "duration", time.Since(start))
-
-		// bubble up panic after releasing
-		if r := recover(); r != nil {
-			c.log.Debugw("WithRateLimit panicked", "methodName", methodName, "timestamp", time.Now().Format(time.RFC3339), "duration", time.Since(start))
-			panic(r)
-		}
-
-		newCount, err := c.cache.DecrementUint("WithRateLimitCount", 1)
-		c.log.Debugw("WithRateLimit count", "count", newCount, "error", err)
+		c.rateLimiter.Release(weight)
+		c.log.Debugw("WithRateLimit released", "methodName", methodName, "duration", time.Since(start))
 	}()
+
+	c.log.Debugw("WithRateLimit starting work")
 
 	// run the user function with the timeout context
 	// if the function respects the context, it will return and lock will be released in defer
-	return f(timeoutCtx)
+	return f(workCtx)
 }
 
 func (c *PTBClient) MoveCall(ctx context.Context, req MoveCallRequest) (TxnMetaData, error) {
@@ -251,32 +272,36 @@ func (c *PTBClient) SendTransaction(ctx context.Context, payload TransactionBloc
 func (c *PTBClient) ReadObjectId(ctx context.Context, objectId string) (models.SuiObjectData, error) {
 	var result models.SuiObjectData
 	err := c.WithRateLimit(ctx, "ReadObjectId", func(ctx context.Context) error {
-		objectReq := models.SuiGetObjectRequest{
-			ObjectId: objectId,
-			Options: models.SuiObjectDataOptions{
-				ShowContent: true,
-				ShowType:    true,
-				ShowOwner:   true,
-			},
-		}
-
-		response, err := c.client.SuiGetObject(ctx, objectReq)
-		if err != nil {
-			return fmt.Errorf("failed to read object: %w", err)
-		}
-
-		c.log.Infow("ReadObjectId response", "response", response)
-
-		if response.Data == nil || response.Data.Content == nil {
-			return fmt.Errorf("object has no content")
-		}
-
-		result = *response.Data
-
-		return nil
+		var err error
+		result, err = c.readObjectIdInternal(ctx, objectId)
+		return err
 	})
-
 	return result, err
+}
+
+// readObjectIdInternal is the internal implementation without rate limiting
+func (c *PTBClient) readObjectIdInternal(ctx context.Context, objectId string) (models.SuiObjectData, error) {
+	objectReq := models.SuiGetObjectRequest{
+		ObjectId: objectId,
+		Options: models.SuiObjectDataOptions{
+			ShowContent: true,
+			ShowType:    true,
+			ShowOwner:   true,
+		},
+	}
+
+	response, err := c.client.SuiGetObject(ctx, objectReq)
+	if err != nil {
+		return models.SuiObjectData{}, fmt.Errorf("failed to read object: %w", err)
+	}
+
+	c.log.Infow("ReadObjectId response", "response", response)
+
+	if response.Data == nil || response.Data.Content == nil {
+		return models.SuiObjectData{}, fmt.Errorf("object has no content")
+	}
+
+	return *response.Data, nil
 }
 
 func (c *PTBClient) ReadFilterOwnedObjectIds(ctx context.Context, ownerAddress string, structType string, limit *uint) ([]models.SuiObjectData, error) {
@@ -320,34 +345,38 @@ func (c *PTBClient) ReadFilterOwnedObjectIds(ctx context.Context, ownerAddress s
 func (c *PTBClient) ReadOwnedObjects(ctx context.Context, ownerAddress string, cursor *models.ObjectId) ([]models.SuiObjectResponse, error) {
 	var result []models.SuiObjectResponse
 	err := c.WithRateLimit(ctx, "ReadOwnedObjects", func(ctx context.Context) error {
-		ownedObjectsReq := models.SuiXGetOwnedObjectsRequest{
-			Address: ownerAddress,
-			Query: models.SuiObjectResponseQuery{
-				Options: models.SuiObjectDataOptions{
-					ShowContent: true,
-					ShowType:    true,
-					ShowOwner:   true,
-				},
-			},
-			Limit: uint64(maxPageSize),
-		}
-
-		if cursor != nil {
-			cursorHex := cursor
-			ownedObjectsReq.Cursor = string(cursorHex.Data())
-		}
-
-		response, err := c.client.SuiXGetOwnedObjects(ctx, ownedObjectsReq)
-		if err != nil {
-			return fmt.Errorf("failed to read owned objects: %w", err)
-		}
-
-		result = response.Data
-
-		return nil
+		var err error
+		result, err = c.readOwnedObjectsInternal(ctx, ownerAddress, cursor)
+		return err
 	})
-
 	return result, err
+}
+
+// readOwnedObjectsInternal is the internal implementation without rate limiting
+func (c *PTBClient) readOwnedObjectsInternal(ctx context.Context, ownerAddress string, cursor *models.ObjectId) ([]models.SuiObjectResponse, error) {
+	ownedObjectsReq := models.SuiXGetOwnedObjectsRequest{
+		Address: ownerAddress,
+		Query: models.SuiObjectResponseQuery{
+			Options: models.SuiObjectDataOptions{
+				ShowContent: true,
+				ShowType:    true,
+				ShowOwner:   true,
+			},
+		},
+		Limit: uint64(maxPageSize),
+	}
+
+	if cursor != nil {
+		cursorHex := cursor
+		ownedObjectsReq.Cursor = string(cursorHex.Data())
+	}
+
+	response, err := c.client.SuiXGetOwnedObjects(ctx, ownedObjectsReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read owned objects: %w", err)
+	}
+
+	return response.Data, nil
 }
 
 func (c *PTBClient) EstimateGas(ctx context.Context, txBytes string) (uint64, error) {
@@ -398,190 +427,197 @@ func (c *PTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, error) 
 func (c *PTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string, typeArgs []string) ([]any, error) {
 	var results []any
 	err := c.WithRateLimit(ctx, "ReadFunction", func(ctx context.Context) error {
-		txn := transaction.NewTransaction()
+		var err error
+		results, err = c.readFunctionInternal(ctx, signerAddress, packageId, module, function, args, argTypes, typeArgs)
+		return err
+	})
+	return results, err
+}
 
-		var txnArgs []transaction.Argument
-		var txnTypeArgs []transaction.TypeTag
+// readFunctionInternal is the internal implementation without rate limiting
+func (c *PTBClient) readFunctionInternal(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string, typeArgs []string) ([]any, error) {
+	var results []any
+	txn := transaction.NewTransaction()
 
-		// Process type arguments
-		for _, typeArg := range typeArgs {
-			typeTag, err := c.createTypeTag(typeArg)
-			if err != nil {
-				return fmt.Errorf("failed to create type tag for %s: %w", typeArg, err)
-			}
-			txnTypeArgs = append(txnTypeArgs, typeTag)
-		}
+	var txnArgs []transaction.Argument
+	var txnTypeArgs []transaction.TypeTag
 
-		for i, arg := range args {
-			argType, ok := common.ValueAt(argTypes, i)
-			if !ok {
-				argType = common.InferArgumentType(arg)
-			}
-
-			arg, err := c.TransformTransactionArg(ctx, txn, arg, argType, true)
-			if err != nil {
-				return fmt.Errorf("failed to transform transaction arg: %w", err)
-			}
-			txnArgs = append(txnArgs, *arg)
-		}
-
-		txn.SetSuiClient(c.client.(*sui.Client))
-		txn.SetSender(models.SuiAddress(signerAddress))
-		txn.SetGasBudget(DefaultGasBudget)
-		txn.SetGasPrice(DefaultGasPrice)
-		txn.MoveCall(models.SuiAddress(packageId), module, function, txnTypeArgs, txnArgs)
-
-		// Get transaction bytes
-		bcsEncodedMsg, err := txn.Data.V1.Kind.Marshal()
+	// Process type arguments
+	for _, typeArg := range typeArgs {
+		typeTag, err := c.createTypeTag(typeArg)
 		if err != nil {
-			return fmt.Errorf("failed to marshal transaction: %w", err)
+			return nil, fmt.Errorf("failed to create type tag for %s: %w", typeArg, err)
 		}
-		txBytes := mystenbcs.ToBase64(bcsEncodedMsg)
+		txnTypeArgs = append(txnTypeArgs, typeTag)
+	}
 
-		// Use dev inspect for read-only function calls
-		devInspectReq := models.SuiDevInspectTransactionBlockRequest{
-			Sender:  signerAddress,
-			TxBytes: txBytes,
-		}
-
-		response, err := c.client.SuiDevInspectTransactionBlock(ctx, devInspectReq)
-		if err != nil || response.Effects.Status.Status != "success" {
-			return fmt.Errorf("failed to read function: %w", err)
+	for i, arg := range args {
+		argType, ok := common.ValueAt(argTypes, i)
+		if !ok {
+			argType = common.InferArgumentType(arg)
 		}
 
-		c.log.Debugw("ReadFunction RPC response", "RPC response", response, "functionTag", fmt.Sprintf("%s::%s::%s", packageId, module, function))
-
-		if len(response.Results) == 0 {
-			return fmt.Errorf("no results from function call: %+v", response)
-		}
-
-		resultsMarshalled, err := response.Results.MarshalJSON()
+		arg, err := c.TransformTransactionArg(ctx, txn, arg, argType, true)
 		if err != nil {
-			return fmt.Errorf("failed to marshal results: %w", err)
+			return nil, fmt.Errorf("failed to transform transaction arg: %w", err)
 		}
-		var functionReadResponse []FunctionReadResponse
-		err = json.Unmarshal(resultsMarshalled, &functionReadResponse)
+		txnArgs = append(txnArgs, *arg)
+	}
+
+	txn.SetSuiClient(c.client.(*sui.Client))
+	txn.SetSender(models.SuiAddress(signerAddress))
+	txn.SetGasBudget(DefaultGasBudget)
+	txn.SetGasPrice(DefaultGasPrice)
+	txn.MoveCall(models.SuiAddress(packageId), module, function, txnTypeArgs, txnArgs)
+
+	// Get transaction bytes
+	bcsEncodedMsg, err := txn.Data.V1.Kind.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal transaction: %w", err)
+	}
+	txBytes := mystenbcs.ToBase64(bcsEncodedMsg)
+
+	// Use dev inspect for read-only function calls
+	devInspectReq := models.SuiDevInspectTransactionBlockRequest{
+		Sender:  signerAddress,
+		TxBytes: txBytes,
+	}
+
+	response, err := c.client.SuiDevInspectTransactionBlock(ctx, devInspectReq)
+	if err != nil || response.Effects.Status.Status != "success" {
+		return nil, fmt.Errorf("failed to read function: %w", err)
+	}
+
+	c.log.Debugw("ReadFunction RPC response", "RPC response", response, "functionTag", fmt.Sprintf("%s::%s::%s", packageId, module, function))
+
+	if len(response.Results) == 0 {
+		return nil, fmt.Errorf("no results from function call: %+v", response)
+	}
+
+	resultsMarshalled, err := response.Results.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+	var functionReadResponse []FunctionReadResponse
+	err = json.Unmarshal(resultsMarshalled, &functionReadResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal results: %w", err)
+	}
+
+	results = make([]any, len(functionReadResponse[0].ReturnValues))
+
+	// parse one or more results
+	for i, returnedValue := range functionReadResponse[0].ReturnValues {
+		returnedValue := returnedValue.([]any)
+		structTag := returnedValue[1].(string)
+		structPartsLen := 3
+
+		// create a bcs decoder from the return value
+		bcsBytes, err := codec.AnySliceToBytes(returnedValue[0].([]any))
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal results: %w", err)
+			return nil, fmt.Errorf("failed to convert return value to bytes: %w", err)
+		}
+		bcsDecoder := bcs.NewDeserializer(bcsBytes)
+
+		// This is a special case for Sui strings as they are represented as a struct with tag "0x1::string::String"
+		// Since we use the tag to fetch the normalized module, it causes a failure since a module "string" does not exist.
+		// We parse the value separately here. The BCS decoder is not actually needed for this case but we are already initializing it for the complex structs
+		// so we can use it to read the string value.
+		if structTag == "0x1::string::String" {
+			strValue := bcsDecoder.ReadString()
+			results[i] = strValue
+			continue
 		}
 
-		results = make([]any, len(functionReadResponse[0].ReturnValues))
+		// Handle vector<T> types. We need to distinguish between vectors of structs
+		// (e.g. vector<0x123::module::MyStruct>) and vectors of primitive values
+		// (e.g. vector<u8>, vector<u64>).
+		//
+		// - For vector<Struct>, fetch the normalized module metadata and decode each
+		//   element into a JSON object using DecodeVectorOfStructs.
+		// - For vector<primitive>, fall back to DecodeSuiPrimative to decode the raw
+		//   values.
+		// In both cases, run the result through ConvertBytesToHex so that any []byte
+		// fields (vector<u8> especially) are hex-encoded instead of base64 when
+		// marshalled to JSON.
+		if strings.HasPrefix(structTag, "vector<") && strings.HasSuffix(structTag, ">") {
+			// Extract inner type to determine if it's a vector of structs or primitives
+			innerType := strings.TrimSuffix(strings.TrimPrefix(structTag, "vector<"), ">")
+			innerStructParts := strings.Split(innerType, "::")
 
-		// parse one or more results
-		for i, returnedValue := range functionReadResponse[0].ReturnValues {
-			returnedValue := returnedValue.([]any)
-			structTag := returnedValue[1].(string)
-			structPartsLen := 3
+			// Check if inner type is a struct (3 parts: package::module::struct)
+			if len(innerStructParts) == structPartsLen {
+				// This is vector<Struct> - get normalized module for the inner struct
+				innerPackageId := innerStructParts[0]
+				innerModuleName := innerStructParts[1]
 
-			// create a bcs decoder from the return value
-			bcsBytes, err := codec.AnySliceToBytes(returnedValue[0].([]any))
-			if err != nil {
-				return fmt.Errorf("failed to convert return value to bytes: %w", err)
-			}
-			bcsDecoder := bcs.NewDeserializer(bcsBytes)
-
-			// This is a special case for Sui strings as they are represented as a struct with tag "0x1::string::String"
-			// Since we use the tag to fetch the normalized module, it causes a failure since a module "string" does not exist.
-			// We parse the value separately here. The BCS decoder is not actually needed for this case but we are already initializing it for the complex structs
-			// so we can use it to read the string value.
-			if structTag == "0x1::string::String" {
-				strValue := bcsDecoder.ReadString()
-				results[i] = strValue
-				continue
-			}
-
-			// Handle vector<T> types. We need to distinguish between vectors of structs
-			// (e.g. vector<0x123::module::MyStruct>) and vectors of primitive values
-			// (e.g. vector<u8>, vector<u64>).
-			//
-			// - For vector<Struct>, fetch the normalized module metadata and decode each
-			//   element into a JSON object using DecodeVectorOfStructs.
-			// - For vector<primitive>, fall back to DecodeSuiPrimative to decode the raw
-			//   values.
-			// In both cases, run the result through ConvertBytesToHex so that any []byte
-			// fields (vector<u8> especially) are hex-encoded instead of base64 when
-			// marshalled to JSON.
-			if strings.HasPrefix(structTag, "vector<") && strings.HasSuffix(structTag, ">") {
-				// Extract inner type to determine if it's a vector of structs or primitives
-				innerType := strings.TrimSuffix(strings.TrimPrefix(structTag, "vector<"), ">")
-				innerStructParts := strings.Split(innerType, "::")
-
-				// Check if inner type is a struct (3 parts: package::module::struct)
-				if len(innerStructParts) == structPartsLen {
-					// This is vector<Struct> - get normalized module for the inner struct
-					innerPackageId := innerStructParts[0]
-					innerModuleName := innerStructParts[1]
-
-					normalizedModule, err := c.GetNormalizedModule(ctx, innerPackageId, innerModuleName)
-					if err != nil {
-						return fmt.Errorf("failed to get normalized module for vector struct: %w", err)
-					}
-
-					// Use the new DecodeVectorOfStructs function
-					jsonResult, err := codec.DecodeVectorOfStructs(bcsDecoder, structTag, normalizedModule.Structs)
-					if err != nil {
-						return fmt.Errorf("failed to decode vector of structs: %w", err)
-					}
-
-					results[i] = jsonResult
-				} else {
-					// This is vector<primitive> - use existing primitive vector handling
-					primitive, err := codec.DecodeSuiPrimative(bcsDecoder, structTag)
-					if err != nil {
-						return fmt.Errorf("failed to decode primitive vector: %w", err)
-					}
-					results[i] = primitive
+				normalizedModule, err := c.getNormalizedModuleInternal(ctx, innerPackageId, innerModuleName)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get normalized module for vector struct: %w", err)
 				}
-				continue
-			}
 
-			// Handle non-vector types (existing logic)
-			structParts := strings.Split(structTag, "::")
+				// Use the new DecodeVectorOfStructs function
+				jsonResult, err := codec.DecodeVectorOfStructs(bcsDecoder, structTag, normalizedModule.Structs)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode vector of structs: %w", err)
+				}
 
-			// if the response type is not a struct (primitive type), skip the result (keep it as is)
-			if len(structParts) != structPartsLen {
+				results[i] = jsonResult
+			} else {
+				// This is vector<primitive> - use existing primitive vector handling
 				primitive, err := codec.DecodeSuiPrimative(bcsDecoder, structTag)
 				if err != nil {
-					return fmt.Errorf("failed to decode primitive: %w", err)
+					return nil, fmt.Errorf("failed to decode primitive vector: %w", err)
 				}
-				// Normalize large ints to decimal strings to be LOOP/JSON friendly
-				if structTag == "u128" || structTag == "u256" {
-					switch v := primitive.(type) {
-					case *big.Int:
-						results[i] = v.String()
-					case big.Int:
-						vv := v
-						results[i] = vv.String()
-					default:
-						results[i] = fmt.Sprint(v)
-					}
-				} else {
-					results[i] = primitive
-				}
-			} else {
-				// otherwise, get the normalized struct and attempt turning the result into JSON
-				normalizedModule, err := c.GetNormalizedModule(ctx, packageId, structParts[1])
-				if err != nil {
-					return fmt.Errorf("failed to get normalized struct: %w", err)
-				}
-
-				jsonResult, err := codec.DecodeSuiStructToJSON(normalizedModule.Structs, structParts[2], bcsDecoder)
-				if err != nil {
-					return fmt.Errorf("failed to parse struct into JSON: %w", err)
-				}
-
-				// convert any []uint8 fields to hex strings
-				hexified := common.ConvertBytesToHex(jsonResult)
-				results[i] = hexified
+				results[i] = primitive
 			}
+			continue
 		}
 
-		c.log.Debugw("ReadFunction results", "functionTag", fmt.Sprintf("%s::%s::%s", packageId, module, function), "results", results)
+		// Handle non-vector types (existing logic)
+		structParts := strings.Split(structTag, "::")
 
-		return nil
-	})
+		// if the response type is not a struct (primitive type), skip the result (keep it as is)
+		if len(structParts) != structPartsLen {
+			primitive, err := codec.DecodeSuiPrimative(bcsDecoder, structTag)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode primitive: %w", err)
+			}
+			// Normalize large ints to decimal strings to be LOOP/JSON friendly
+			if structTag == "u128" || structTag == "u256" {
+				switch v := primitive.(type) {
+				case *big.Int:
+					results[i] = v.String()
+				case big.Int:
+					vv := v
+					results[i] = vv.String()
+				default:
+					results[i] = fmt.Sprint(v)
+				}
+			} else {
+				results[i] = primitive
+			}
+		} else {
+			// otherwise, get the normalized struct and attempt turning the result into JSON
+			normalizedModule, err := c.getNormalizedModuleInternal(ctx, packageId, structParts[1])
+			if err != nil {
+				return nil, fmt.Errorf("failed to get normalized struct: %w", err)
+			}
 
-	return results, err
+			jsonResult, err := codec.DecodeSuiStructToJSON(normalizedModule.Structs, structParts[2], bcsDecoder)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse struct into JSON: %w", err)
+			}
+
+			// convert any []uint8 fields to hex strings
+			hexified := common.ConvertBytesToHex(jsonResult)
+			results[i] = hexified
+		}
+	}
+
+	c.log.Debugw("ReadFunction results", "functionTag", fmt.Sprintf("%s::%s::%s", packageId, module, function), "results", results)
+
+	return results, nil
 }
 
 func (c *PTBClient) SignAndSendTransaction(ctx context.Context, txBytesRaw string, signerPublicKey []byte, executionRequestType TransactionRequestType) (SuiTransactionBlockResponse, error) {
@@ -907,8 +943,17 @@ func (c *PTBClient) GetSUIBalance(ctx context.Context, address string) (*big.Int
 }
 
 func (c *PTBClient) GetNormalizedModule(ctx context.Context, packageId string, module string) (models.GetNormalizedMoveModuleResponse, error) {
-	c.log.Debugw("Getting normalized module", "packageId", packageId, "module", module)
+	var result models.GetNormalizedMoveModuleResponse
+	err := c.WithRateLimit(ctx, "GetNormalizedModule", func(ctx context.Context) error {
+		var err error
+		result, err = c.getNormalizedModuleInternal(ctx, packageId, module)
+		return err
+	})
+	return result, err
+}
 
+// getNormalizedModuleInternal is the internal implementation without rate limiting
+func (c *PTBClient) getNormalizedModuleInternal(ctx context.Context, packageId string, module string) (models.GetNormalizedMoveModuleResponse, error) {
 	// check if the normalized module is already cached
 	normalizedModule, ok := c.normalizedModules[packageId][module]
 	if ok {
@@ -923,8 +968,6 @@ func (c *PTBClient) GetNormalizedModule(ctx context.Context, packageId string, m
 		return models.GetNormalizedMoveModuleResponse{}, fmt.Errorf("failed to get normalized module: %w", err)
 	}
 
-	c.log.Debugw("Normalized module response", "normalizedModule", normalizedModule, "packageId", packageId, "module", module)
-
 	if _, ok := c.normalizedModules[packageId]; !ok {
 		c.normalizedModules[packageId] = make(map[string]models.GetNormalizedMoveModuleResponse)
 	}
@@ -932,16 +975,25 @@ func (c *PTBClient) GetNormalizedModule(ctx context.Context, packageId string, m
 	// cache the normalized module
 	c.normalizedModules[packageId][module] = normalizedModule
 
-	c.log.Debugw("Normalized module cached", "packageId", packageId, "module", module)
-
 	return normalizedModule, nil
 }
 
 // LoadModulePackages returns the set of package IDs for a given module using its original package ID
 // This method assumes that module names are unique across all packages
 func (c *PTBClient) LoadModulePackageIds(ctx context.Context, packageId string, module string, signerAddress string) ([]string, error) {
+	var result []string
+	err := c.WithRateLimit(ctx, "LoadModulePackageIds", func(ctx context.Context) error {
+		var err error
+		result, err = c.loadModulePackageIdsInternal(ctx, packageId, module, signerAddress)
+		return err
+	})
+	return result, err
+}
+
+// loadModulePackageIdsInternal is the internal implementation without rate limiting
+func (c *PTBClient) loadModulePackageIdsInternal(ctx context.Context, packageId string, module string, signerAddress string) ([]string, error) {
 	// Ensure that the module keeps track of its package IDs by checking that it has `add_package_id` function
-	normalizedModule, err := c.GetNormalizedModule(ctx, packageId, module)
+	normalizedModule, err := c.getNormalizedModuleInternal(ctx, packageId, module)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get normalized module: %w", err)
 	}
@@ -968,8 +1020,8 @@ func (c *PTBClient) LoadModulePackageIds(ctx context.Context, packageId string, 
 		return nil, fmt.Errorf("pointer struct name not found for package %s and module %s", packageId, module)
 	}
 
-	// Read the owned objects to get the pointer object's ID
-	ownedObjects, err := c.ReadOwnedObjects(ctx, packageId, nil)
+	// Read the owned objects to get the pointer object's ID - use internal method
+	ownedObjects, err := c.readOwnedObjectsInternal(ctx, packageId, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get owned objects: %w", err)
 	}
@@ -993,7 +1045,8 @@ func (c *PTBClient) LoadModulePackageIds(ctx context.Context, packageId string, 
 
 	c.log.Debugw("pointer ref object", "pointerObject", pointerObject)
 
-	parentObjectID, err := c.GetParentObjectID(ctx, packageId, module, pointerStructName)
+	// Use internal method to avoid nested semaphore acquisition
+	parentObjectID, err := c.getParentObjectIDInternal(ctx, packageId, module, pointerStructName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parent object ID in LoadModulePackageIds: %w", err)
 	}
@@ -1035,8 +1088,8 @@ func (c *PTBClient) LoadModulePackageIds(ctx context.Context, packageId string, 
 
 	c.log.Debugw("stateObjectId", "stateObjectId", stateObjectID, "derivationKey", derivationKey)
 
-	// Read the state object
-	stateObject, err := c.ReadObjectId(ctx, stateObjectID)
+	// Read the state object - use internal method
+	stateObject, err := c.readObjectIdInternal(ctx, stateObjectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get state object: %w", err)
 	}
@@ -1051,7 +1104,19 @@ func (c *PTBClient) LoadModulePackageIds(ctx context.Context, packageId string, 
 }
 
 func (c *PTBClient) GetLatestPackageId(ctx context.Context, packageId string, module string, signerAddress string) (string, error) {
-	packageIds, err := c.LoadModulePackageIds(ctx, packageId, module, signerAddress)
+	var result string
+	err := c.WithRateLimit(ctx, "GetLatestPackageId", func(ctx context.Context) error {
+		var err error
+		result, err = c.getLatestPackageIdInternal(ctx, packageId, module, signerAddress)
+		return err
+	})
+	return result, err
+}
+
+// getLatestPackageIdInternal is the internal implementation without rate limiting
+func (c *PTBClient) getLatestPackageIdInternal(ctx context.Context, packageId string, module string, signerAddress string) (string, error) {
+	// Use internal method to avoid nested semaphore acquisition
+	packageIds, err := c.loadModulePackageIdsInternal(ctx, packageId, module, signerAddress)
 	if err != nil {
 		return "", fmt.Errorf("failed to load module package ids: %w", err)
 	}
@@ -1122,7 +1187,19 @@ func (c *PTBClient) GetCCIPPackageID(ctx context.Context, offRampPackageID strin
 // This is used to get addresses stored within pointer objects on-chain. For example, the state object ID of a package is stored in the pointer object,
 // so we need to get the value of the pointer object's field to get the state object ID.
 func (c *PTBClient) GetValuesFromPackageOwnedObjectField(ctx context.Context, packageID string, moduleID string, objectName string, fieldKeys []string) (map[string]string, error) {
-	ownedObjects, err := c.ReadOwnedObjects(ctx, packageID, nil)
+	var result map[string]string
+	err := c.WithRateLimit(ctx, "GetValuesFromPackageOwnedObjectField", func(ctx context.Context) error {
+		var err error
+		result, err = c.getValuesFromPackageOwnedObjectFieldInternal(ctx, packageID, moduleID, objectName, fieldKeys)
+		return err
+	})
+	return result, err
+}
+
+// getValuesFromPackageOwnedObjectFieldInternal is the internal implementation without rate limiting
+func (c *PTBClient) getValuesFromPackageOwnedObjectFieldInternal(ctx context.Context, packageID string, moduleID string, objectName string, fieldKeys []string) (map[string]string, error) {
+	// Use internal method to avoid nested semaphore acquisition
+	ownedObjects, err := c.readOwnedObjectsInternal(ctx, packageID, nil)
 	if err != nil {
 		c.log.Errorw("Error reading owned objects", "error", err)
 		return nil, err
@@ -1152,7 +1229,19 @@ func (c *PTBClient) GetValuesFromPackageOwnedObjectField(ctx context.Context, pa
 // With derived objects, pointers now store a reference to the parent "Object" struct (e.g., OffRampObject, CCIPObject).
 // e.g. OffRampStatePointer contains "off_ramp_object_id" field pointing to OffRampObject.
 func (c *PTBClient) GetParentObjectID(ctx context.Context, packageID string, moduleID string, pointerObjectName string) (string, error) {
-	ownedObjects, err := c.ReadOwnedObjects(ctx, packageID, nil)
+	var result string
+	err := c.WithRateLimit(ctx, "GetParentObjectID", func(ctx context.Context) error {
+		var err error
+		result, err = c.getParentObjectIDInternal(ctx, packageID, moduleID, pointerObjectName)
+		return err
+	})
+	return result, err
+}
+
+// getParentObjectIDInternal is the internal implementation without rate limiting
+func (c *PTBClient) getParentObjectIDInternal(ctx context.Context, packageID string, moduleID string, pointerObjectName string) (string, error) {
+	// Use internal method to avoid nested semaphore acquisition
+	ownedObjects, err := c.readOwnedObjectsInternal(ctx, packageID, nil)
 	if err != nil {
 		c.log.Errorw("Error reading owned objects", "error", err)
 		return "", err
@@ -1201,7 +1290,8 @@ func (c *PTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, acco
 	if cached, ok := c.GetCachedValue(ccipPointerConfig.ParentFieldName); ok {
 		ccipObjectRefID = cached.(string)
 	} else {
-		ccipObjectID, err := c.GetParentObjectID(ctx, ccipPackageAddress, "state_object", ccipPointerConfig.Pointer)
+		// Use internal method to avoid nested semaphore acquisition
+		ccipObjectID, err := c.getParentObjectIDInternal(ctx, ccipPackageAddress, "state_object", ccipPointerConfig.Pointer)
 		if err != nil {
 			return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to get ccip parent object ID: %w", err)
 		}

--- a/relayer/client/ptb_client.go
+++ b/relayer/client/ptb_client.go
@@ -1211,7 +1211,7 @@ func (c *PTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, acco
 			return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to derive ccip object ref ID: %w", err)
 		}
 
-		c.SetCachedValue(ccipPointerConfig.ParentFieldName, ccipObjectID)
+		c.SetCachedValue(ccipPointerConfig.ParentFieldName, ccipObjectRefID)
 	}
 
 	// Obtain the pool token metadata using the token pool package ID by calling into TokenAdminRegistry

--- a/relayer/client/ptb_client.go
+++ b/relayer/client/ptb_client.go
@@ -141,6 +141,11 @@ func NewPTBClient(
 
 	httpClient := &http.Client{
 		Timeout: DefaultHTTPTimeout,
+		Transport: &http.Transport{
+			MaxConnsPerHost:     int(maxConcurrentRequests) * 2,
+			MaxIdleConns:        int(maxConcurrentRequests) * 2,
+			MaxIdleConnsPerHost: int(maxConcurrentRequests) * 2,
+		},
 	}
 	client := sui.NewSuiClientWithCustomClient(rpcUrl, httpClient)
 
@@ -175,16 +180,14 @@ func (c *PTBClient) WithRateLimit(ctx context.Context, methodName string, f func
 		weight = weightValue
 	}
 
+	workCtx, cancel := context.WithTimeout(ctx, c.transactionTimeout)
+	defer cancel()
+
 	// If rate limiter is disabled or weight is 0, skip semaphore entirely.
 	// This will skip adding to the semaphore queue and prevent unnecessary queuing.
 	if c.rateLimiter == nil || weight == 0 {
-		workCtx, cancel := context.WithTimeout(ctx, c.transactionTimeout)
-		defer cancel()
 		return f(workCtx)
 	}
-
-	workCtx, cancel := context.WithTimeout(ctx, c.transactionTimeout)
-	defer cancel()
 
 	// acquire with the timeout context so it can't hang forever
 	if err := c.rateLimiter.Acquire(ctx, weight); err != nil {

--- a/relayer/client/ptb_client.go
+++ b/relayer/client/ptb_client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/loop"
 
+	module_token_admin_registry "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/token_admin_registry"
 	module_offramp "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_offramp/offramp"
 	suiSigner "github.com/smartcontractkit/chainlink-sui/relayer/signer"
 
@@ -76,6 +77,7 @@ type SuiPTBClient interface {
 	GetCCIPPackageID(ctx context.Context, offRampPackageID string, signerAddress string) (string, error)
 	GetValuesFromPackageOwnedObjectField(ctx context.Context, packageID string, moduleID string, objectName string, fieldKeys []string) (map[string]string, error)
 	GetParentObjectID(ctx context.Context, packageID string, moduleID string, pointerObjectName string) (string, error)
+	GetTokenPoolConfigByPackageAddress(ctx context.Context, accountAddress string, tokenPoolAddress string, ccipPackageAddress string) (module_token_admin_registry.TokenConfig, error)
 }
 
 // PTBClient implements SuiClient interface using the blockvision SDK
@@ -1177,6 +1179,70 @@ func (c *PTBClient) GetParentObjectID(ctx context.Context, packageID string, mod
 	}
 
 	return "", fmt.Errorf("pointer object %s not found in package %s", qualifiedName, packageID)
+}
+
+// A helper to abstract away having to provide the generic type of a token pool state. Requires a CCIP / StateObject package binding.
+func (c *PTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, accountAddress string, tokenPoolAddress string, ccipPackageAddress string) (module_token_admin_registry.TokenConfig, error) {
+	devInspectSigner := suiSigner.NewDevInspectSigner(accountAddress)
+	tokenAdminRegistry, err := module_token_admin_registry.NewTokenAdminRegistry(ccipPackageAddress, c.GetClient())
+	if err != nil {
+		return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to create token admin registry contract: %w", err)
+	}
+
+	// Obtain the CCIPObjectRef ID from the CCIP package
+	ccipPointerConfigs := common.GetPointerConfigsByContract("ccip")
+	if len(ccipPointerConfigs) == 0 {
+		return module_token_admin_registry.TokenConfig{}, fmt.Errorf("ccip pointer config not found")
+	}
+
+	ccipPointerConfig := ccipPointerConfigs[0]
+
+	var ccipObjectRefID string
+	if cached, ok := c.GetCachedValue(ccipPointerConfig.ParentFieldName); ok {
+		ccipObjectRefID = cached.(string)
+	} else {
+		ccipObjectID, err := c.GetParentObjectID(ctx, ccipPackageAddress, "state_object", ccipPointerConfig.Pointer)
+		if err != nil {
+			return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to get ccip parent object ID: %w", err)
+		}
+
+		ccipObjectRefID, err = bind.DeriveObjectIDWithVectorU8Key(ccipObjectID, []byte("CCIPObjectRef"))
+		if err != nil {
+			return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to derive ccip object ref ID: %w", err)
+		}
+
+		c.SetCachedValue(ccipPointerConfig.ParentFieldName, ccipObjectID)
+	}
+
+	// Obtain the pool token metadata using the token pool package ID by calling into TokenAdminRegistry
+	poolTokenMetadataAddress, err := tokenAdminRegistry.DevInspect().GetPoolLocalToken(ctx, &bind.CallOpts{
+		WaitForExecution: true,
+		Signer:           devInspectSigner,
+	}, bind.Object{
+		Id: ccipObjectRefID,
+	}, tokenPoolAddress)
+
+	if err != nil {
+		return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to get pool local token: %w", err)
+	} else if poolTokenMetadataAddress == "" {
+		return module_token_admin_registry.TokenConfig{}, fmt.Errorf("pool token metadata address not found")
+	}
+
+	// Obtain the token pool config using the token pool metadata address by calling into TokenAdminRegistry
+	tokenPoolConfig, err := tokenAdminRegistry.DevInspect().GetTokenConfigStruct(ctx, &bind.CallOpts{
+		WaitForExecution: true,
+		Signer:           devInspectSigner,
+	}, bind.Object{
+		Id: ccipObjectRefID,
+	}, poolTokenMetadataAddress)
+
+	if err != nil {
+		return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to get token pool config: %w", err)
+	} else if tokenPoolConfig.TokenType == "" || tokenPoolConfig.TokenPoolPackageId == "" {
+		return module_token_admin_registry.TokenConfig{}, fmt.Errorf("failed to get token pool config: empty response fields")
+	}
+
+	return tokenPoolConfig, nil
 }
 
 // Add helper method to create type tags

--- a/relayer/client/ptb_client_test.go
+++ b/relayer/client/ptb_client_test.go
@@ -69,6 +69,7 @@ func TestPTBClient(t *testing.T) {
 			"get_count",
 			args,
 			argTypes,
+			[]string{},
 		)
 		require.NoError(t, err)
 		require.NotNil(t, response)
@@ -318,6 +319,7 @@ func TestPTBClient(t *testing.T) {
 			"get_result_struct",
 			[]any{},
 			[]string{},
+			[]string{},
 		)
 		require.NoError(t, err)
 		utils.PrettyPrint(response)
@@ -331,6 +333,7 @@ func TestPTBClient(t *testing.T) {
 			"counter",
 			"type_and_version",
 			[]any{},
+			[]string{},
 			[]string{},
 		)
 		require.NoError(t, err)
@@ -346,6 +349,7 @@ func TestPTBClient(t *testing.T) {
 			"get_nested_result_struct",
 			[]any{},
 			[]string{},
+			[]string{},
 		)
 		require.NoError(t, err)
 		utils.PrettyPrint(response)
@@ -359,6 +363,7 @@ func TestPTBClient(t *testing.T) {
 			"counter",
 			"get_multi_nested_result_struct",
 			[]any{},
+			[]string{},
 			[]string{},
 		)
 		require.NoError(t, err)
@@ -374,6 +379,7 @@ func TestPTBClient(t *testing.T) {
 			"get_tuple_struct",
 			[]any{},
 			[]string{},
+			[]string{},
 		)
 		require.NoError(t, err)
 		utils.PrettyPrint(response)
@@ -387,6 +393,7 @@ func TestPTBClient(t *testing.T) {
 			"counter",
 			"get_ocr_config",
 			[]any{},
+			[]string{},
 			[]string{},
 		)
 		require.NoError(t, err)
@@ -402,6 +409,7 @@ func TestPTBClient(t *testing.T) {
 			"get_vector_of_u8",
 			[]any{},
 			[]string{},
+			[]string{},
 		)
 		require.NoError(t, err)
 		utils.PrettyPrint(values)
@@ -415,6 +423,7 @@ func TestPTBClient(t *testing.T) {
 			"counter",
 			"get_vector_of_addresses",
 			[]any{},
+			[]string{},
 			[]string{},
 		)
 		require.NoError(t, err)

--- a/relayer/codec/types.go
+++ b/relayer/codec/types.go
@@ -65,6 +65,8 @@ type SuiFunctionParam struct {
 	DefaultValue any
 	// Result from a previous PTB Command (optional). It is used for expressive construction of PTB commands
 	PTBDependency *PTBCommandDependency
+	// GenericDependency maps to internal helpers for fetching an unknown generic type required by the parameter
+	GenericDependency *string
 }
 
 type SuiPTBCommandType string

--- a/relayer/testutils/fake_client.go
+++ b/relayer/testutils/fake_client.go
@@ -43,7 +43,7 @@ func (c *FakeSuiPTBClient) ReadOwnedObjects(ctx context.Context, ownerAddress st
 	return []models.SuiObjectResponse{}, nil
 }
 
-func (c *FakeSuiPTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string) ([]any, error) {
+func (c *FakeSuiPTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string, typeArgs []string) ([]any, error) {
 	return []any{}, nil
 }
 
@@ -206,7 +206,7 @@ func (c *StatefulFakeSuiPTBClient) ReadOwnedObjects(ctx context.Context, ownerAd
 	return []models.SuiObjectResponse{}, nil
 }
 
-func (c *StatefulFakeSuiPTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string) ([]any, error) {
+func (c *StatefulFakeSuiPTBClient) ReadFunction(ctx context.Context, signerAddress string, packageId string, module string, function string, args []any, argTypes []string, typeArgs []string) ([]any, error) {
 	return []any{}, nil
 }
 

--- a/relayer/testutils/fake_client.go
+++ b/relayer/testutils/fake_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/patrickmn/go-cache"
 
+	module_token_admin_registry "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-sui/relayer/client"
 )
 
@@ -173,6 +174,10 @@ func (c *FakeSuiPTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, 
 
 func (c *FakeSuiPTBClient) QueryCoinsByAddress(ctx context.Context, address string, coinType string) ([]models.CoinData, error) {
 	return []models.CoinData{}, nil
+}
+
+func (c *FakeSuiPTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, accountAddress string, tokenPoolAddress string, ccipPackageAddress string) (module_token_admin_registry.TokenConfig, error) {
+	return module_token_admin_registry.TokenConfig{}, nil
 }
 
 // StatefulFakeSuiPTBClient is a more sophisticated fake client that can change behavior
@@ -345,4 +350,8 @@ func (c *StatefulFakeSuiPTBClient) GetReferenceGasPrice(ctx context.Context) (*b
 
 func (c *StatefulFakeSuiPTBClient) QueryCoinsByAddress(ctx context.Context, address string, coinType string) ([]models.CoinData, error) {
 	return []models.CoinData{}, nil
+}
+
+func (c *StatefulFakeSuiPTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, accountAddress string, tokenPoolAddress string, ccipPackageAddress string) (module_token_admin_registry.TokenConfig, error) {
+	return module_token_admin_registry.TokenConfig{}, nil
 }


### PR DESCRIPTION
Enables finding an unknown generic type for a parameter defined in a ChainReaderFunction. Each generic type resolver must be implemented separately and may require some bindings of package need to fetch the results.

This PR also updates the concurrency and rate limiting controls in PTBClient.