### PR TITLE
feat(deployment): Add changesets to configure MCMS and transfer ownership to self

### DIFF
--- a/deployment/changesets/cs_mcms_accept_ownership_self.go
+++ b/deployment/changesets/cs_mcms_accept_ownership_self.go
@@ -1,0 +1,52 @@
+package changesets
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/mcms"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+)
+
+var _ cldf.ChangeSetV2[mcmsops.AcceptMCMSOwnershipSeqInput] = AcceptMCMSOwnership{}
+
+type AcceptMCMSOwnership struct{}
+
+// VerifyPreconditions implements deployment.ChangeSetV2.
+func (a AcceptMCMSOwnership) VerifyPreconditions(e cldf.Environment, config mcmsops.AcceptMCMSOwnershipSeqInput) error {
+	return nil
+}
+
+// Apply implements deployment.ChangeSetV2.
+func (a AcceptMCMSOwnership) Apply(e cldf.Environment, config mcmsops.AcceptMCMSOwnershipSeqInput) (cldf.ChangesetOutput, error) {
+	suiChains := e.BlockChains.SuiChains()
+	suiChain := suiChains[config.ChainSelector]
+	deps := sui_ops.OpTxDeps{
+		Client: suiChain.Client,
+		Signer: suiChain.Signer,
+		GetCallOpts: func() *bind.CallOpts {
+			b := uint64(400_000_000)
+			return &bind.CallOpts{
+				WaitForExecution: true,
+				GasBudget:        &b,
+			}
+		},
+		SuiRPC: suiChain.URL,
+	}
+
+	// Run AcceptMCMSOwnership Sequence
+	acceptReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.AcceptMCMSOwnershipSequence, deps, config)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate accept ownership proposal for Sui chain %d: %w", config.ChainSelector, err)
+	}
+
+	return cldf.ChangesetOutput{
+		Reports:               []cld_ops.Report[any, any]{acceptReport.ToGenericReport()},
+		MCMSTimelockProposals: []mcms.TimelockProposal{acceptReport.Output},
+	}, nil
+}

--- a/deployment/changesets/cs_mcms_configure.go
+++ b/deployment/changesets/cs_mcms_configure.go
@@ -1,0 +1,106 @@
+package changesets
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/mcms"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	"github.com/smartcontractkit/chainlink-sui/deployment/utils"
+)
+
+type ConfigureMCMSConfig struct {
+	mcmsops.ConfigureMCMSSeqInput
+	TimelockConfig *utils.TimelockConfig // If nil, configuration will be executed directly
+}
+
+var _ cldf.ChangeSetV2[ConfigureMCMSConfig] = ConfigureMCMS{}
+
+type ConfigureMCMS struct{}
+
+// VerifyPreconditions implements deployment.ChangeSetV2.
+func (c ConfigureMCMS) VerifyPreconditions(e cldf.Environment, config ConfigureMCMSConfig) error {
+	return nil
+}
+
+// Apply implements deployment.ChangeSetV2.
+func (c ConfigureMCMS) Apply(e cldf.Environment, config ConfigureMCMSConfig) (cldf.ChangesetOutput, error) {
+	ab := cldf.NewMemoryAddressBook()
+	seqReports := make([]cld_ops.Report[any, any], 0)
+
+	state, err := deployment.LoadOnchainStatesui(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, err
+	}
+
+	suiChains := e.BlockChains.SuiChains()
+
+	suiChain := suiChains[config.ChainSelector]
+
+	deps := sui_ops.OpTxDeps{
+		Client: suiChain.Client,
+		Signer: suiChain.Signer,
+		GetCallOpts: func() *bind.CallOpts {
+			b := uint64(400_000_000)
+			return &bind.CallOpts{
+				WaitForExecution: true,
+				GasBudget:        &b,
+			}
+		},
+		SuiRPC: suiChain.URL,
+	}
+
+	// If timelock proposal is to be generated, disable signer in deps
+	if config.TimelockConfig != nil {
+		deps.Signer = nil
+	}
+
+	// Run ConfigureMCMS Sequence
+	configReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.ConfigureMCMSSequence, deps, config.ConfigureMCMSSeqInput)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to configure MCMS for Sui chain %d: %w", config.ChainSelector, err)
+	}
+
+	seqReports = append(seqReports, configReport.ToGenericReport())
+
+	mcmsProposal := mcms.TimelockProposal{}
+	if config.TimelockConfig != nil {
+		defs := []cld_ops.Definition{}
+		inputs := []any{}
+
+		for _, r := range configReport.Output.Reports {
+			defs = append(defs, r.Def)
+			inputs = append(inputs, r.Input)
+		}
+
+		mcmsConfig := mcmsops.ProposalGenerateInput{
+			ChainSelector:  config.ChainSelector,
+			Defs:           defs,
+			Inputs:         inputs,
+			MmcsPackageID:  state[config.ChainSelector].MCMSPackageID,
+			McmsStateObjID: state[config.ChainSelector].MCMSStateObjectID,
+			TimelockObjID:  state[config.ChainSelector].MCMSTimelockObjectID,
+			AccountObjID:   state[config.ChainSelector].MCMSAccountStateObjectID,
+			RegistryObjID:  state[config.ChainSelector].MCMSRegistryObjectID,
+			TimelockConfig: *config.TimelockConfig,
+		}
+
+		result, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, mcmsConfig)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal: %w", err)
+		}
+		mcmsProposal = result.Output
+	}
+
+	return cldf.ChangesetOutput{
+		AddressBook:           ab,
+		Reports:               seqReports,
+		MCMSTimelockProposals: []mcms.TimelockProposal{mcmsProposal},
+	}, nil
+}

