### PR TITLE
fix(deployment): Connect lane router

### DIFF
--- a/deployment/changesets/cs_connect_sui_to_evm.go
+++ b/deployment/changesets/cs_connect_sui_to_evm.go
@@ -104,12 +104,16 @@ func (d ConnectSuiToEVM) Apply(e cldf.Environment, config ConnectSuiToEVMConfig)
 	seqReports = append(seqReports, []operations.Report[any, any]{reportApplySourceChainConfigUpdatesOp.ToGenericReport()}...)
 
 	// Configure Router
+	onrampAddresses := make([]string, len(config.ApplyDestChainConfigureOnRampInput.DestChainSelector))
+	for i := range config.ApplyDestChainConfigureOnRampInput.DestChainSelector {
+		onrampAddresses[i] = config.ApplyDestChainConfigureOnRampInput.OnRampPackageId
+	}
 	reportConfigureRouterOp, err := operations.ExecuteOperation(e.OperationsBundle, ccip_router_ops.SetOnRampsOp, deps, ccip_router_ops.SetOnRampsInput{
 		RouterPackageId:     state[config.SuiChainSelector].CCIPRouterAddress,
 		RouterStateObjectId: state[config.SuiChainSelector].CCIPRouterStateObjectID,
-		OwnerCapObjectId:    state[config.SuiChainSelector].CCIPRouterOwnerCapObjectId, // TODO: this value is not stored in onchain state
-		DestChainSelectors:  []uint64{},
-		OnRampAddresses:     []string{},
+		OwnerCapObjectId:    state[config.SuiChainSelector].CCIPRouterOwnerCapObjectId,
+		DestChainSelectors:  config.ApplyDestChainConfigureOnRampInput.DestChainSelector,
+		OnRampAddresses:     onrampAddresses,
 	})
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run ConfigureRouterOp for Sui chain %d: %w", config.SuiChainSelector, err)

--- a/deployment/changesets/cs_connect_sui_to_evm.go
+++ b/deployment/changesets/cs_connect_sui_to_evm.go
@@ -5,12 +5,14 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	ccip_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
 	ccip_offramp_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_offramp"
 	ccip_onramp_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
+	ccip_router_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 )
 
 type ConnectSuiToEVMConfig struct {
@@ -100,6 +102,19 @@ func (d ConnectSuiToEVM) Apply(e cldf.Environment, config ConnectSuiToEVMConfig)
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run ApplySourceChainConfigUpdatesOp for Sui chain %d: %w", config.SuiChainSelector, err)
 	}
 	seqReports = append(seqReports, []operations.Report[any, any]{reportApplySourceChainConfigUpdatesOp.ToGenericReport()}...)
+
+	// Configure Router
+	reportConfigureRouterOp, err := operations.ExecuteOperation(e.OperationsBundle, ccip_router_ops.SetOnRampsOp, deps, ccip_router_ops.SetOnRampsInput{
+		RouterPackageId:     state[config.SuiChainSelector].CCIPRouterAddress,
+		RouterStateObjectId: state[config.SuiChainSelector].CCIPRouterStateObjectID,
+		OwnerCapObjectId:    state[config.SuiChainSelector].CCIPRouterOwnerCapObjectId, // TODO: this value is not stored in onchain state
+		DestChainSelectors:  []uint64{},
+		OnRampAddresses:     []string{},
+	})
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to run ConfigureRouterOp for Sui chain %d: %w", config.SuiChainSelector, err)
+	}
+	seqReports = append(seqReports, []operations.Report[any, any]{reportConfigureRouterOp.ToGenericReport()}...)
 
 	return cldf.ChangesetOutput{
 		Reports: seqReports,

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -119,6 +119,12 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save Router state object Id %s for Sui chain %d: %w", routerReport.Output.Objects.RouterStateObjectId, config.SuiChainSelector, err)
 	}
 
+	typeAndVersionRouterOwnerCap := cldf.NewTypeAndVersion(deployment.SuiCCIPRouterOwnerCapObjectIDType, deployment.Version1_0_0)
+	err = ab.Save(config.SuiChainSelector, routerReport.Output.Objects.OwnerCapObjectId, typeAndVersionRouterOwnerCap)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to save Router owner cap object Id %s for Sui chain %d: %w", routerReport.Output.Objects.OwnerCapObjectId, config.SuiChainSelector, err)
+	}
+
 	// --------------------------
 	// CCIP SEQUENCE
 	// --------------------------

