### PR TITLE
Enhancement: Enable static and input-based response in CR functions

### DIFF
--- a/relayer/chainreader/config/config.go
+++ b/relayer/chainreader/config/config.go
@@ -35,6 +35,10 @@ type ChainReaderFunction struct {
 	ResultTupleToStruct []string
 	// Defines a mapping for renaming response fields
 	ResultFieldRenames map[string]aptosCRConfig.RenamedField
+	// Static response
+	StaticResponse []any
+	// Response from inputs
+	ResponseFromInputs []string
 }
 
 type ChainReaderEvent struct {

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -926,6 +926,19 @@ func (s *suiChainReader) executeFunction(ctx context.Context, parsed *readIdenti
 	// this is the upgraded pkgID
 	parsed.address = latestPackageId
 
+	if len(functionConfig.StaticResponse) > 0 {
+		return functionConfig.StaticResponse, nil
+	} else if len(functionConfig.ResponseFromInputs) > 0 {
+		for _, pluckFromInput := range functionConfig.ResponseFromInputs {
+			switch pluckFromInput {
+			case "package_id":
+				return []any{latestPackageId}, nil
+			default:
+				return nil, fmt.Errorf("unknown response from inputs selection: %s", pluckFromInput)
+			}
+		}
+	}
+
 	values, err := s.client.ReadFunction(ctx, functionConfig.SignerAddress, parsed.address, parsed.contractName, parsed.readName, args, argTypes, typeArgs)
 	if err != nil {
 		s.logger.Errorw("ReadFunction failed",

--- a/relayer/chainreader/reader/chainreader_local_test.go
+++ b/relayer/chainreader/reader/chainreader_local_test.go
@@ -277,6 +277,32 @@ func runChainReaderCounterTest(t *testing.T, log logger.Logger, rpcUrl string) {
 							},
 						},
 					},
+					"static_response": {
+						Name:          "static_response",
+						SignerAddress: accountAddress,
+						Params: []codec.SuiFunctionParam{
+							{
+								Type:       "object_id",
+								Name:       "counter_id",
+								PointerTag: pointerTag,
+								Required:   true,
+							},
+							{
+								Type:       "object_id",
+								Name:       "ccip_object_ref_id",
+								PointerTag: pointerTagSecondary,
+								Required:   true,
+							},
+						},
+						StaticResponse:      []any{1, 2, 3},
+						ResultTupleToStruct: []string{"a", "b", "c"},
+					},
+					"response_from_inputs": {
+						Name:               "response_from_inputs",
+						SignerAddress:      accountAddress,
+						Params:             []codec.SuiFunctionParam{},
+						ResponseFromInputs: []string{"package_id"},
+					},
 				},
 				Events: map[string]*config.ChainReaderEvent{
 					"counter_incremented": {
@@ -1456,5 +1482,36 @@ func runChainReaderCounterTest(t *testing.T, log logger.Logger, rpcUrl string) {
 
 		err = testutils.ValidateJSON(retAllSourceChainConfigs, expectedSchema)
 		require.NoError(t, err)
+	})
+
+	t.Run("GetLatestValue_ResponseFromInputs", func(t *testing.T) {
+		var retResponseFromInputs any
+		params := map[string]any{}
+
+		err = chainReader.GetLatestValue(
+			context.Background(),
+			strings.Join([]string{packageId, "Counter", "response_from_inputs"}, "-"),
+			primitives.Finalized,
+			&params, // no parameters needed
+			&retResponseFromInputs,
+		)
+		require.NoError(t, err)
+		testutils.PrettyPrintDebug(log, retResponseFromInputs, "retResponseFromInputs")
+	})
+
+	t.Run("GetLatestValue_StaticResponse", func(t *testing.T) {
+		var retStaticResponse any
+		params := map[string]any{}
+
+		err = chainReader.GetLatestValue(
+			context.Background(),
+			strings.Join([]string{packageId, "Counter", "static_response"}, "-"),
+			primitives.Finalized,
+			&params, // no parameters needed
+			&retStaticResponse,
+		)
+		require.NoError(t, err)
+		testutils.PrettyPrintDebug(log, retStaticResponse, "retStaticResponse")
+		require.Equal(t, map[string]any{"a": 1, "b": 2, "c": 3}, retStaticResponse, "Expected static response to be map[string]any with keys a, b, and c")
 	})
 }


### PR DESCRIPTION
Below are the CR configs (`functions`) that can be used within any module:

```go
// example 1 - respond back with a static value
"static_response_example": {
	Name:          "static_response_example",
	SignerAddress: accountAddress,
	Params: []codec.SuiFunctionParam{},
	StaticResponse:      []any{1, 2, 3}, // this will always be returned, as if it came from the contract
	ResultTupleToStruct: []string{"a", "b", "c"},
},
// example 2 - respond back with the latest package ID of the module this config is placed in
"response_from_inputs_example": {
	Name:               "response_from_inputs_example",
	SignerAddress:      accountAddress,
	Params:             []codec.SuiFunctionParam{},
	ResponseFromInputs: []string{"package_id"}, // this will always read the latest package ID of the module
},
```

The same thing as example 2 can be done for the virtual `get_arm` call.