--- a/deployment/ops/mcms/op_set_config.go
+++ b/deployment/ops/mcms/op_set_config.go
@@ -8,12 +8,13 @@ import (
 
 	cselectors "github.com/smartcontractkit/chain-selectors"
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
-	modulemcms "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms"
-	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	modulemcms "github.com/smartcontractkit/chainlink-sui/bindings/generated/mcms/mcms"
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 )
 
 type MCMSSetConfigInput struct {
@@ -28,6 +29,13 @@ type MCMSSetConfigInput struct {
 	Config    types.Config `json:"config"`
 	ClearRoot bool         `json:"clearRoot"`
 }
+
+var SetConfigMCMSOp = cld_ops.NewOperation(
+	sui_ops.NewSuiOperationName("mcms", "mcms", "set_config"),
+	semver.MustParse("0.1.0"),
+	"Set config in the MCMS contract",
+	setConfigMcmsHandler,
+)
 
 var setConfigMcmsHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input MCMSSetConfigInput) (output sui_ops.OpTxResult[cld_ops.EmptyInput], err error) {
 	opts := deps.GetCallOpts()
@@ -92,10 +100,3 @@ var setConfigMcmsHandler = func(b cld_ops.Bundle, deps sui_ops.OpTxDeps, input M
 		PackageId: input.McmsPackageID,
 	}, err
 }
-
-var SetConfigMCMSOp = cld_ops.NewOperation(
-	sui_ops.NewSuiOperationName("mcms", "mcms", "set_config"),
-	semver.MustParse("0.1.0"),
-	"Set config in the MCMS contract",
-	setConfigMcmsHandler,
-)