--- a/deployment/ops/ccip_router/op_deploy.go
+++ b/deployment/ops/ccip_router/op_deploy.go
@@ -57,6 +57,13 @@ type DeployCCIPRouterObjects struct {
 	RouterStatePointerObjectId string
 }
 
+var DeployCCIPRouterOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-router", "package", "deploy"),
+	semver.MustParse("0.1.0"),
+	"Deploys the CCIP router package",
+	deployHandler,
+)
+
 var deployHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input DeployCCIPRouterInput) (output sui_ops.OpTxResult[DeployCCIPRouterObjects], err error) {
 	opts := deps.GetCallOpts()
 	opts.Signer = deps.Signer
@@ -171,6 +178,13 @@ type SetOnRampsObjects struct {
 	// No specific objects are returned from set_on_ramps
 }
 
+var SetOnRampsOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-router", "package", "set-on-ramps"),
+	semver.MustParse("0.1.0"),
+	"Sets on-ramp addresses for destination chains in the CCIP router",
+	setOnRampsHandler,
+)
+
 var setOnRampsHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input SetOnRampsInput) (output sui_ops.OpTxResult[SetOnRampsObjects], err error) {
 	routerPackage, err := module_router.NewRouter(input.RouterPackageId, deps.Client)
 	if err != nil {
@@ -225,20 +239,6 @@ var setOnRampsHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input SetO
 	}, nil
 }
 
-var DeployCCIPRouterOp = cld_ops.NewOperation(
-	sui_ops.NewSuiOperationName("ccip-router", "package", "deploy"),
-	semver.MustParse("0.1.0"),
-	"Deploys the CCIP router package",
-	deployHandler,
-)
-
-var SetOnRampsOp = cld_ops.NewOperation(
-	sui_ops.NewSuiOperationName("ccip-router", "package", "set-on-ramps"),
-	semver.MustParse("0.1.0"),
-	"Sets on-ramp addresses for destination chains in the CCIP router",
-	setOnRampsHandler,
-)
-
 // NoObjects is used for operations that don't return any specific objects
 type NoObjects struct{}
 
@@ -250,6 +250,13 @@ type AcceptOwnershipInput struct {
 	RouterPackageId     string
 	RouterStateObjectId string
 }
+
+var AcceptOwnershipOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-router", "package", "accept-ownership"),
+	semver.MustParse("0.1.0"),
+	"Accepts ownership transfer for the CCIP router",
+	acceptOwnershipHandler,
+)
 
 var acceptOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptOwnershipInput) (output sui_ops.OpTxResult[NoObjects], err error) {
 	routerContract, err := module_router.NewRouter(input.RouterPackageId, deps.Client)
@@ -295,13 +302,6 @@ var acceptOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input
 	}, nil
 }
 
-var AcceptOwnershipOp = cld_ops.NewOperation(
-	sui_ops.NewSuiOperationName("ccip-router", "package", "accept-ownership"),
-	semver.MustParse("0.1.0"),
-	"Accepts ownership transfer for the CCIP router",
-	acceptOwnershipHandler,
-)
-
 // ================================================================
 // |                  Transfer Ownership                         |
 // ================================================================
@@ -312,6 +312,13 @@ type TransferOwnershipInput struct {
 	OwnerCapObjectId    string
 	NewOwner            string
 }
+
+var TransferOwnershipOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-router", "package", "transfer-ownership"),
+	semver.MustParse("0.1.0"),
+	"Transfers ownership of the CCIP router to a new owner",
+	transferOwnershipHandler,
+)
 
 var transferOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input TransferOwnershipInput) (output sui_ops.OpTxResult[NoObjects], err error) {
 	routerContract, err := module_router.NewRouter(input.RouterPackageId, deps.Client)
@@ -341,13 +348,6 @@ var transferOwnershipHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, inp
 	}, nil
 }
 
