### PR TITLE
Fix inconsistent timestamp for failed transactions

### DIFF
--- a/relayer/chainreader/indexer/transactions_indexer.go
+++ b/relayer/chainreader/indexer/transactions_indexer.go
@@ -526,7 +526,8 @@ func (tIndexer *TransactionsIndexer) syncTransmitterTransactions(ctx context.Con
 				TxDigest:            txDigestHex,
 				BlockHeight:         checkpointResponse.SequenceNumber,
 				BlockHash:           blockHashBytes,
-				BlockTimestamp:      blockTimestamp,
+				// Convert to seconds for consistency with events indexer.
+				BlockTimestamp:      blockTimestamp / 1000,
 				Data:                executionStateChanged,
 				IsSynthetic:         true,
 			}


### PR DESCRIPTION
Making blocktimestamp consistent with event indexer.