--- a/deployment/ops/mcms/seq_accept_ownership.go
+++ b/deployment/ops/mcms/seq_accept_ownership.go
@@ -1,0 +1,64 @@
+package mcmsops
+
+import (
+    "fmt"
+
+    "github.com/Masterminds/semver/v3"
+    "github.com/smartcontractkit/mcms"
+    "github.com/smartcontractkit/mcms/types"
+
+    cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+    sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+    "github.com/smartcontractkit/chainlink-sui/deployment/utils"
+)
+
+type AcceptMCMSOwnershipSeqInput struct {
+    ChainSelector             uint64 `json:"chainSelector" yaml:"chainSelector"`
+    PackageId                 string `json:"packageId" yaml:"packageId"`
+    McmsMultisigStateObjectId string `json:"mcmsMultisigStateObjectId" yaml:"mcmsMultisigStateObjectId"`
+    TimelockObjectId          string `json:"timelockObjectId" yaml:"timelockObjectId"`
+    McmsAccountStateObjectId  string `json:"mcmsAccountStateObjectId" yaml:"mcmsAccountStateObjectId"`
+    McmsRegistryObjectId      string `json:"mcmsRegistryObjectId" yaml:"mcmsRegistryObjectId"`
+    McmsDeployerStateObjectId string `json:"mcmsDeployerStateObjectId" yaml:"mcmsDeployerStateObjectId"`
+}
+
+var AcceptMCMSOwnershipSequence = cld_ops.NewSequence(
+    "sui-accept-mcms-ownership-seq",
+    semver.MustParse("0.1.0"),
+    "Generates the MCMS proposal to accept MCMS ownership via the timelock",
+    acceptMCMSOwnership,
+)
+
+func acceptMCMSOwnership(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input AcceptMCMSOwnershipSeqInput) (mcms.TimelockProposal, error) {
+    proposalInput := ProposalGenerateInput{
+        Defs: []cld_ops.Definition{
+            MCMSAcceptOwnershipOp.Def(),
+        },
+        Inputs: []any{
+            MCMSAcceptOwnershipInput{
+                McmsPackageID:   input.PackageId,
+                AccountObjectID: input.McmsAccountStateObjectId,
+            },
+        },
+        MmcsPackageID:      input.PackageId,
+        McmsStateObjID:     input.McmsMultisigStateObjectId,
+        TimelockObjID:      input.TimelockObjectId,
+        AccountObjID:       input.McmsAccountStateObjectId,
+        RegistryObjID:      input.McmsRegistryObjectId,
+        DeployerStateObjID: input.McmsDeployerStateObjectId,
+        ChainSelector:      input.ChainSelector,
+        TimelockConfig: utils.TimelockConfig{
+            MCMSAction:   types.TimelockActionSchedule,
+            MinDelay:     0,
+            OverrideRoot: false,
+        },
+    }
+
+    report, err := cld_ops.ExecuteSequence(env, MCMSDynamicProposalGenerateSeq, deps, proposalInput)
+    if err != nil {
+        return mcms.TimelockProposal{}, fmt.Errorf("failed to generate accept ownership proposal: %w", err)
+    }
+
+    return report.Output, nil
+}