-var TransferOwnershipOp = cld_ops.NewOperation(
-	sui_ops.NewSuiOperationName("ccip-router", "package", "transfer-ownership"),
-	semver.MustParse("0.1.0"),
-	"Transfers ownership of the CCIP router to a new owner",
-	transferOwnershipHandler,
-)
-
 // ================================================================
 // |               Execute Ownership Transfer                     |
 // ================================================================
@@ -358,6 +358,13 @@ type ExecuteOwnershipTransferInput struct {
 	OwnerCapObjectId    string
 	To                  string
 }
+
+var ExecuteOwnershipTransferOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("ccip-router", "package", "execute-ownership-transfer"),
+	semver.MustParse("0.1.0"),
+	"Executes ownership transfer for the CCIP router",
+	executeOwnershipTransferHandler,
+)
 
 var executeOwnershipTransferHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input ExecuteOwnershipTransferInput) (output sui_ops.OpTxResult[NoObjects], err error) {
 	routerContract, err := module_router.NewRouter(input.RouterPackageId, deps.Client)
@@ -386,10 +393,3 @@ var executeOwnershipTransferHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDe
 		Objects:   NoObjects{},
 	}, nil
 }
-
-var ExecuteOwnershipTransferOp = cld_ops.NewOperation(
-	sui_ops.NewSuiOperationName("ccip-router", "package", "execute-ownership-transfer"),
-	semver.MustParse("0.1.0"),
-	"Executes ownership transfer for the CCIP router",
-	executeOwnershipTransferHandler,
-)

