### PR TITLE
feat(deployment): views Ramps as maps

### DIFF
--- a/deployment/state.go
+++ b/deployment/state.go
@@ -30,10 +30,10 @@ type SuiChainView struct {
 
 	MCMSWithTimelock view.MCMSWithTimelockView `json:"mcmsWithTimelock"`
 
-	CCIP    view.CCIPView    `json:"ccip,omitempty"`
-	OnRamp  view.OnRampView  `json:"onRamp,omitempty"`
-	OffRamp view.OffRampView `json:"offRamp,omitempty"`
-	Router  view.RouterView  `json:"router,omitempty"`
+	CCIP    view.CCIPView               `json:"ccip,omitempty"`
+	OnRamp  map[string]view.OnRampView  `json:"onRamp,omitempty"`
+	OffRamp map[string]view.OffRampView `json:"offRamp,omitempty"`
+	Router  view.RouterView             `json:"router,omitempty"`
 
 	TokenPools map[string]map[string]view.TokenPoolView `json:"tokenPools,omitempty"` // TokenSymbol => TokenPool Address => PoolView
 }
@@ -111,6 +111,8 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 	chainView := SuiChainView{
 		ChainSelector: selector,
 		TokenPools:    make(map[string]map[string]view.TokenPoolView),
+		OnRamp:        make(map[string]view.OnRampView),
+		OffRamp:       make(map[string]view.OffRampView),
 	}
 
 	lggr.Infow("generating Sui chain view", "chain", chainName, "selector", selector)
@@ -174,7 +176,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 				return fmt.Errorf("failed to generate onramp view for onramp %s: %w", s.OnRampAddress, err)
 			}
 			mu.Lock()
-			chainView.OnRamp = onRampView
+			chainView.OnRamp[s.OnRampAddress] = onRampView
 			mu.Unlock()
 			lggr.Infow("generated onRamp view", "onRampAddress", s.OnRampAddress, "chain", chainName)
 			return nil
@@ -189,7 +191,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 				return fmt.Errorf("failed to generate offramp view for offramp %s: %w", s.OffRampAddress, err)
 			}
 			mu.Lock()
-			chainView.OffRamp = offRampView
+			chainView.OffRamp[s.OffRampAddress] = offRampView
 			mu.Unlock()
 			lggr.Infow("generated offRamp view", "offRampAddress", s.OffRampAddress, "chain", chainName)
 			return nil

--- a/integration-tests/deploy/config.go
+++ b/integration-tests/deploy/config.go
@@ -214,56 +214,60 @@ func BuildExpectedSuiChainView(s *DeployTestSuite, state deployment.CCIPChainSta
 				},
 			},
 		},
-		OnRamp: view.OnRampView{
-			ContractMetaData: view.ContractMetaData{
-				Address:        state.OnRampAddress,
-				Owner:          owner,
-				TypeAndVersion: "OnRamp 1.6.0",
-				StateObjectID:  state.OnRampStateObjectId,
-			},
-			StaticConfig: view.OnRampStaticConfig{
-				ChainSelector: SuiChainSelector,
-			},
-			DynamicConfig: view.OnRampDynamicConfig{
-				FeeAggregator:  owner,
-				AllowlistAdmin: owner,
-			},
-			DestChainSpecificData: map[uint64]view.DestChainSpecificData{
-				EVMChainSelector: {
-					AllowedSendersList: []string{},
-					DestChainConfig: view.OnRampDestChainConfig{
-						SequenceNumber:   0,
-						AllowlistEnabled: DestChainConfigureOnRamp.DestChainAllowListEnabled[0],
-						Router:           DestChainConfigureOnRamp.DestChainRouters[0],
+		OnRamp: map[string]view.OnRampView{
+			state.OnRampAddress: {
+				ContractMetaData: view.ContractMetaData{
+					Address:        state.OnRampAddress,
+					Owner:          owner,
+					TypeAndVersion: "OnRamp 1.6.0",
+					StateObjectID:  state.OnRampStateObjectId,
+				},
+				StaticConfig: view.OnRampStaticConfig{
+					ChainSelector: SuiChainSelector,
+				},
+				DynamicConfig: view.OnRampDynamicConfig{
+					FeeAggregator:  owner,
+					AllowlistAdmin: owner,
+				},
+				DestChainSpecificData: map[uint64]view.DestChainSpecificData{
+					EVMChainSelector: {
+						AllowedSendersList: []string{},
+						DestChainConfig: view.OnRampDestChainConfig{
+							SequenceNumber:   0,
+							AllowlistEnabled: DestChainConfigureOnRamp.DestChainAllowListEnabled[0],
+							Router:           DestChainConfigureOnRamp.DestChainRouters[0],
+						},
+						ExpectedNextSeqNum: 1,
 					},
-					ExpectedNextSeqNum: 1,
 				},
 			},
 		},
-		OffRamp: view.OffRampView{
-			ContractMetaData: view.ContractMetaData{
-				Address:        state.OffRampAddress,
-				Owner:          owner,
-				TypeAndVersion: "OffRamp 1.6.0",
-				StateObjectID:  state.OffRampStateObjectId,
-			},
-			StaticConfig: view.OffRampStaticConfig{
-				ChainSelector:      SuiChainSelector,
-				RMNRemote:          state.CCIPAddress,
-				TokenAdminRegistry: state.CCIPAddress,
-				NonceManager:       state.CCIPAddress,
-			},
-			DynamicConfig: view.OffRampDynamicConfig{
-				FeeQuoter:                               state.CCIPAddress,
-				PermissionlessExecutionThresholdSeconds: 28800,
-			},
-			SourceChainConfigs: map[uint64]view.OffRampSourceChainConfig{
-				EVMChainSelector: {
-					Router:                    state.CCIPAddress,
-					IsEnabled:                 true,
-					MinSeqNr:                  1,
-					IsRMNVerificationDisabled: true,
-					OnRamp:                    fmt.Sprintf("0x%s", DestChainOnRampAddress),
+		OffRamp: map[string]view.OffRampView{
+			state.OffRampAddress: {
+				ContractMetaData: view.ContractMetaData{
+					Address:        state.OffRampAddress,
+					Owner:          owner,
+					TypeAndVersion: "OffRamp 1.6.0",
+					StateObjectID:  state.OffRampStateObjectId,
+				},
+				StaticConfig: view.OffRampStaticConfig{
+					ChainSelector:      SuiChainSelector,
+					RMNRemote:          state.CCIPAddress,
+					TokenAdminRegistry: state.CCIPAddress,
+					NonceManager:       state.CCIPAddress,
+				},
+				DynamicConfig: view.OffRampDynamicConfig{
+					FeeQuoter:                               state.CCIPAddress,
+					PermissionlessExecutionThresholdSeconds: 28800,
+				},
+				SourceChainConfigs: map[uint64]view.OffRampSourceChainConfig{
+					EVMChainSelector: {
+						Router:                    state.CCIPAddress,
+						IsEnabled:                 true,
+						MinSeqNr:                  1,
+						IsRMNVerificationDisabled: true,
+						OnRamp:                    fmt.Sprintf("0x%s", DestChainOnRampAddress),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
# Summary
Use `OnRamp` and `OffRamp` as maps of `address -> (on/off)RampView` instead of a single object. Although there'll be only one OnRamp and OffRamp this adheres to the same pattern used by other chain families.

# Testing
Integration tests that asserts views