--- a/deployment/ops/mcms/seq_configure.go
+++ b/deployment/ops/mcms/seq_configure.go
@@ -1,0 +1,77 @@
+package mcmsops
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
+	"github.com/smartcontractkit/mcms/types"
+
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+)
+
+// ConfigureMCMSSeqInput defines the input for configuring MCMS
+type ConfigureMCMSSeqInput struct {
+	ChainSelector               uint64 `json:"chainSelector" yaml:"chainSelector"`
+	PackageId                   string `json:"packageId" yaml:"packageId"`
+	McmsAccountOwnerCapObjectId string `json:"mcmsAccountOwnerCapObjectId" yaml:"mcmsAccountOwnerCapObjectId"`
+	McmsAccountStateObjectId    string `json:"mcmsAccountStateObjectId" yaml:"mcmsAccountStateObjectId"`
+	McmsMultisigStateObjectId   string `json:"mcmsMultisigStateObjectId" yaml:"mcmsMultisigStateObjectId"`
+
+	// Optional configs for each timelock role
+	// If nil, the role will not be configured
+	Bypasser  *types.Config `json:"bypasser,omitempty" yaml:"bypasser,omitempty"`
+	Proposer  *types.Config `json:"proposer,omitempty" yaml:"proposer,omitempty"`
+	Canceller *types.Config `json:"canceller,omitempty" yaml:"canceller,omitempty"`
+}
+
+type ConfigureMCMSSeqOutput struct {
+	Reports []cld_ops.Report[any, any]
+}
+
+var ConfigureMCMSSequence = cld_ops.NewSequence(
+	"sui-configure-mcms-seq",
+	semver.MustParse("0.1.0"),
+	"Configures the MCMS package with the provided timelock roles configuration",
+	configureMCMS,
+)
+
+func configureMCMS(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input ConfigureMCMSSeqInput) (ConfigureMCMSSeqOutput, error) {
+	// Configure each timelock role if config is provided
+	roleConfigs := []struct {
+		config *types.Config
+		role   suisdk.TimelockRole
+		name   string
+	}{
+		{input.Bypasser, suisdk.TimelockRoleBypasser, "Bypasser"},
+		{input.Canceller, suisdk.TimelockRoleCanceller, "Canceller"},
+		{input.Proposer, suisdk.TimelockRoleProposer, "Proposer"},
+	}
+
+	opReports := make([]cld_ops.Report[any, any], 0)
+	for _, roleConfig := range roleConfigs {
+		if roleConfig.config == nil {
+			continue
+		}
+
+		setConfigInput := MCMSSetConfigInput{
+			ChainSelector: input.ChainSelector,
+			McmsPackageID: input.PackageId,
+			OwnerCap:      input.McmsAccountOwnerCapObjectId,
+			McmsObjectID:  input.McmsMultisigStateObjectId,
+			Role:          roleConfig.role,
+			Config:        *roleConfig.config,
+		}
+
+		report, err := cld_ops.ExecuteOperation(env, SetConfigMCMSOp, deps, setConfigInput)
+		if err != nil {
+			return ConfigureMCMSSeqOutput{}, fmt.Errorf("failed to set config for role %s: %w", roleConfig.name, err)
+		}
+		opReports = append(opReports, report.ToGenericReport())
+		env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
+	}
+
+	return ConfigureMCMSSeqOutput{Reports: opReports}, nil
+}

--- a/deployment/ops/mcms/seq_deploy.go
+++ b/deployment/ops/mcms/seq_deploy.go
@@ -44,34 +44,19 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 		}
 
 		// Configure each timelock role if config is provided
-		roleConfigs := []struct {
-			config *types.Config
-			role   suisdk.TimelockRole
-			name   string
-		}{
-			{input.Bypasser, suisdk.TimelockRoleBypasser, "Bypasser"},
-			{input.Canceller, suisdk.TimelockRoleCanceller, "Canceller"},
-			{input.Proposer, suisdk.TimelockRoleProposer, "Proposer"},
+		cfgMCMSInput := ConfigureMCMSSeqInput{
+			ChainSelector:               input.ChainSelector,
+			PackageId:                   deployReport.Output.PackageId,
+			McmsAccountOwnerCapObjectId: deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
+			McmsAccountStateObjectId:    deployReport.Output.Objects.McmsAccountStateObjectId,
+			McmsMultisigStateObjectId:   deployReport.Output.Objects.McmsMultisigStateObjectId,
+			Bypasser:                    input.Bypasser,
+			Proposer:                    input.Proposer,
+			Canceller:                   input.Canceller,
 		}
-
-		for _, roleConfig := range roleConfigs {
-			if roleConfig.config != nil {
-				setConfigInput := MCMSSetConfigInput{
-					ChainSelector: input.ChainSelector,
-					McmsPackageID: deployReport.Output.PackageId,
-					OwnerCap:      deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
-					McmsObjectID:  deployReport.Output.Objects.McmsMultisigStateObjectId,
-					Role:          roleConfig.role,
-					Config:        *roleConfig.config,
-				}
-
-				_, err = cld_ops.ExecuteOperation(env, SetConfigMCMSOp, deps, setConfigInput)
-				if err != nil {
-					return DeployMCMSSeqOutput{}, fmt.Errorf("failed to set config for role %s: %w", roleConfig.name, err)
-				}
-
-				env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
-			}
+		_, err = cld_ops.ExecuteSequence(env, ConfigureMCMSSequence, deps, cfgMCMSInput)
+		if err != nil {
+			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to configure MCMS: %w", err)
 		}
 
 		// Init the ownership transfer to self
@@ -126,3 +111,67 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 		return output, nil
 	},
 )