--- a/deployment/state.go
+++ b/deployment/state.go
@@ -62,8 +62,9 @@ type CCIPChainState struct {
 	FeeQuoterCapId         string
 
 	// CCIP Router related
-	CCIPRouterAddress       string
-	CCIPRouterStateObjectID string
+	CCIPRouterAddress          string
+	CCIPRouterStateObjectID    string
+	CCIPRouterOwnerCapObjectId string
 
 	// OnRamp related
 	OnRampAddress          string
@@ -346,6 +347,8 @@ func loadsuiChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) (C
 			chainState.CCIPRouterAddress = addr
 		case SuiCCIPRouterStateObjectType:
 			chainState.CCIPRouterStateObjectID = addr
+		case SuiCCIPRouterOwnerCapObjectIDType:
+			chainState.CCIPRouterOwnerCapObjectId = addr
 
 		// CCIP related
 		case SuiCCIPType:

--- a/deployment/types.go
+++ b/deployment/types.go
@@ -7,8 +7,7 @@ import (
 )
 
 var (
-	SuiCCIPRouterType                deployment.ContractType = "SuiRouter"
-	SuiCCIPRouterStateObjectType     deployment.ContractType = "SuiRouterStateObjectID"
+	// CCIP
 	SuiCCIPType                      deployment.ContractType = "SuiCCIP"
 	SuiCCIPObjectRefType             deployment.ContractType = "SuiCCIPObjectRef"
 	SuiCCIPOwnerCapObjectIDType      deployment.ContractType = "SuiCCIPOwnerCapObjectID"
@@ -24,6 +23,11 @@ var (
 	SuiOffRampStateObjectIDType      deployment.ContractType = "SuiOffRampStateObjectID"
 	SuiLockReleaseTPType             deployment.ContractType = "SuiLockReleaseToken"
 	SuiLockReleaseTPStateType        deployment.ContractType = "SuiLockReleaseTokenState"
+
+	// CCIP Router
+	SuiCCIPRouterType                 deployment.ContractType = "SuiRouter"
+	SuiCCIPRouterStateObjectType      deployment.ContractType = "SuiRouterStateObjectID"
+	SuiCCIPRouterOwnerCapObjectIDType deployment.ContractType = "SuiCCIPRouterOwnerCapObjectID"
 
 	// MCMS Related
 	SuiMcmsPackageIDType               deployment.ContractType = "SuiManyChainMultisigPackageID"

--- a/integration-tests/deploy/config.go
+++ b/integration-tests/deploy/config.go
@@ -145,7 +145,29 @@ func BuildExpectedSuiChainView(s *DeployTestSuite, state deployment.CCIPChainSta
 					LinkToken:                    state.LinkTokenCoinMetadataId,
 					TokenPriceStalenessThreshold: deployment.DefaultCCIPSeqConfig.TokenPriceStalenessThreshold,
 				},
-				DestinationChainConfigs: map[uint64]view.FeeQuoterDestChainConfig{}, // TODO: Changesets are not configuring router, any configuration that requires GetDestChains will be empty
+				DestinationChainConfigs: map[uint64]view.FeeQuoterDestChainConfig{
+					EVMChainSelector: {
+						IsEnabled:                         ccipConfig.IsEnabled,
+						MaxNumberOfTokensPerMsg:           ccipConfig.MaxNumberOfTokensPerMsg,
+						MaxDataBytes:                      ccipConfig.MaxDataBytes,
+						MaxPerMsgGasLimit:                 ccipConfig.MaxPerMsgGasLimit,
+						DestGasOverhead:                   ccipConfig.DestGasOverhead,
+						DestGasPerPayloadByteBase:         ccipConfig.DestGasPerPayloadByteBase,
+						DestGasPerPayloadByteHigh:         ccipConfig.DestGasPerPayloadByteHigh,
+						DestGasPerPayloadByteThreshold:    ccipConfig.DestGasPerPayloadByteThreshold,
+						DestDataAvailabilityOverheadGas:   ccipConfig.DestDataAvailabilityOverheadGas,
+						DestGasPerDataAvailabilityByte:    ccipConfig.DestGasPerDataAvailabilityByte,
+						DestDataAvailabilityMultiplierBps: ccipConfig.DestDataAvailabilityMultiplierBps,
+						ChainFamilySelector:               fmt.Sprintf("%x", ccipConfig.ChainFamilySelector),
+						EnforceOutOfOrder:                 ccipConfig.EnforceOutOfOrder,
+						DefaultTokenFeeUsdCents:           ccipConfig.DefaultTokenFeeUsdCents,
+						DefaultTokenDestGasOverhead:       ccipConfig.DefaultTokenDestGasOverhead,
+						DefaultTxGasLimit:                 ccipConfig.DefaultTxGasLimit,
+						GasMultiplierWeiPerEth:            ccipConfig.GasMultiplierWeiPerEth,
+						GasPriceStalenessThreshold:        ccipConfig.GasPriceStalenessThreshold,
+						NetworkFeeUsdCents:                ccipConfig.NetworkFeeUsdCents,
+					},
+				},
 			},
 			RMNRemote: view.RMNRemoteView{
 				ContractMetaData: view.ContractMetaData{
@@ -206,7 +228,17 @@ func BuildExpectedSuiChainView(s *DeployTestSuite, state deployment.CCIPChainSta
 				FeeAggregator:  owner,
 				AllowlistAdmin: owner,
 			},
-			DestChainSpecificData: map[uint64]view.DestChainSpecificData{},
+			DestChainSpecificData: map[uint64]view.DestChainSpecificData{
+				EVMChainSelector: {
+					AllowedSendersList: []string{},
+					DestChainConfig: view.OnRampDestChainConfig{
+						SequenceNumber:   0,
+						AllowlistEnabled: DestChainConfigureOnRamp.DestChainAllowListEnabled[0],
+						Router:           DestChainConfigureOnRamp.DestChainRouters[0],
+					},
+					ExpectedNextSeqNum: 1,
+				},
+			},
 		},
 		OffRamp: view.OffRampView{
 			ContractMetaData: view.ContractMetaData{
@@ -243,7 +275,7 @@ func BuildExpectedSuiChainView(s *DeployTestSuite, state deployment.CCIPChainSta
 				StateObjectID:  state.CCIPRouterStateObjectID,
 			},
 			IsTestRouter: false,
-			OnRamps:      map[uint64]string{},
+			OnRamps:      map[uint64]string{EVMChainSelector: state.OnRampAddress},
 			OffRamps:     nil,
 		},
 		TokenPools: map[string]map[string]view.TokenPoolView{


### PR DESCRIPTION
core ref: 40d55027b3215700ffd83669a555988248712f4b
# Summary
This PR ensures Router state is explicitly configured when connecting SUI to an EVM destination, and makes the Router the canonical source of destination selectors

# Features
- Update state to save `CCIPRouterOwnerCapObjectId`
- Update `ConnectSuiToEVMConfig` changeset to configure Router
- nit: rearrange `op_deploy.go` file to correct go style
- update integration tests to account for destination chain configs in views