### PR TITLE
Fix: Update events query to account for corrupted offset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.6.3
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
+	github.com/mr-tron/base58 v1.2.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/errors v0.9.1
@@ -100,7 +101,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/relayer/chainreader/database/database.go
+++ b/relayer/chainreader/database/database.go
@@ -120,7 +120,7 @@ func (store *DBStore) QueryEvents(ctx context.Context, eventAccountAddress, even
 		if sortDir, ok := limitAndSort.SortBy[0].(query.SortBySequence); ok && sortDir.GetDirection() == query.Desc {
 			direction = "DESC"
 		}
-		baseSQL += " ORDER BY (block_height, event_offset) " + direction
+		baseSQL += " ORDER BY (block_height::BIGINT, event_offset) " + direction
 	} else {
 		// default to descending order if no sort is provided
 		baseSQL += " ORDER BY (block_height::BIGINT, event_offset) DESC"

--- a/relayer/chainreader/database/database.go
+++ b/relayer/chainreader/database/database.go
@@ -123,7 +123,7 @@ func (store *DBStore) QueryEvents(ctx context.Context, eventAccountAddress, even
 		baseSQL += " ORDER BY (block_height, event_offset) " + direction
 	} else {
 		// default to descending order if no sort is provided
-		baseSQL += " ORDER BY (block_height, event_offset) DESC"
+		baseSQL += " ORDER BY (block_height::BIGINT, event_offset) DESC"
 	}
 
 	limit := limitAndSort.Limit.Count

--- a/relayer/chainreader/database/database.go
+++ b/relayer/chainreader/database/database.go
@@ -120,10 +120,10 @@ func (store *DBStore) QueryEvents(ctx context.Context, eventAccountAddress, even
 		if sortDir, ok := limitAndSort.SortBy[0].(query.SortBySequence); ok && sortDir.GetDirection() == query.Desc {
 			direction = "DESC"
 		}
-		baseSQL += " ORDER BY event_offset " + direction
+		baseSQL += " ORDER BY (block_height, event_offset) " + direction
 	} else {
 		// default to descending order if no sort is provided
-		baseSQL += " ORDER BY event_offset DESC"
+		baseSQL += " ORDER BY (block_height, event_offset) DESC"
 	}
 
 	limit := limitAndSort.Limit.Count

--- a/relayer/chainreader/database/database_queries.go
+++ b/relayer/chainreader/database/database_queries.go
@@ -43,9 +43,20 @@ const (
     `
 
 	QueryEventsBase = `
-	SELECT event_account_address, event_handle, event_offset, block_version, block_height, block_hash, block_timestamp, tx_digest, data
-	FROM sui.events
-	WHERE event_account_address = $1 AND event_handle = $2
+	WITH filtered_events AS (
+		SELECT event_account_address, event_handle, event_offset, block_version, 
+			block_height, block_hash, block_timestamp, tx_digest, data,
+			ROW_NUMBER() OVER (
+				PARTITION BY tx_digest, block_height, md5(data::text)
+				ORDER BY event_offset DESC
+			) as rn
+		FROM sui.events
+		WHERE event_account_address = $1 AND event_handle = $2
+	)
+	SELECT event_account_address, event_handle, event_offset, block_version, 
+		block_height, block_hash, block_timestamp, tx_digest, data
+	FROM filtered_events
+	WHERE rn = 1
     `
 
 	QueryEventsOffset = `

--- a/relayer/chainreader/indexer/events_indexer_test.go
+++ b/relayer/chainreader/indexer/events_indexer_test.go
@@ -4,11 +4,14 @@ package indexer_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/mr-tron/base58"
 
 	indexer2 "github.com/smartcontractkit/chainlink-sui/relayer/chainreader/indexer"
 
@@ -17,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
 	"github.com/smartcontractkit/chainlink-sui/relayer/chainreader/database"
 	"github.com/smartcontractkit/chainlink-sui/relayer/client"
@@ -559,5 +563,173 @@ func TestEventsIndexer(t *testing.T) {
 		wg.Wait()
 
 		log.Infow("Race detection test completed - no races detected!")
+	})
+
+	t.Run("TestOrderedEventsQueryWithOutOfOrderEventOffset", func(t *testing.T) {
+		// insert duplicate events with out of order event_offset for CCIPMessageSent
+
+		packageId := "0x30e087460af8a8aacccbc218aa358cdcde8d43faf61ec0638d71108e276e2f1d"
+		eventHandle := packageId + "::onramp::CCIPMessageSent"
+		baseRecord := database.EventRecord{
+			EventAccountAddress: accountAddress,
+			EventHandle:         eventHandle,
+			EventOffset:         0,
+			TxDigest:            "5HueCGU5rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ",
+			BlockVersion:        0,
+			BlockHeight:         "100",
+			BlockHash:           []byte("5HueCGU5rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"),
+			BlockTimestamp:      1000000000,
+			Data:                map[string]any{},
+		}
+
+		// insert duplicate and incorrect event offsets
+		for i := range 200_000 {
+			recordA := baseRecord
+			recordB := baseRecord
+
+			// use different event_offset for both records
+			recordA.EventOffset = uint64(i)
+			recordB.EventOffset = uint64(i%2 + 1000)
+
+			// use duplicate data for both records
+			recordA.BlockHeight = strconv.Itoa(100 + i)
+			recordB.BlockHeight = strconv.Itoa(100 + i)
+
+			recordA.TxDigest = base58.Encode([]byte("record" + strconv.Itoa(i)))
+			recordB.TxDigest = base58.Encode([]byte("record" + strconv.Itoa(i)))
+
+			recordA.Data = map[string]any{
+				"destChainSelector": 3478487238524512106,
+				"sequenceNumber":    776 + uint64(i),
+			}
+			recordB.Data = map[string]any{
+				"destChainSelector": 3478487238524512106,
+				"sequenceNumber":    776 + uint64(i),
+			}
+
+			dbStore.InsertEvents(ctx, []database.EventRecord{recordA, recordB})
+		}
+
+		// insert some other unrelated events
+		for i := range 10_000 {
+			recordA := baseRecord
+
+			// use different event_offset for both records
+			recordA.EventOffset = uint64(i + 1)
+
+			// use duplicate data for both records
+			recordA.BlockHeight = "100"
+
+			recordA.TxDigest = base58.Encode([]byte("record" + strconv.Itoa(i)))
+
+			recordA.EventHandle = packageId + "::onramp::SomeOtherEvent"
+
+			recordA.Data = map[string]any{
+				"destChainSelector": 3478487238524512106,
+				"sequenceNumber":    176 + uint64(i),
+			}
+
+			dbStore.InsertEvents(ctx, []database.EventRecord{recordA})
+		}
+
+		// query events with out of order event_offset
+		events, err := dbStore.QueryEvents(ctx, accountAddress, eventHandle, []query.Expression{
+			{
+				BoolExpression: query.BoolExpression{
+					BoolOperator: query.AND,
+					Expressions: []query.Expression{
+						{
+							Primitive: &primitives.Comparator{
+								Name: "sequenceNumber",
+								ValueComparators: []primitives.ValueComparator{
+									{Value: uint64(776), Operator: primitives.Gte},
+									{Value: uint64(779), Operator: primitives.Lte},
+								},
+							},
+						},
+						{
+							Primitive: &primitives.Comparator{
+								Name: "destChainSelector",
+								ValueComparators: []primitives.ValueComparator{
+									{Value: "3478487238524512106", Operator: primitives.Eq},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, query.LimitAndSort{
+			Limit: query.Limit{
+				Count: 100,
+			},
+			SortBy: []query.SortBy{
+				query.NewSortBySequence(query.Asc),
+			},
+		})
+
+		// we should only get 10 events
+		require.NoError(t, err)
+		require.Equal(t, 4, len(events))
+
+		for _, event := range events {
+			fmt.Printf("eventHandle: %s\n", event.EventHandle)
+			fmt.Printf("sequenceNumber: %f\n", event.Data["sequenceNumber"].(float64))
+			fmt.Println("--------------------------------")
+		}
+
+		// events should have strictly increasing sequence numbers and be in order
+		for i := range len(events) - 1 {
+			require.Equal(t, events[i].Data["sequenceNumber"].(float64)+1, events[i+1].Data["sequenceNumber"].(float64))
+		}
+
+		// query another range for the same event handle
+		events, err = dbStore.QueryEvents(ctx, accountAddress, eventHandle, []query.Expression{
+			{
+				BoolExpression: query.BoolExpression{
+					BoolOperator: query.AND,
+					Expressions: []query.Expression{
+						{
+							Primitive: &primitives.Comparator{
+								Name: "sequenceNumber",
+								ValueComparators: []primitives.ValueComparator{
+									{Value: uint64(779), Operator: primitives.Gte},
+									{Value: uint64(785), Operator: primitives.Lte},
+								},
+							},
+						},
+						{
+							Primitive: &primitives.Comparator{
+								Name: "destChainSelector",
+								ValueComparators: []primitives.ValueComparator{
+									{Value: "3478487238524512106", Operator: primitives.Eq},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, query.LimitAndSort{
+			Limit: query.Limit{
+				Count: 100,
+			},
+			SortBy: []query.SortBy{
+				query.NewSortBySequence(query.Asc),
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 7, len(events))
+
+		for _, event := range events {
+			fmt.Printf("eventHandle: %s\n", event.EventHandle)
+			fmt.Printf("sequenceNumber: %f\n", event.Data["sequenceNumber"].(float64))
+			fmt.Println("--------------------------------")
+		}
+
+		// events should have strictly increasing sequence numbers and be in order
+		for i := range len(events) - 1 {
+			require.Equal(t, events[i].EventHandle, eventHandle)
+			require.Equal(t, events[i].Data["sequenceNumber"].(float64)+1, events[i+1].Data["sequenceNumber"].(float64))
+		}
 	})
 }


### PR DESCRIPTION
This PR resolves an edge case which occurs due to the following factors:
* Sui does not provide a global index for events. Events are indexed by transaction.
* The current Sui relayer deployment fetches events from the RPC and inserts them into the DB whenever it receives a `QueryKey` call with that event handle.
* The current deployment does include an update to how the `event_offset` is set which queried the DB for the highest event offset before inserting new ones.

What's the issue that occured?
* An RPC failure with a concurrent `QueryKey` call and a poller sync of the event yielded different `events_offset` values.
* With the `event_offset` being corrupted (not globally increasing or duplicated) and the sort being done on `event_offset` along, the returned set of events was not sorted correctly.


How does the updated query resolve these issues without changing the DB structure?
* Given the restriction of not changing the DB structure (specifically the unique index on events). The query must account for the same event being inserted with different `event_offset` values.
* The updated query uses a composite sort by default with `ORDER BY (block_height, event_offset)`.