+
+// ConfigureMCMSSeqInput defines the input for configuring MCMS
+type ConfigureMCMSSeqInput struct {
+	ChainSelector               uint64 `json:"chainSelector" yaml:"chainSelector"`
+	PackageId                   string `json:"packageId" yaml:"packageId"`
+	McmsAccountOwnerCapObjectId string `json:"mcmsAccountOwnerCapObjectId" yaml:"mcmsAccountOwnerCapObjectId"`
+	McmsAccountStateObjectId    string `json:"mcmsAccountStateObjectId" yaml:"mcmsAccountStateObjectId"`
+	McmsMultisigStateObjectId   string `json:"mcmsMultisigStateObjectId" yaml:"mcmsMultisigStateObjectId"`
+
+	// Optional configs for each timelock role
+	// If nil, the role will not be configured
+	Bypasser  *types.Config `json:"bypasser,omitempty" yaml:"bypasser,omitempty"`
+	Proposer  *types.Config `json:"proposer,omitempty" yaml:"proposer,omitempty"`
+	Canceller *types.Config `json:"canceller,omitempty" yaml:"canceller,omitempty"`
+}
+
+type ConfigureMCMSSeqOutput struct {
+	Reports []cld_ops.Report[any, any]
+}
+
+var ConfigureMCMSSequence = cld_ops.NewSequence(
+	"sui-configure-mcms-seq",
+	semver.MustParse("0.1.0"),
+	"Configures the MCMS package with the provided timelock roles configuration",
+	configureMCMS,
+)
+
+func configureMCMS(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input ConfigureMCMSSeqInput) (ConfigureMCMSSeqOutput, error) {
+	// Configure each timelock role if config is provided
+	roleConfigs := []struct {
+		config *types.Config
+		role   suisdk.TimelockRole
+		name   string
+	}{
+		{input.Bypasser, suisdk.TimelockRoleBypasser, "Bypasser"},
+		{input.Canceller, suisdk.TimelockRoleCanceller, "Canceller"},
+		{input.Proposer, suisdk.TimelockRoleProposer, "Proposer"},
+	}
+
+	opReports := make([]cld_ops.Report[any, any], 0)
+	for _, roleConfig := range roleConfigs {
+		if roleConfig.config == nil {
+			continue
+		}
+
+		setConfigInput := MCMSSetConfigInput{
+			ChainSelector: input.ChainSelector,
+			McmsPackageID: input.PackageId,
+			OwnerCap:      input.McmsAccountOwnerCapObjectId,
+			McmsObjectID:  input.McmsMultisigStateObjectId,
+			Role:          roleConfig.role,
+			Config:        *roleConfig.config,
+		}
+
+		report, err := cld_ops.ExecuteOperation(env, SetConfigMCMSOp, deps, setConfigInput)
+		if err != nil {
+			return ConfigureMCMSSeqOutput{}, fmt.Errorf("failed to set config for role %s: %w", roleConfig.name, err)
+		}
+		opReports = append(opReports, report.ToGenericReport())
+		env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
+	}
+
+	return ConfigureMCMSSeqOutput{Reports: opReports}, nil
+}

--- a/deployment/ops/mcms/seq_deploy.go
+++ b/deployment/ops/mcms/seq_deploy.go
@@ -6,13 +6,11 @@ import (
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/smartcontractkit/mcms"
-	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/types"
 
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
-	"github.com/smartcontractkit/chainlink-sui/deployment/utils"
 )
 
 // DeployMCMSSeqInput defines the input for deploying MCMS with timelock roles configuration
