### PR TITLE
Feat: Add a coin reservation abstraction to prevent equivocation within the same relayer

### DIFF
--- a/relayer/client/suierrors/errors.go
+++ b/relayer/client/suierrors/errors.go
@@ -13,6 +13,8 @@ determine if an error is considered retryable (e.g. IsRetryable) according to Su
 package suierrors
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -28,6 +30,7 @@ const (
 	CheckpointAndConsensusErrors
 	PublishingErrors
 	SoftBundleErrors
+	LockCoinErrors
 	UnknownErrors
 )
 
@@ -47,6 +50,8 @@ func (c ErrorCategory) String() string {
 		return "Publishing Errors"
 	case SoftBundleErrors:
 		return "Soft Bundle Errors"
+	case LockCoinErrors:
+		return "Lock Coins Errors"
 	default:
 		return "Unknown Error Category"
 	}
@@ -146,6 +151,9 @@ var ErrNoSharedObjectError = NewSuiError(SoftBundleErrors, "NoSharedObjectError"
 var ErrAlreadyExecutedError = NewSuiError(SoftBundleErrors, "AlreadyExecutedError")
 var ErrCertificateAlreadyProcessed = NewSuiError(SoftBundleErrors, "CertificateAlreadyProcessed")
 
+// Lock Coins error
+var ErrLockCoins = NewSuiError(LockCoinErrors, "already locked by a different transaction")
+
 // Unknown Error
 var ErrUnknownError = NewSuiError(UnknownErrors, "UnknownError")
 
@@ -176,6 +184,7 @@ var suiErrorMappings = []struct {
 	{ErrUnsupported.Error(), ErrUnsupported},
 	{ErrMoveFunctionInputError.Error(), ErrMoveFunctionInputError},
 	{ErrPostRandomCommandRestrictions.Error(), ErrPostRandomCommandRestrictions},
+	{ErrObjectVersionUnavailableForConsumption.Error(), ErrObjectVersionUnavailableForConsumption},
 
 	// Gas Errors
 	{ErrMissingGasPayment.Error(), ErrMissingGasPayment},
@@ -225,9 +234,16 @@ var suiErrorMappings = []struct {
 	{ErrAlreadyExecutedError.Error(), ErrAlreadyExecutedError},
 	{ErrCertificateAlreadyProcessed.Error(), ErrCertificateAlreadyProcessed},
 
+	// Lock Coins error
+	{ErrLockCoins.Error(), ErrLockCoins},
+
 	// Unknown Error
 	{ErrUnknownError.Error(), ErrUnknownError},
 }
+
+var lockedObjectRe = regexp.MustCompile(
+	`Object\s+\((0x[0-9a-fA-F]+),\s*SequenceNumber\((\d+)\)`,
+)
 
 // ParseSuiErrorMessage maps a raw RPC error message to a structured error.
 // It iterates over the known substrings in suiErrorMappings. If a substring is found,
@@ -240,6 +256,25 @@ func ParseSuiErrorMessage(msg string) *SuiError {
 	}
 
 	return NewSuiError(UnknownErrors, msg)
+}
+
+// ExtractLockedObjectRef parses a Sui equivocation / lock error message and returns
+// (objectID, version, ok).
+func ExtractLockedObjectRef(msg string) (string, uint64, bool) {
+	m := lockedObjectRe.FindStringSubmatch(msg)
+	if len(m) != 3 {
+		return "", 0, false
+	}
+
+	objID := m[1]
+	verStr := m[2]
+
+	ver, err := strconv.ParseUint(verStr, 10, 64)
+	if err != nil {
+		return objID, 0, false
+	}
+
+	return objID, ver, true
 }
 
 var ExponentialBackoffErrors = []error{

--- a/relayer/client/suierrors/errors.go
+++ b/relayer/client/suierrors/errors.go
@@ -297,3 +297,7 @@ var GasBumpErrors = []error{
 	ErrInsufficientGas,
 	ErrGasPriceTooHigh,
 }
+
+var CoinRefreshErrors = []error{
+	ErrLockCoins,
+}

--- a/relayer/txm/broadcaster.go
+++ b/relayer/txm/broadcaster.go
@@ -92,6 +92,13 @@ func broadcastTransactions(loopCtx context.Context, txm *SuiTxm, transactions []
 			// Default to retrying the transaction
 			newState := StateRetriable
 
+			// Attach the transaction submission error to the transaction object. If it remains marked as retriable, 
+			// the "confirmer" loop will pick it up and potentially retry it.
+			err = txm.transactionRepository.UpdateTransactionBroadcastError(tx.TransactionID, err.Error())
+			if err != nil {
+				txm.lggr.Errorw("Failed to update transaction broadcast error", "txID", tx.TransactionID, "error", err)
+			}
+
 			if resp.Effects.Status.Status != "" && resp.TxDigest == "" {
 				// Update the transaction state to Failed if the digest is empty
 				// An empty digest indicates a total failure of the transaction
@@ -102,7 +109,6 @@ func broadcastTransactions(loopCtx context.Context, txm *SuiTxm, transactions []
 			// Attempt updating the state if it has changed
 			if tx.State != newState {
 				err = txm.transactionRepository.ChangeState(tx.TransactionID, newState)
-
 				if err != nil {
 					txm.lggr.Errorw("Failed to change transaction state", "txID", tx.TransactionID, "error", err)
 				}
@@ -118,6 +124,8 @@ func broadcastTransactions(loopCtx context.Context, txm *SuiTxm, transactions []
 			continue
 		}
 
+		// Update the transaction state to submitted as we have not yet confirmed its status.
+		// The "confirmer" loop checks the transactions statuses and possibly marks them as finalized.
 		err = txm.transactionRepository.ChangeState(tx.TransactionID, StateSubmitted)
 		if err != nil {
 			txm.lggr.Errorw("Failed to change transaction state to Submitted", "txID", tx.TransactionID, "error", err)

--- a/relayer/txm/confirmer.go
+++ b/relayer/txm/confirmer.go
@@ -163,6 +163,8 @@ func handleTransactionError(ctx context.Context, txm *SuiTxm, tx SuiTx, result *
 		return handleExponentialBackoffRetry(txm, tx)
 	case GasBump:
 		return handleGasBumpRetry(ctx, txm, tx, txError)
+	case CoinRefresh:
+		return handleCoinRefreshRetry(ctx, txm, tx, txError)
 	case NoRetry:
 		return markTransactionFailed(txm, tx, txError)
 	default:
@@ -195,6 +197,40 @@ func handleGasBumpRetry(ctx context.Context, txm *SuiTxm, tx SuiTx, txError *sui
 		return err
 	}
 
+	txm.broadcastChannel <- tx.TransactionID
+	return nil
+}
+
+func handleCoinRefreshRetry(ctx context.Context, txm *SuiTxm, tx SuiTx, txError *suierrors.SuiError) error {
+	txm.lggr.Infow("Coin refresh strategy - refreshing coins for locked coin error", "transactionID", tx.TransactionID)
+
+	// Release the old coins that are locked
+	if err := txm.coinManager.ReleaseCoins(tx.TransactionID); err != nil {
+		// This is not critical - coins will auto-release after TTL
+		txm.lggr.Debugw("Failed to release old coins", "transactionID", tx.TransactionID, "error", err)
+	}
+
+	// Get the current transaction to ensure we have the latest state
+	currentTx, err := txm.transactionRepository.GetTransaction(tx.TransactionID)
+	if err != nil {
+		txm.lggr.Errorw("Failed to get current transaction", "transactionID", tx.TransactionID, "error", err)
+		return err
+	}
+
+	// Calling UpdateTransactionGas will also update the gas coins used as the transaction gets re-built
+	// with new (unlocked) coins.
+	// Call chain: UpdateTransactionGas -> UpdateBSCPayload -> preparePTBTransaction (this refreshes the coins).
+	if err := txm.transactionRepository.UpdateTransactionGas(ctx, txm.keystoreService, txm.suiGateway, tx.TransactionID, currentTx.Metadata.GasLimit); err != nil {
+		txm.lggr.Errorw("Failed to update transaction with refreshed coins", "transactionID", tx.TransactionID, "error", err)
+		return err
+	}
+
+	if err := txm.transactionRepository.ChangeState(tx.TransactionID, StateRetriable); err != nil {
+		txm.lggr.Errorw("Failed to update transaction state", "transactionID", tx.TransactionID, "error", err)
+		return err
+	}
+
+	txm.lggr.Infow("Transaction refreshed with new coins", "transactionID", tx.TransactionID)
 	txm.broadcastChannel <- tx.TransactionID
 	return nil
 }

--- a/relayer/txm/confirmer.go
+++ b/relayer/txm/confirmer.go
@@ -121,6 +121,9 @@ func handleTransactionError(ctx context.Context, txm *SuiTxm, tx SuiTx, result *
 		
 		coinID, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(objectID))
 		if err == nil && !txm.coinManager.IsCoinReserved(*coinID) {
+			// Coin lock duration
+			expiry := 24 * time.Hour
+			
 			// The coin is not recorded is not marked as reserved, mark it as reserved
 			err = txm.coinManager.TryReserveCoins(ctx, tx.TransactionID, []transaction.SuiObjectRef{
 				{
@@ -128,7 +131,7 @@ func handleTransactionError(ctx context.Context, txm *SuiTxm, tx SuiTx, result *
 					Version:  0,
 					Digest:   nil,
 				},
-			})
+			}, &expiry)
 
 			if err != nil {
 				// This is not a critical error, so we continue

--- a/relayer/txm/confirmer.go
+++ b/relayer/txm/confirmer.go
@@ -128,7 +128,7 @@ func handleTransactionError(ctx context.Context, txm *SuiTxm, tx SuiTx, result *
 		coinID, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(objectID))
 		if err == nil && !txm.coinManager.IsCoinReserved(*coinID) {
 			// Coin lock duration
-			expiry := 24 * time.Hour
+			expiry := DefaultLockedCoinTTL
 
 			// The coin is not recorded is not marked as reserved, mark it as reserved
 			err = txm.coinManager.TryReserveCoins(ctx, tx.TransactionID, []transaction.SuiObjectRef{

--- a/relayer/txm/confirmer.go
+++ b/relayer/txm/confirmer.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
 	"github.com/smartcontractkit/chainlink-sui/relayer/client"
@@ -56,14 +58,26 @@ func checkConfirmations(loopCtx context.Context, txm *SuiTxm) {
 
 	for _, tx := range inFlightTransactions {
 		txm.lggr.Debugw("Checking transaction confirmations", "transactionID", tx.TransactionID)
-		if tx.State != StateSubmitted {
-			continue
-		}
 
-		txm.lggr.Debugw("Transaction is in submitted state", "transactionID", tx.TransactionID)
-		resp, err := txm.suiGateway.GetTransactionStatus(loopCtx, tx.Digest)
-		if err != nil {
-			txm.lggr.Errorw("Error getting transaction status", "transactionID", tx.TransactionID, "error", err)
+		var resp client.TransactionResult
+		var err error
+
+		if tx.State == StateSubmitted {
+			txm.lggr.Debugw("Transaction is in submitted state", "transactionID", tx.TransactionID)
+			resp, err = txm.suiGateway.GetTransactionStatus(loopCtx, tx.Digest)
+			if err != nil {
+				txm.lggr.Errorw("Error getting transaction status", "transactionID", tx.TransactionID, "error", err)
+				continue
+			}
+		} else if tx.State == StateRetriable {
+			txm.lggr.Debugw("Transaction is in retriable state", "transactionID", tx.TransactionID)
+			// Check if it's a broadcast error (never made it onchain)
+			if tx.BroadcastError == "" {
+				continue
+			}
+			resp.Status = failure
+			resp.Error = tx.BroadcastError
+		} else {
 			continue
 		}
 
@@ -95,8 +109,37 @@ func handleTransactionError(ctx context.Context, txm *SuiTxm, tx SuiTx, result *
 	txm.lggr.Debugw("Handling transaction error", "transactionID", tx.TransactionID, "error", result.Error)
 
 	txError := suierrors.ParseSuiErrorMessage(result.Error)
-	if txError == nil {
-		txError = suierrors.NewSuiError(suierrors.UnknownErrors, result.Error)
+
+	// Check if the error is a locked object error, mark the coin as reserved if it is not already
+	// to avoid other transactions from using it
+	if objectID, version, ok := suierrors.ExtractLockedObjectRef(result.Error); ok {
+		txm.lggr.Infow("Detected locked coin at confirmation time",
+			"txID", tx.TransactionID,
+			"objectID", objectID,
+			"version", version,
+		)
+		
+		coinID, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(objectID))
+		if err == nil && !txm.coinManager.IsCoinReserved(*coinID) {
+			// The coin is not recorded is not marked as reserved, mark it as reserved
+			err = txm.coinManager.TryReserveCoins(ctx, tx.TransactionID, []transaction.SuiObjectRef{
+				{
+					ObjectId: *coinID,
+					Version:  0,
+					Digest:   nil,
+				},
+			})
+
+			if err != nil {
+				// This is not a critical error, so we continue
+				txm.lggr.Debugw(
+					"Failed to mark locked coin as reserved",
+					"transactionID", tx.TransactionID,
+					"objectID", objectID,
+					"error", err,
+				)
+			}
+		}
 	}
 
 	isRetryable, strategy := txm.retryManager.IsRetryable(&tx, result.Error)

--- a/relayer/txm/confirmer.go
+++ b/relayer/txm/confirmer.go
@@ -102,7 +102,12 @@ func handleSuccess(txm *SuiTxm, tx SuiTx) error {
 		return err
 	}
 	txm.lggr.Infow("Transaction finalized", "transactionID", tx.TransactionID)
-	txm.coinManager.ReleaseCoins(tx.TransactionID)
+
+	if err := txm.coinManager.ReleaseCoins(tx.TransactionID); err != nil {
+		// This error is not critical, can be safely ignored as the coins will auto-release after the default TTL
+		txm.lggr.Debugw("Failed to release coins", "transactionID", tx.TransactionID, "error", err)
+	}
+
 	return nil
 }
 
@@ -119,12 +124,12 @@ func handleTransactionError(ctx context.Context, txm *SuiTxm, tx SuiTx, result *
 			"objectID", objectID,
 			"version", version,
 		)
-		
+
 		coinID, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(objectID))
 		if err == nil && !txm.coinManager.IsCoinReserved(*coinID) {
 			// Coin lock duration
 			expiry := 24 * time.Hour
-			
+
 			// The coin is not recorded is not marked as reserved, mark it as reserved
 			err = txm.coinManager.TryReserveCoins(ctx, tx.TransactionID, []transaction.SuiObjectRef{
 				{
@@ -231,8 +236,12 @@ func markTransactionFailed(txm *SuiTxm, tx SuiTx, txError *suierrors.SuiError) e
 		return err
 	}
 
-	txm.coinManager.ReleaseCoins(tx.TransactionID)
-
 	txm.lggr.Infow("Transaction failed", "transactionID", tx.TransactionID)
+
+	if err := txm.coinManager.ReleaseCoins(tx.TransactionID); err != nil {
+		// This error is not critical, can be safely ignored as the coins will auto-release after the default TTL
+		txm.lggr.Debugw("Failed to release coins", "transactionID", tx.TransactionID, "error", err)
+	}
+
 	return nil
 }

--- a/relayer/txm/confirmer.go
+++ b/relayer/txm/confirmer.go
@@ -102,6 +102,7 @@ func handleSuccess(txm *SuiTxm, tx SuiTx) error {
 		return err
 	}
 	txm.lggr.Infow("Transaction finalized", "transactionID", tx.TransactionID)
+	txm.coinManager.ReleaseCoins(tx.TransactionID)
 	return nil
 }
 
@@ -229,6 +230,8 @@ func markTransactionFailed(txm *SuiTxm, tx SuiTx, txError *suierrors.SuiError) e
 		txm.lggr.Errorw("Failed to update transaction error", "transactionID", tx.TransactionID, "error", err)
 		return err
 	}
+
+	txm.coinManager.ReleaseCoins(tx.TransactionID)
 
 	txm.lggr.Infow("Transaction failed", "transactionID", tx.TransactionID)
 	return nil

--- a/relayer/txm/confirmer_test.go
+++ b/relayer/txm/confirmer_test.go
@@ -56,6 +56,7 @@ func TestConfirmerRoutine_GasBump(t *testing.T) {
 	// Create a fake gas manager that returns an updated gas value.
 	maxGasBudget := big.NewInt(12000000)
 	gasManager := txm.NewSuiGasManager(lggr, fakeClient, *maxGasBudget, 0)
+	coinManager := txm.NewGasCoinManager(lggr, fakeClient)
 
 	// For the confirmer, the keystore is not used; create a dummy signer.
 	keystoreInstance := testutils.NewTestKeystore(t)
@@ -119,6 +120,7 @@ func TestConfirmerRoutine_GasBump(t *testing.T) {
 		TxError:       nil,
 		GasBudget:     maxGasBudget.Uint64(),
 		Ptb:           ptb,
+		CoinManager:   coinManager,
 	}
 	err = store.AddTransaction(tx)
 	require.NoError(t, err)
@@ -184,6 +186,7 @@ func TestConfirmerRoutine_SuccessfulGasBumpAfterTwoAttempts(t *testing.T) {
 	maxGasBudget := big.NewInt(10000000)
 	percentIncrease := int64(120) // 120% (20% increase) per bump
 	gasManager := txm.NewSuiGasManager(lggr, fakeClient, *maxGasBudget, percentIncrease)
+	coinManager := txm.NewGasCoinManager(lggr, fakeClient)
 
 	// Create keystore
 	keystoreInstance := testutils.NewTestKeystore(t)
@@ -248,6 +251,7 @@ func TestConfirmerRoutine_SuccessfulGasBumpAfterTwoAttempts(t *testing.T) {
 		TxError:       nil,
 		GasBudget:     maxGasBudget.Uint64(), // Use max budget to allow for gas bumps
 		Ptb:           ptb,
+		CoinManager:   coinManager,
 	}
 	err = store.AddTransaction(tx)
 	require.NoError(t, err)
@@ -360,6 +364,7 @@ func TestConfirmerRoutine_ExponentialBackoffRetry(t *testing.T) {
 
 	// Add a transaction in StateSubmitted with a known digest
 	txID := "tx-exponential-backoff-retry-test"
+	coinManager := txm.NewGasCoinManager(lggr, fakeClient)
 	tx := txm.SuiTx{
 		TransactionID: txID,
 		Sender:        address,
@@ -376,6 +381,7 @@ func TestConfirmerRoutine_ExponentialBackoffRetry(t *testing.T) {
 		TxError:       nil,
 		GasBudget:     initialGasBudget,
 		Ptb:           ptb,
+		CoinManager:   coinManager,
 	}
 	err = store.AddTransaction(tx)
 	require.NoError(t, err)

--- a/relayer/txm/gas_coin_manager.go
+++ b/relayer/txm/gas_coin_manager.go
@@ -1,0 +1,78 @@
+package txm
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/patrickmn/go-cache"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-sui/relayer/client"
+)
+
+const (
+	DefaultLockedCoinTTL = 24 * time.Hour
+	DefaultAllocationTimeout = 30 * time.Second
+)
+
+type GasCoinManager interface {
+	TryReserveCoins(ctx context.Context, txID string, coinIDs []models.ObjectId) error
+	ReleaseCoins(txID string) error
+	IsCoinReserved(coinID models.ObjectId) bool
+}
+
+// SuiGasCoinManager is the concrete implementation of GasCoinManager.
+type SuiGasCoinManager struct {
+	lggr   logger.Logger
+	client client.SuiPTBClient
+	coinsCache *cache.Cache
+}
+
+// NewGasCoinManager creates a new SuiGasCoinManager.
+func NewGasCoinManager(lggr logger.Logger, suiClient client.SuiPTBClient) *SuiGasCoinManager {
+	gcm := &SuiGasCoinManager{
+		lggr:      logger.Named(lggr, "SuiGasCoinManager"),
+		client:    suiClient,
+		coinsCache: cache.New(DefaultAllocationTimeout, DefaultLockedCoinTTL),
+	}
+	return gcm
+}
+
+func (m *SuiGasCoinManager) TryReserveCoins(ctx context.Context, txID string, coinIDs []models.ObjectId) error {
+	for _, coinIDBytes := range coinIDs {
+		if m.IsCoinReserved(coinIDBytes) {
+			return fmt.Errorf("coin %s is already reserved", coinIDBytes)
+		}
+		
+		coinID := hex.EncodeToString(coinIDBytes.Data())
+		m.coinsCache.Set(coinID, true, DefaultAllocationTimeout)
+	}
+
+	m.coinsCache.Set(txID, coinIDs, DefaultAllocationTimeout)
+
+	return nil
+}
+
+func (m *SuiGasCoinManager) ReleaseCoins(txID string) error {
+	coinIDs, ok := m.coinsCache.Get(txID)
+	if !ok {
+		return fmt.Errorf("no coins reserved for transaction %s", txID)
+	}
+
+	for _, coinIDBytes := range coinIDs.([]models.ObjectId) {
+		coinID := hex.EncodeToString(coinIDBytes.Data())
+		m.coinsCache.Delete(coinID)
+	}
+
+	m.coinsCache.Delete(txID)
+	return nil
+}
+
+func (m *SuiGasCoinManager) IsCoinReserved(coinID models.ObjectId) bool {
+	coinIDStr := hex.EncodeToString(coinID.Data())
+	isReserved, found := m.coinsCache.Get(coinIDStr)
+	return found && isReserved.(bool)
+}

--- a/relayer/txm/gas_coin_manager.go
+++ b/relayer/txm/gas_coin_manager.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/patrickmn/go-cache"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -19,9 +20,9 @@ const (
 )
 
 type GasCoinManager interface {
-	TryReserveCoins(ctx context.Context, txID string, coinIDs []models.ObjectId) error
+	TryReserveCoins(ctx context.Context, txID string, paymentCoins []transaction.SuiObjectRef) error
 	ReleaseCoins(txID string) error
-	IsCoinReserved(coinID models.ObjectId) bool
+	IsCoinReserved(coinID models.SuiAddressBytes) bool
 }
 
 // SuiGasCoinManager is the concrete implementation of GasCoinManager.
@@ -41,13 +42,13 @@ func NewGasCoinManager(lggr logger.Logger, suiClient client.SuiPTBClient) *SuiGa
 	return gcm
 }
 
-func (m *SuiGasCoinManager) TryReserveCoins(ctx context.Context, txID string, coinIDs []models.ObjectId) error {
-	for _, coinIDBytes := range coinIDs {
-		if m.IsCoinReserved(coinIDBytes) {
-			return fmt.Errorf("coin %s is already reserved", coinIDBytes)
+func (m *SuiGasCoinManager) TryReserveCoins(ctx context.Context, txID string, coinIDs []transaction.SuiObjectRef) error {
+	for _, coin := range coinIDs {
+		if m.IsCoinReserved(coin.ObjectId) {
+			return fmt.Errorf("coin %s is already reserved", coin.ObjectId)
 		}
 		
-		coinID := hex.EncodeToString(coinIDBytes.Data())
+		coinID := hex.EncodeToString(coin.ObjectId[:])
 		m.coinsCache.Set(coinID, true, DefaultAllocationTimeout)
 	}
 
@@ -62,8 +63,8 @@ func (m *SuiGasCoinManager) ReleaseCoins(txID string) error {
 		return fmt.Errorf("no coins reserved for transaction %s", txID)
 	}
 
-	for _, coinIDBytes := range coinIDs.([]models.ObjectId) {
-		coinID := hex.EncodeToString(coinIDBytes.Data())
+	for _, coinIDBytes := range coinIDs.([]models.SuiAddressBytes) {
+		coinID := hex.EncodeToString(coinIDBytes[:])
 		m.coinsCache.Delete(coinID)
 	}
 
@@ -71,8 +72,8 @@ func (m *SuiGasCoinManager) ReleaseCoins(txID string) error {
 	return nil
 }
 
-func (m *SuiGasCoinManager) IsCoinReserved(coinID models.ObjectId) bool {
-	coinIDStr := hex.EncodeToString(coinID.Data())
+func (m *SuiGasCoinManager) IsCoinReserved(coinID models.SuiAddressBytes) bool {
+	coinIDStr := hex.EncodeToString(coinID[:])
 	isReserved, found := m.coinsCache.Get(coinIDStr)
 	return found && isReserved.(bool)
 }

--- a/relayer/txm/gas_coin_manager.go
+++ b/relayer/txm/gas_coin_manager.go
@@ -74,8 +74,8 @@ func (m *SuiGasCoinManager) ReleaseCoins(txID string) error {
 		return fmt.Errorf("no coins reserved for transaction %s", txID)
 	}
 
-	for _, coinIDBytes := range coinIDs.([]models.SuiAddressBytes) {
-		coinID := hex.EncodeToString(coinIDBytes[:])
+	for _, coin := range coinIDs.([]transaction.SuiObjectRef) {
+		coinID := hex.EncodeToString(coin.ObjectId[:])
 		m.coinsCache.Delete(coinID)
 	}
 

--- a/relayer/txm/gas_coin_manager.go
+++ b/relayer/txm/gas_coin_manager.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultLockedCoinTTL = 24 * time.Hour
+	DefaultLockedCoinTTL     = 24 * time.Hour
 	DefaultAllocationTimeout = 30 * time.Second
 )
 
@@ -27,24 +27,24 @@ type GasCoinManager interface {
 
 // SuiGasCoinManager is the concrete implementation of GasCoinManager.
 type SuiGasCoinManager struct {
-	lggr   logger.Logger
-	client client.SuiPTBClient
+	lggr       logger.Logger
+	client     client.SuiPTBClient
 	coinsCache *cache.Cache
 }
 
 // NewGasCoinManager creates a new SuiGasCoinManager.
 func NewGasCoinManager(lggr logger.Logger, suiClient client.SuiPTBClient) *SuiGasCoinManager {
 	gcm := &SuiGasCoinManager{
-		lggr:      logger.Named(lggr, "SuiGasCoinManager"),
-		client:    suiClient,
+		lggr:       logger.Named(lggr, "SuiGasCoinManager"),
+		client:     suiClient,
 		coinsCache: cache.New(DefaultAllocationTimeout, DefaultLockedCoinTTL),
 	}
 	return gcm
 }
 
 func (m *SuiGasCoinManager) TryReserveCoins(
-	ctx context.Context, 
-	txID string, 
+	ctx context.Context,
+	txID string,
 	coinIDs []transaction.SuiObjectRef,
 	expiry *time.Duration,
 ) error {
@@ -52,7 +52,7 @@ func (m *SuiGasCoinManager) TryReserveCoins(
 		if m.IsCoinReserved(coin.ObjectId) {
 			return fmt.Errorf("coin %s is already reserved", coin.ObjectId)
 		}
-		
+
 		coinID := hex.EncodeToString(coin.ObjectId[:])
 		expiresAt := DefaultAllocationTimeout
 
@@ -68,6 +68,8 @@ func (m *SuiGasCoinManager) TryReserveCoins(
 	return nil
 }
 
+// ReleaseCoins only releases reservations stored under a txID key (txID -> []SuiObjectRef).
+// It does not work with coinID keys (coinID -> bool) and cannot unlock those entries directly.
 func (m *SuiGasCoinManager) ReleaseCoins(txID string) error {
 	coinIDs, ok := m.coinsCache.Get(txID)
 	if !ok {

--- a/relayer/txm/gas_coin_manager.go
+++ b/relayer/txm/gas_coin_manager.go
@@ -20,7 +20,7 @@ const (
 )
 
 type GasCoinManager interface {
-	TryReserveCoins(ctx context.Context, txID string, paymentCoins []transaction.SuiObjectRef) error
+	TryReserveCoins(ctx context.Context, txID string, paymentCoins []transaction.SuiObjectRef, expiry *time.Duration) error
 	ReleaseCoins(txID string) error
 	IsCoinReserved(coinID models.SuiAddressBytes) bool
 }
@@ -42,14 +42,25 @@ func NewGasCoinManager(lggr logger.Logger, suiClient client.SuiPTBClient) *SuiGa
 	return gcm
 }
 
-func (m *SuiGasCoinManager) TryReserveCoins(ctx context.Context, txID string, coinIDs []transaction.SuiObjectRef) error {
+func (m *SuiGasCoinManager) TryReserveCoins(
+	ctx context.Context, 
+	txID string, 
+	coinIDs []transaction.SuiObjectRef,
+	expiry *time.Duration,
+) error {
 	for _, coin := range coinIDs {
 		if m.IsCoinReserved(coin.ObjectId) {
 			return fmt.Errorf("coin %s is already reserved", coin.ObjectId)
 		}
 		
 		coinID := hex.EncodeToString(coin.ObjectId[:])
-		m.coinsCache.Set(coinID, true, DefaultAllocationTimeout)
+		expiresAt := DefaultAllocationTimeout
+
+		if expiry != nil {
+			expiresAt = *expiry
+		}
+
+		m.coinsCache.Set(coinID, true, expiresAt)
 	}
 
 	m.coinsCache.Set(txID, coinIDs, DefaultAllocationTimeout)

--- a/relayer/txm/gas_coin_manager_test.go
+++ b/relayer/txm/gas_coin_manager_test.go
@@ -1,0 +1,83 @@
+//go:build unit
+
+package txm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-sui/relayer/testutils"
+	"github.com/smartcontractkit/chainlink-sui/relayer/txm"
+)
+
+func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
+	lggr := logger.Test(t)
+	mockClient := &testutils.FakeSuiPTBClient{}
+	gcm := txm.NewGasCoinManager(lggr, mockClient)
+	
+	ctx := context.Background()
+	txID := "test-tx-123"
+	
+	// Create test coin IDs
+	coinID1, err := models.NewHexData("0x1234567890abcdef1234567890abcdef12345678")
+	require.NoError(t, err)
+	coinID2, err := models.NewHexData("0xabcdef1234567890abcdef1234567890abcdef12")
+	require.NoError(t, err)
+	
+	coinIDs := []models.ObjectId{*coinID1, *coinID2}
+	
+	t.Run("successfully reserve coins", func(t *testing.T) {
+		err := gcm.TryReserveCoins(ctx, txID, coinIDs)
+		assert.NoError(t, err)
+		
+		// Verify coins are reserved
+		assert.True(t, gcm.IsCoinReserved(*coinID1))
+		assert.True(t, gcm.IsCoinReserved(*coinID2))
+		
+		// Verify transaction is stored
+		isReserved := gcm.IsCoinReserved(*coinID1)
+		assert.True(t, isReserved)
+		isReserved = gcm.IsCoinReserved(*coinID2)
+		assert.True(t, isReserved)
+	})
+	
+	t.Run("fail to reserve already reserved coin", func(t *testing.T) {
+		// Try to reserve the same coins again
+		err := gcm.TryReserveCoins(ctx, "tx-test-2", coinIDs)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is already reserved")
+	})
+
+	t.Run("reserved then released coins can be reserved again", func(t *testing.T) {
+		coinID1, err := models.NewHexData("0x1234567890abcdef1234123890abcdef12345678")
+		require.NoError(t, err)
+		coinID2, err := models.NewHexData("0x1234567890abcdef1234153890abcdef12345678")
+		require.NoError(t, err)
+		
+		coinIDs := []models.ObjectId{*coinID1, *coinID2}
+
+		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs)
+		assert.NoError(t, err)
+
+		// coins are reserved
+		assert.True(t, gcm.IsCoinReserved(*coinID1))
+		assert.True(t, gcm.IsCoinReserved(*coinID2))
+
+		// release the coins
+		err = gcm.ReleaseCoins("tx-test-3")
+		assert.NoError(t, err)
+
+		// coins are not reserved
+		assert.False(t, gcm.IsCoinReserved(*coinID1))
+		assert.False(t, gcm.IsCoinReserved(*coinID2))
+
+		// try to reserve the coins again
+		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs)
+		assert.NoError(t, err)
+	})
+}

--- a/relayer/txm/gas_coin_manager_test.go
+++ b/relayer/txm/gas_coin_manager_test.go
@@ -49,7 +49,7 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 	}
 	
 	t.Run("successfully reserve coins", func(t *testing.T) {
-		err := gcm.TryReserveCoins(ctx, txID, coinIDs)
+		err := gcm.TryReserveCoins(ctx, txID, coinIDs, nil)
 		assert.NoError(t, err)
 		
 		// Verify coins are reserved
@@ -65,7 +65,7 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 	
 	t.Run("fail to reserve already reserved coin", func(t *testing.T) {
 		// Try to reserve the same coins again
-		err := gcm.TryReserveCoins(ctx, "tx-test-2", coinIDs)
+		err := gcm.TryReserveCoins(ctx, "tx-test-2", coinIDs, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "is already reserved")
 	})
@@ -92,7 +92,7 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 			},
 		}
 
-		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs)
+		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs, nil)
 		assert.NoError(t, err)
 
 		// coins are reserved
@@ -108,7 +108,7 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 		assert.False(t, gcm.IsCoinReserved(*coinID2Bytes))
 
 		// try to reserve the coins again
-		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs)
+		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs, nil)
 		assert.NoError(t, err)
 	})
 
@@ -123,7 +123,7 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 			},
 		}
 		
-		err = gcm.TryReserveCoins(ctx, "tx-test-4", coinIDs)
+		err = gcm.TryReserveCoins(ctx, "tx-test-4", coinIDs, nil)
 		assert.NoError(t, err)
 		
 		// coins should be released automatically after the default TTL (30 seconds)

--- a/relayer/txm/gas_coin_manager_test.go
+++ b/relayer/txm/gas_coin_manager_test.go
@@ -4,9 +4,12 @@ package txm_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,25 +27,39 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 	txID := "test-tx-123"
 	
 	// Create test coin IDs
-	coinID1, err := models.NewHexData("0x1234567890abcdef1234567890abcdef12345678")
+	coinID1 := models.SuiAddress("0x1234567890abcdef1234567890abcdef12345678")
+	coinID2 := models.SuiAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+
+	coinID1Bytes, err := transaction.ConvertSuiAddressStringToBytes(coinID1)
 	require.NoError(t, err)
-	coinID2, err := models.NewHexData("0xabcdef1234567890abcdef1234567890abcdef12")
+	coinID2Bytes, err := transaction.ConvertSuiAddressStringToBytes(coinID2)
 	require.NoError(t, err)
-	
-	coinIDs := []models.ObjectId{*coinID1, *coinID2}
+
+	coinIDs := []transaction.SuiObjectRef{
+		{
+			ObjectId: *coinID1Bytes,
+			Version:  1,
+			Digest:   nil,
+		},
+		{
+			ObjectId: *coinID2Bytes,
+			Version:  1,
+			Digest:   nil,
+		},
+	}
 	
 	t.Run("successfully reserve coins", func(t *testing.T) {
 		err := gcm.TryReserveCoins(ctx, txID, coinIDs)
 		assert.NoError(t, err)
 		
 		// Verify coins are reserved
-		assert.True(t, gcm.IsCoinReserved(*coinID1))
-		assert.True(t, gcm.IsCoinReserved(*coinID2))
+		assert.True(t, gcm.IsCoinReserved(*coinID1Bytes))
+		assert.True(t, gcm.IsCoinReserved(*coinID2Bytes))
 		
 		// Verify transaction is stored
-		isReserved := gcm.IsCoinReserved(*coinID1)
+		isReserved := gcm.IsCoinReserved(*coinID1Bytes)
 		assert.True(t, isReserved)
-		isReserved = gcm.IsCoinReserved(*coinID2)
+		isReserved = gcm.IsCoinReserved(*coinID2Bytes)
 		assert.True(t, isReserved)
 	})
 	
@@ -54,30 +71,69 @@ func TestSuiGasCoinManager_TryReserveCoins(t *testing.T) {
 	})
 
 	t.Run("reserved then released coins can be reserved again", func(t *testing.T) {
-		coinID1, err := models.NewHexData("0x1234567890abcdef1234123890abcdef12345678")
-		require.NoError(t, err)
-		coinID2, err := models.NewHexData("0x1234567890abcdef1234153890abcdef12345678")
+		coinID1 := models.SuiAddress("0x1234567890abcdef1234123890abcdef12345678")
+		coinID1Bytes, err := transaction.ConvertSuiAddressStringToBytes(coinID1)
 		require.NoError(t, err)
 		
-		coinIDs := []models.ObjectId{*coinID1, *coinID2}
+		coinID2 := models.SuiAddress("0x1234567890abcdef1234153890abcdef12345678")
+		coinID2Bytes, err := transaction.ConvertSuiAddressStringToBytes(coinID2)
+		require.NoError(t, err)
+		
+		coinIDs := []transaction.SuiObjectRef{
+			{
+				ObjectId: *coinID1Bytes,
+				Version:  1,
+				Digest:   nil,
+			},
+			{
+				ObjectId: *coinID2Bytes,
+				Version:  1,
+				Digest:   nil,
+			},
+		}
 
 		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs)
 		assert.NoError(t, err)
 
 		// coins are reserved
-		assert.True(t, gcm.IsCoinReserved(*coinID1))
-		assert.True(t, gcm.IsCoinReserved(*coinID2))
+		assert.True(t, gcm.IsCoinReserved(*coinID1Bytes))
+		assert.True(t, gcm.IsCoinReserved(*coinID2Bytes))
 
 		// release the coins
 		err = gcm.ReleaseCoins("tx-test-3")
 		assert.NoError(t, err)
 
 		// coins are not reserved
-		assert.False(t, gcm.IsCoinReserved(*coinID1))
-		assert.False(t, gcm.IsCoinReserved(*coinID2))
+		assert.False(t, gcm.IsCoinReserved(*coinID1Bytes))
+		assert.False(t, gcm.IsCoinReserved(*coinID2Bytes))
 
 		// try to reserve the coins again
 		err = gcm.TryReserveCoins(ctx, "tx-test-3", coinIDs)
 		assert.NoError(t, err)
+	})
+
+	t.Run("coins should be released automatically after the default TTL", func(t *testing.T) {
+		coinID1Bytes, err := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress("0x1234567890abcdef1234123890abcdef12345123"))
+		require.NoError(t, err)
+		coinIDs := []transaction.SuiObjectRef{
+			{
+				ObjectId: *coinID1Bytes,
+				Version:  1,
+				Digest:   nil,
+			},
+		}
+		
+		err = gcm.TryReserveCoins(ctx, "tx-test-4", coinIDs)
+		assert.NoError(t, err)
+		
+		// coins should be released automatically after the default TTL (30 seconds)
+		require.Eventually(t, func() bool {
+			isReserved := gcm.IsCoinReserved(*coinID1Bytes)
+			if isReserved {
+				fmt.Println("coin is still reserved")
+			}
+
+			return !isReserved
+		}, 45*time.Second, 10*time.Second)
 	})
 }

--- a/relayer/txm/retry_manager.go
+++ b/relayer/txm/retry_manager.go
@@ -136,6 +136,8 @@ func defaultRetryStrategy(tx *SuiTx, txErrorMsg string, maxRetries int) (bool, R
 // isRetryable determines if a Sui error is retryable (transient) and returns the appropriate retry strategy.
 // It uses errors.Is to correctly recognize wrapped errors.
 func isRetryable(err error) (bool, RetryStrategy) {
+	
+	
 	for _, retryErr := range suierrors.ExponentialBackoffErrors {
 		if errors.Is(err, retryErr) {
 			return true, ExponentialBackoff

--- a/relayer/txm/retry_manager.go
+++ b/relayer/txm/retry_manager.go
@@ -16,6 +16,8 @@ const (
 	ExponentialBackoff
 	// GasBump indicates that the transaction should be retried after bumping its gas budget.
 	GasBump
+	// CoinRefresh indicates that the transaction should be retried with fresh coins (e.g., for locked coin errors).
+	CoinRefresh
 )
 
 // RetryStrategyFunc defines a function signature for evaluating if a transaction error
@@ -136,8 +138,6 @@ func defaultRetryStrategy(tx *SuiTx, txErrorMsg string, maxRetries int) (bool, R
 // isRetryable determines if a Sui error is retryable (transient) and returns the appropriate retry strategy.
 // It uses errors.Is to correctly recognize wrapped errors.
 func isRetryable(err error) (bool, RetryStrategy) {
-	
-	
 	for _, retryErr := range suierrors.ExponentialBackoffErrors {
 		if errors.Is(err, retryErr) {
 			return true, ExponentialBackoff
@@ -147,6 +147,12 @@ func isRetryable(err error) (bool, RetryStrategy) {
 	for _, retryErr := range suierrors.GasBumpErrors {
 		if errors.Is(err, retryErr) {
 			return true, GasBump
+		}
+	}
+
+	for _, retryErr := range suierrors.CoinRefreshErrors {
+		if errors.Is(err, retryErr) {
+			return true, CoinRefresh
 		}
 	}
 

--- a/relayer/txm/retry_manager_test.go
+++ b/relayer/txm/retry_manager_test.go
@@ -35,7 +35,7 @@ func TestCallbackRetryManager_IsRetryable_Scenarios(t *testing.T) {
 		{
 			name:          "Gas error with retries available returns GasBump",
 			txRetries:     0,
-			errMessage:    "Transaction failed: GasPriceTooHigh", // Should map to GasErrors by suierrors mapping
+			errMessage:    "Transaction failed: GasPriceTooHigh", // GasBump
 			maxRetries:    3,
 			expectedRetry: true,
 			expectedStrat: txm.GasBump,
@@ -43,10 +43,18 @@ func TestCallbackRetryManager_IsRetryable_Scenarios(t *testing.T) {
 		{
 			name:          "Non gas retryable error returns ExponentialBackoff",
 			txRetries:     0,
-			errMessage:    "Transaction failed: PackageVerificationTimeout", // Should fall under default (non gas) retryable
+			errMessage:    "Transaction failed: PackageVerificationTimeout", // ExponentialBackoff
 			maxRetries:    3,
 			expectedRetry: true,
 			expectedStrat: txm.ExponentialBackoff,
+		},
+		{
+			name:          "Locked coin error returns CoinRefresh",
+			txRetries:     0,
+			errMessage:    "Transaction failed: already locked by a different transaction", // CoinRefresh
+			maxRetries:    3,
+			expectedRetry: true,
+			expectedStrat: txm.CoinRefresh,
 		},
 		{
 			name:          "Exceeded max retries returns NoRetry",

--- a/relayer/txm/store.go
+++ b/relayer/txm/store.go
@@ -171,6 +171,8 @@ var validTransitions = map[TransactionState]map[TransactionState]bool{
 		StateSubmitted: true,
 		StateFinalized: true,
 		StateFailed:    true,
+		// Allow going from retriable to itself to avoid raising errors
+		StateRetriable: true,
 	},
 	StateFinalized: {},
 	StateFailed:    {},

--- a/relayer/txm/store.go
+++ b/relayer/txm/store.go
@@ -49,6 +49,7 @@ type TxmStore interface {
 	) error
 
 	UpdateTransactionError(transactionID string, txError *suierrors.SuiError) error
+	UpdateTransactionBroadcastError(transactionID string, broadcastError string) error
 
 	// DeleteTransaction removes a transaction from the store.
 	// Returns an error if the transaction is not found.
@@ -159,6 +160,7 @@ var validTransitions = map[TransactionState]map[TransactionState]bool{
 	StatePending: {
 		StateSubmitted: true,
 		StateFailed:    true,
+		StateRetriable: true,
 	},
 	StateSubmitted: {
 		StateFinalized: true,
@@ -321,6 +323,19 @@ func (s *InMemoryStore) UpdateTransactionError(transactionID string, txError *su
 		return fmt.Errorf("transaction not found")
 	}
 	tx.TxError = txError
+
+	return nil
+}
+
+func (s *InMemoryStore) UpdateTransactionBroadcastError(transactionID string, broadcastError string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, exists := s.transactions[transactionID]
+	if !exists {
+		return fmt.Errorf("transaction not found")
+	}
+	tx.BroadcastError = broadcastError
 
 	return nil
 }

--- a/relayer/txm/transaction.go
+++ b/relayer/txm/transaction.go
@@ -63,9 +63,11 @@ type SuiTx struct {
 	Digest                string
 	LastUpdatedAt         uint64
 	TxError               *suierrors.SuiError
+	BroadcastError        string
 	GasBudget             uint64
 	Ptb                   *transaction.Transaction
 	PaymentCoinsObjectRef []transaction.SuiObjectRef
+	CoinManager           GasCoinManager
 }
 
 // UpdateBSCPayload regenerates the BCS payload and signatures for the SuiTx.
@@ -91,7 +93,7 @@ func (tx *SuiTx) UpdateBSCPayload(
 		return fmt.Errorf("failed to get address from public key: %w", err)
 	}
 
-	txBytes, paymentCoins, err := preparePTBTransaction(ctx, signerAddress, suiClient, tx.Ptb, tx.GasBudget, lggr)
+	txBytes, paymentCoins, err := preparePTBTransaction(ctx, signerAddress, suiClient, tx.Ptb, tx.GasBudget, lggr, tx.CoinManager)
 	if err != nil {
 		return fmt.Errorf("failed to prepare PTB transaction: %w", err)
 	}
@@ -155,6 +157,7 @@ func TransactionIDGenerator() string {
 //   - ptb: The ProgrammableTransaction block containing the commands to be executed.
 //   - simulateTx: Boolean flag indicating whether to simulate the transaction (currently unused).
 //   - gasManager: Gas manager for estimating gas requirements.
+//   - coinManager: Coin manager for managing gas coins.
 //
 // Returns:
 //   - *SuiTx: A complete transaction object ready for submission with accurate gas estimation.
@@ -171,6 +174,7 @@ func GeneratePTBTransactionWithGasEstimation(
 	ptb *transaction.Transaction,
 	simulateTx bool,
 	gasManager GasManager,
+	coinManager GasCoinManager,
 ) (*SuiTx, error) {
 	signerAddress, err := client.GetAddressFromPublicKey(pubKey)
 	if err != nil {
@@ -193,7 +197,8 @@ func GeneratePTBTransactionWithGasEstimation(
 		"preliminaryGasBudget", preliminaryGasBudget)
 
 	preliminaryTx, err := buildPreliminaryTransaction(
-		ctx, signerAddress, suiClient, ptb, preliminaryGasBudget, lggr,
+		ctx, signerAddress, suiClient, ptb, 
+		preliminaryGasBudget, lggr, coinManager,
 	)
 	if err != nil {
 		lggr.Errorf("failed to build preliminary transaction: %v", err)
@@ -358,21 +363,8 @@ func preparePTBTransaction(
 	ptb *transaction.Transaction,
 	gasBudget uint64,
 	lggr logger.Logger,
+	coinManager GasCoinManager,
 ) (txBytes string, paymentCoins []transaction.SuiObjectRef, err error) {
-	// Get current epoch
-	epoch, err := suiClient.GetLatestEpoch(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to get current epoch: %w", err)
-	}
-
-	lggr.Debugw("Current epoch", "epoch", epoch)
-
-	// Parse epoch into uint64
-	epochUint, err := strconv.ParseUint(epoch, 10, 64)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to parse epoch: %w", err)
-	}
-
 	// Get available coins for gas
 	coinData, err := suiClient.GetCoinsByAddress(ctx, signerAddress)
 	if err != nil {
@@ -382,9 +374,16 @@ func preparePTBTransaction(
 	// Filter coins that are not locked
 	filteredCoinData := make([]models.CoinData, 0)
 	for _, coin := range coinData {
-		if coin.LockedUntilEpoch == 0 || coin.LockedUntilEpoch < epochUint {
-			filteredCoinData = append(filteredCoinData, coin)
+		coinObjectIdBytes, coinErr := transaction.ConvertSuiAddressStringToBytes(models.SuiAddress(coin.CoinObjectId))
+		if coinErr != nil {
+			return "", nil, fmt.Errorf("failed to convert coin object ID to bytes: %w", coinErr)
 		}
+
+		if coinManager.IsCoinReserved(*coinObjectIdBytes) {
+			continue
+		}
+
+		filteredCoinData = append(filteredCoinData, coin)
 	}
 
 	// Select coins for gas budget
@@ -444,9 +443,10 @@ func buildPreliminaryTransaction(
 	ptb *transaction.Transaction,
 	gasBudget uint64,
 	lggr logger.Logger,
+	coinManager GasCoinManager,
 ) (*SuiTx, error) {
 	// Use common preparation logic
-	txBytes, paymentCoins, err := preparePTBTransaction(ctx, signerAddress, suiClient, ptb, gasBudget, lggr)
+	txBytes, paymentCoins, err := preparePTBTransaction(ctx, signerAddress, suiClient, ptb, gasBudget, lggr, coinManager)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/txm/transaction.go
+++ b/relayer/txm/transaction.go
@@ -280,6 +280,7 @@ func GeneratePTBTransactionWithGasEstimation(
 		LastUpdatedAt:         GetCurrentUnixTimestamp(),
 		TxError:               nil,
 		GasBudget:             finalGasBudget,
+		CoinManager:           coinManager,
 		Ptb:                   ptb,
 		PaymentCoinsObjectRef: preliminaryTx.PaymentCoinsObjectRef, // Use the coins selected in preliminary tx
 	}, nil

--- a/relayer/txm/transaction_test.go
+++ b/relayer/txm/transaction_test.go
@@ -113,6 +113,8 @@ func TestTransactionGeneration(t *testing.T) {
 			GasLimit: big.NewInt(int64(gasBudget)),
 		}
 
+		coinManager := txm.NewGasCoinManager(lggr, ptbClient)
+
 		tx, err := txm.GeneratePTBTransactionWithGasEstimation(
 			ctx,
 			publicKeyBytes,
@@ -125,6 +127,7 @@ func TestTransactionGeneration(t *testing.T) {
 			ptb,
 			true,
 			gasManager,
+			coinManager,
 		)
 
 		finalGasBudget := tx.GasBudget

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -33,6 +33,7 @@ type SuiTxm struct {
 	transactionRepository TxmStore
 	retryManager          RetryManager
 	gasManager            GasManager
+	coinManager           GasCoinManager
 	configuration         Config
 	Starter               commonutils.StartStopOnce
 	done                  sync.WaitGroup
@@ -49,6 +50,8 @@ func NewSuiTxm(
 	lggr.Infof("SuiTxm configuration: %+v", conf)
 	lggr.Infof("Gas manager Max Gas Budget: %+v", gasManager.MaxGasBudget())
 
+	coinManager := NewGasCoinManager(lggr, gateway)
+
 	return &SuiTxm{
 		lggr:                  logger.Named(lggr, "SuiTxm"),
 		suiGateway:            gateway,
@@ -56,6 +59,7 @@ func NewSuiTxm(
 		transactionRepository: transactionsRepository,
 		retryManager:          retryManager,
 		gasManager:            gasManager,
+		coinManager:           coinManager,
 		configuration:         conf,
 		broadcastChannel:      make(chan string, conf.BroadcastChanSize),
 		stopChannel:           make(chan struct{}),
@@ -86,7 +90,7 @@ func (txm *SuiTxm) EnqueuePTB(ctx context.Context, transactionID string, txMetad
 	txn, err := GeneratePTBTransactionWithGasEstimation(
 		ctx, signerPublicKey, txm.lggr, txm.keystoreService, txm.suiGateway,
 		txm.configuration.RequestType, transactionID, txMetadata,
-		ptb, simulateTx, txm.gasManager,
+		ptb, simulateTx, txm.gasManager, txm.coinManager,
 	)
 	if err != nil {
 		txm.lggr.Errorw("Failed to generate PTB txn", "error", err)
@@ -104,6 +108,12 @@ func (txm *SuiTxm) EnqueuePTB(ctx context.Context, transactionID string, txMetad
 	txm.broadcastChannel <- transactionID
 	txm.lggr.Infow("PTB Transaction added to broadcast channel", "transactionID", transactionID)
 	txm.lggr.Infow("PTB Transaction enqueued", "transactionID", transactionID)
+
+	err = txm.coinManager.TryReserveCoins(ctx, transactionID, txn.PaymentCoinsObjectRef)
+	if err != nil {
+		txm.lggr.Errorw("Failed to reserve coins", "error", err)
+		return nil, err
+	}
 
 	return txn, nil
 }

--- a/relayer/txm/txm.go
+++ b/relayer/txm/txm.go
@@ -109,7 +109,7 @@ func (txm *SuiTxm) EnqueuePTB(ctx context.Context, transactionID string, txMetad
 	txm.lggr.Infow("PTB Transaction added to broadcast channel", "transactionID", transactionID)
 	txm.lggr.Infow("PTB Transaction enqueued", "transactionID", transactionID)
 
-	err = txm.coinManager.TryReserveCoins(ctx, transactionID, txn.PaymentCoinsObjectRef)
+	err = txm.coinManager.TryReserveCoins(ctx, transactionID, txn.PaymentCoinsObjectRef, nil)
 	if err != nil {
 		txm.lggr.Errorw("Failed to reserve coins", "error", err)
 		return nil, err

--- a/relayer/txm/txm_test.go
+++ b/relayer/txm/txm_test.go
@@ -5,6 +5,7 @@ package txm_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -188,6 +189,112 @@ func TestEnqueuePTBIntegration(t *testing.T) {
 		})
 	}
 	txManager.Close()
+}
+
+func TestCoinReservations(t *testing.T) {
+	ctx := context.Background()
+	logger := logger.Test(t)
+	logger.Debugw("Starting Sui node")
+
+	gasLimit := int64(200000000000)
+
+	suiClient, txManager, _, _, _, publicKeyBytes, packageId, objectID := testutils.SetupTestEnv(t, ctx, logger, gasLimit)
+
+	chainWriterConfig := config.ChainWriterConfig{
+		Modules: map[string]*config.ChainWriterModule{
+			"counter": {
+				Name:     "Counter",
+				ModuleID: packageId,
+				Functions: map[string]*config.ChainWriterFunction{
+					"ptb_call": {
+						Name:      "ptb_call",
+						PublicKey: publicKeyBytes,
+						Params:    []codec.SuiFunctionParam{},
+						PTBCommands: []config.ChainWriterPTBCommand{
+							{
+								Type:      codec.SuiPTBCommandMoveCall,
+								PackageId: &packageId,
+								ModuleId:  strPtr("counter"),
+								Function:  strPtr("increment_by"),
+								Params: []codec.SuiFunctionParam{
+									{
+										Name:     "counter",
+										Type:     "object_id",
+										Required: true,
+									},
+									{
+										Name:     "by",
+										Type:     "u64",
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	numTransactions := 10
+	ptbConstructor := ptb.NewPTBConstructor(chainWriterConfig, suiClient, logger)
+	numEnqueuedTransactions := 0
+
+	// queue N transactions
+	for i := range numTransactions {
+		arg := config.Arguments{
+			Args: map[string]any{
+				"counter": objectID,
+				"by":      uint64(i),
+			},
+		}
+		ptb, err := ptbConstructor.BuildPTBCommands(ctx, "counter", "ptb_call", arg, packageId, chainWriterConfig.Modules["counter"].Functions["ptb_call"])
+		require.NoError(t, err, "Failed to build PTB commands")
+
+		txID := fmt.Sprintf("test-txID-%d", i)
+		_, err = txManager.EnqueuePTB(ctx, txID, &commontypes.TxMeta{GasLimit: big.NewInt(gasLimit)}, publicKeyBytes, ptb)
+		
+		if err != nil {
+			logger.Errorw("Failed to enqueue PTB", "error", err)
+			continue
+		}
+
+		numEnqueuedTransactions++
+	}
+
+	// start the txm with multiple queued transactions
+	err := txManager.Start(ctx)
+	require.NoError(t, err, "Failed to start transaction manager")
+
+	defer txManager.Close()
+
+	successfulTransactions := map[string]bool{}
+
+	require.Eventually(t, func() bool {
+		successCount := 0
+
+		for i := range numEnqueuedTransactions {
+			txID := fmt.Sprintf("test-txID-%d", i)
+			
+			// Skip if the transaction has already been finalized
+			if _, ok := successfulTransactions[txID]; ok {
+				successCount++
+				continue
+			}
+			
+			status, statusErr := txManager.GetTransactionStatus(ctx, txID)
+			if statusErr != nil {
+				return false
+			}
+
+			if status == commontypes.Finalized {
+				successCount++
+				successfulTransactions[txID] = true
+			}
+		}
+
+		return successCount == numEnqueuedTransactions
+	}, 60*time.Second, 3*time.Second, "Transactions final state not reached")
 }
 
 // Helper function to convert a string to a string pointer


### PR DESCRIPTION
The PR includes the following: 

* Add a `GasCoinManager` abstraction to keep a cache of "reserved" coins (being used in other transacitons)
    * Current default expiry of reservation is 30 seconds
* Bring over some of the code in this [PR](https://github.com/smartcontractkit/chainlink-sui/pull/303) to include the LockedCoin error label and regex matching
* Add broadcast error parsing


Additional description of the change 

For a tx we build/send, you reserve its payment coins by calling `TryReserveCoins(txID, []SuiObjectRef, expiry=nil)` (or similar). That creates:

- `coinID -> true` with TTL = 30s (default)
- `txID -> []SuiObjectRef` with TTL = 30s

If we then detect the “locked coin / equivocation” issue and run the quarantine path, you call `TryReserveCoins(..., &expiry)` with 24h, which creates:

- `coinID -> true` with TTL = 24h
- `txID -> []SuiObjectRef` with TTL = 30s (still)

So after ~30s or failure/success:
- the txID mapping expires
- the coinID reservation remains for up to 24h

That’s why later ReleaseCoins(txID) often can’t undo the 24h quarantine: it loses the txID→coins index, but the coin lock key is still present.