@@ -36,142 +34,64 @@ var DeployMCMSSequence = cld_ops.NewSequence(
 	"sui-deploy-mcms-seq",
 	semver.MustParse("0.1.0"),
 	"Deploys the MCMS package, sets the initial configuration, init the ownership transfer to self and generates the proposal to accept the ownership",
-	func(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input DeployMCMSSeqInput) (DeployMCMSSeqOutput, error) {
-		// Deploy MCMS first
-		deployReport, err := cld_ops.ExecuteOperation(env, DeployMCMSOp, deps, cld_ops.EmptyInput{})
-		if err != nil {
-			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to deploy MCMS: %w", err)
-		}
-
-		// Configure each timelock role if config is provided
-		cfgMCMSInput := ConfigureMCMSSeqInput{
-			ChainSelector:               input.ChainSelector,
-			PackageId:                   deployReport.Output.PackageId,
-			McmsAccountOwnerCapObjectId: deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
-			McmsAccountStateObjectId:    deployReport.Output.Objects.McmsAccountStateObjectId,
-			McmsMultisigStateObjectId:   deployReport.Output.Objects.McmsMultisigStateObjectId,
-			Bypasser:                    input.Bypasser,
-			Proposer:                    input.Proposer,
-			Canceller:                   input.Canceller,
-		}
-		_, err = cld_ops.ExecuteSequence(env, ConfigureMCMSSequence, deps, cfgMCMSInput)
-		if err != nil {
-			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to configure MCMS: %w", err)
-		}
-
-		// Init the ownership transfer to self
-		transferOwnershipInput := MCMSTransferOwnershipInput{
-			McmsPackageID:   deployReport.Output.PackageId,
-			OwnerCap:        deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
-			AccountObjectID: deployReport.Output.Objects.McmsAccountStateObjectId,
-		}
-		_, err = cld_ops.ExecuteOperation(env, MCMSTransferOwnershipOp, deps, transferOwnershipInput)
-		if err != nil {
-			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to transfer ownership to MCMS: %w", err)
-		}
-
-		// Generate the proposal to accept the ownership
-		proposalInput := ProposalGenerateInput{
-			Defs: []cld_ops.Definition{
-				MCMSAcceptOwnershipOp.Def(),
-			},
-			Inputs: []any{
-				MCMSAcceptOwnershipInput{
-					McmsPackageID:   deployReport.Output.PackageId,
-					AccountObjectID: deployReport.Output.Objects.McmsAccountStateObjectId,
-				},
-			},
-			// MCMS related
-			MmcsPackageID:      deployReport.Output.PackageId,
-			McmsStateObjID:     deployReport.Output.Objects.McmsMultisigStateObjectId,
-			TimelockObjID:      deployReport.Output.Objects.TimelockObjectId,
-			AccountObjID:       deployReport.Output.Objects.McmsAccountStateObjectId,
-			RegistryObjID:      deployReport.Output.Objects.McmsRegistryObjectId,
-			DeployerStateObjID: deployReport.Output.Objects.McmsDeployerStateObjectId,
-			ChainSelector:      uint64(input.ChainSelector),
-			// Proposal
-			TimelockConfig: utils.TimelockConfig{
-				MCMSAction:   types.TimelockActionSchedule,
-				MinDelay:     0,
-				OverrideRoot: false,
-			},
-		}
-
-		acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(env, MCMSDynamicProposalGenerateSeq, deps, proposalInput)
-		if err != nil {
-			return DeployMCMSSeqOutput{}, fmt.Errorf("failed to generate accept ownership proposal: %w", err)
-		}
-
-		output := DeployMCMSSeqOutput{
-			AcceptOwnershipProposal: acceptOwnershipProposalReport.Output,
-			PackageId:               deployReport.Output.PackageId,
-			Objects:                 deployReport.Output.Objects,
-		}
-
-		return output, nil
-	},
+	deployMCMS,
 )
 
-// ConfigureMCMSSeqInput defines the input for configuring MCMS
-type ConfigureMCMSSeqInput struct {
-	ChainSelector               uint64 `json:"chainSelector" yaml:"chainSelector"`
-	PackageId                   string `json:"packageId" yaml:"packageId"`
-	McmsAccountOwnerCapObjectId string `json:"mcmsAccountOwnerCapObjectId" yaml:"mcmsAccountOwnerCapObjectId"`
-	McmsAccountStateObjectId    string `json:"mcmsAccountStateObjectId" yaml:"mcmsAccountStateObjectId"`
-	McmsMultisigStateObjectId   string `json:"mcmsMultisigStateObjectId" yaml:"mcmsMultisigStateObjectId"`
+func deployMCMS(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input DeployMCMSSeqInput) (DeployMCMSSeqOutput, error) {
+	// Deploy MCMS first
+	deployReport, err := cld_ops.ExecuteOperation(env, DeployMCMSOp, deps, cld_ops.EmptyInput{})
+	if err != nil {
+		return DeployMCMSSeqOutput{}, fmt.Errorf("failed to deploy MCMS: %w", err)
+	}
 
-	// Optional configs for each timelock role
-	// If nil, the role will not be configured
-	Bypasser  *types.Config `json:"bypasser,omitempty" yaml:"bypasser,omitempty"`
-	Proposer  *types.Config `json:"proposer,omitempty" yaml:"proposer,omitempty"`
-	Canceller *types.Config `json:"canceller,omitempty" yaml:"canceller,omitempty"`
-}
-
-type ConfigureMCMSSeqOutput struct {
-	Reports []cld_ops.Report[any, any]
-}
-
-var ConfigureMCMSSequence = cld_ops.NewSequence(
-	"sui-configure-mcms-seq",
-	semver.MustParse("0.1.0"),
-	"Configures the MCMS package with the provided timelock roles configuration",
-	configureMCMS,
-)
-
-func configureMCMS(env cld_ops.Bundle, deps sui_ops.OpTxDeps, input ConfigureMCMSSeqInput) (ConfigureMCMSSeqOutput, error) {
 	// Configure each timelock role if config is provided
-	roleConfigs := []struct {
-		config *types.Config
-		role   suisdk.TimelockRole
-		name   string
-	}{
-		{input.Bypasser, suisdk.TimelockRoleBypasser, "Bypasser"},
-		{input.Canceller, suisdk.TimelockRoleCanceller, "Canceller"},
-		{input.Proposer, suisdk.TimelockRoleProposer, "Proposer"},
+	cfgMCMSInput := ConfigureMCMSSeqInput{
+		ChainSelector:               input.ChainSelector,
+		PackageId:                   deployReport.Output.PackageId,
+		McmsAccountOwnerCapObjectId: deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
+		McmsAccountStateObjectId:    deployReport.Output.Objects.McmsAccountStateObjectId,
+		McmsMultisigStateObjectId:   deployReport.Output.Objects.McmsMultisigStateObjectId,
+		Bypasser:                    input.Bypasser,
+		Proposer:                    input.Proposer,
+		Canceller:                   input.Canceller,
+	}
+	_, err = cld_ops.ExecuteSequence(env, ConfigureMCMSSequence, deps, cfgMCMSInput)
+	if err != nil {
+		return DeployMCMSSeqOutput{}, fmt.Errorf("failed to configure MCMS: %w", err)
 	}
 
-	opReports := make([]cld_ops.Report[any, any], 0)
-	for _, roleConfig := range roleConfigs {
-		if roleConfig.config == nil {
-			continue
-		}
-
-		setConfigInput := MCMSSetConfigInput{
-			ChainSelector: input.ChainSelector,
-			McmsPackageID: input.PackageId,
-			OwnerCap:      input.McmsAccountOwnerCapObjectId,
-			McmsObjectID:  input.McmsMultisigStateObjectId,
-			Role:          roleConfig.role,
-			Config:        *roleConfig.config,
-		}
-
-		report, err := cld_ops.ExecuteOperation(env, SetConfigMCMSOp, deps, setConfigInput)
-		if err != nil {
-			return ConfigureMCMSSeqOutput{}, fmt.Errorf("failed to set config for role %s: %w", roleConfig.name, err)
-		}
-		opReports = append(opReports, report.ToGenericReport())
-		env.Logger.Infow("Set MCMS config", "role", roleConfig.name, "chainSelector", input.ChainSelector)
+	// Init the ownership transfer to self
+	transferOwnershipInput := MCMSTransferOwnershipInput{
+		McmsPackageID:   deployReport.Output.PackageId,
+		OwnerCap:        deployReport.Output.Objects.McmsAccountOwnerCapObjectId,
+		AccountObjectID: deployReport.Output.Objects.McmsAccountStateObjectId,
+	}
+	_, err = cld_ops.ExecuteOperation(env, MCMSTransferOwnershipOp, deps, transferOwnershipInput)
+	if err != nil {
+		return DeployMCMSSeqOutput{}, fmt.Errorf("failed to transfer ownership to MCMS: %w", err)
 	}
 
-	return ConfigureMCMSSeqOutput{Reports: opReports}, nil
+	// Generate accept ownership proposal
+	acceptOwnershipInput := AcceptMCMSOwnershipSeqInput{
+		ChainSelector:             input.ChainSelector,
+		PackageId:                 deployReport.Output.PackageId,
+		McmsAccountStateObjectId:  deployReport.Output.Objects.McmsAccountStateObjectId,
+		McmsDeployerStateObjectId: deployReport.Output.Objects.McmsDeployerStateObjectId,
+		McmsMultisigStateObjectId: deployReport.Output.Objects.McmsMultisigStateObjectId,
+		McmsRegistryObjectId:      deployReport.Output.Objects.McmsRegistryObjectId,
+		TimelockObjectId:          deployReport.Output.Objects.TimelockObjectId,
+	}
+
+	acceptOwnershipProposalReport, err := cld_ops.ExecuteSequence(env, AcceptMCMSOwnershipSequence, deps, acceptOwnershipInput)
+	if err != nil {
+		return DeployMCMSSeqOutput{}, fmt.Errorf("failed to generate accept ownership proposal: %w", err)
+	}
+
+	output := DeployMCMSSeqOutput{
+		AcceptOwnershipProposal: acceptOwnershipProposalReport.Output,
+		PackageId:               deployReport.Output.PackageId,
+		Objects:                 deployReport.Output.Objects,
+	}
+
+	return output, nil
 }

--- a/deployment/ops/mcms/seq_deploy_test.go
+++ b/deployment/ops/mcms/seq_deploy_test.go
@@ -184,5 +184,13 @@ func TestDeployMCMSSeq(t *testing.T) {
 	require.NotEmpty(t, objects.McmsAccountStateObjectId, "MCMS Account State Object ID should not be empty")
 	require.NotEmpty(t, objects.McmsAccountOwnerCapObjectId, "MCMS Account Owner Cap Object ID should not be empty")
 	require.NotEmpty(t, report.Output.PackageId, "Package ID should not be empty")
-	require.NotEmpty(t, report.Output.AcceptOwnershipProposal, "Accept Ownership Proposal should not be empty")
+
+	// Verify the accept ownership proposal was generated correctly
+	proposal := report.Output.AcceptOwnershipProposal
+	require.NotEmpty(t, proposal.Description, "Proposal description should not be empty")
+	require.Contains(t, proposal.Description, "accept_ownership", "Proposal should reference accept_ownership operation")
+	require.NotEmpty(t, proposal.Version, "Proposal version should not be empty")
+	require.NotZero(t, proposal.ValidUntil, "Proposal ValidUntil should be set")
+	require.NotEmpty(t, proposal.Operations, "Proposal should contain operations")
+	require.Len(t, proposal.Operations, 1, "Proposal should contain exactly one operation")
 }


### PR DESCRIPTION
# Summary
Since MCMS wasn't configured during deployments (via deploy mcms changeset) we need support for configuring it and generating the proposal to accept ownership to self.

# Features
- Refactored mcms config into its own sequence
- Refactored accept mcms ownership into its own sequence
- Created changesets for both

# Testing
Implemented assertions for the accept ownership proposal in the refactored sequence