### PR TITLE
fix(deployment): Add timelock configs to curse/uncurse cs

### DIFF
--- a/deployment/changesets/cs_curse_uncurse.go
+++ b/deployment/changesets/cs_curse_uncurse.go
@@ -7,11 +7,15 @@ import (
 
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/mcms"
 
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
+	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 	rmn_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops/rmn"
+	"github.com/smartcontractkit/chainlink-sui/deployment/utils"
 )
 
 type CurseUncurseOperationType string
@@ -22,10 +26,11 @@ const (
 )
 
 type CurseUncurseChainsConfig struct {
-	SuiChainSelector   uint64   `yaml:"suiChainSelector"`
-	OperationType      string   `yaml:"operationType"`
-	IsGlobalCurse      bool     `yaml:"isGlobalCurse"`
-	DestChainSelectors []uint64 `yaml:"destChainSelectors"`
+	SuiChainSelector   uint64                `yaml:"suiChainSelector"`
+	OperationType      string                `yaml:"operationType"`
+	IsGlobalCurse      bool                  `yaml:"isGlobalCurse"`
+	DestChainSelectors []uint64              `yaml:"destChainSelectors"`
+	TimelockConfig     *utils.TimelockConfig `yaml:"timelockConfig,omitempty"`
 }
 
 var _ cldf.ChangeSetV2[CurseUncurseChainsConfig] = CurseUncurseChains{}
@@ -90,6 +95,11 @@ func (c CurseUncurseChains) Apply(e cldf.Environment, cfg CurseUncurseChainsConf
 		SuiRPC: suiChain.URL,
 	}
 
+	// If timelock proposal is to be generated, disable signer in deps
+	if cfg.TimelockConfig != nil {
+		deps.Signer = nil
+	}
+
 	input := rmn_ops.CurseUncurseChainInput{
 		CCIPPackageId:    chainState.CCIPAddress,
 		StateObjectId:    chainState.CCIPObjectRef,
@@ -112,7 +122,35 @@ func (c CurseUncurseChains) Apply(e cldf.Environment, cfg CurseUncurseChainsConf
 		genericReport = report.ToGenericReport()
 	}
 
-	return cldf.ChangesetOutput{Reports: []operations.Report[any, any]{genericReport}}, nil
+	mcmsProposal := mcms.TimelockProposal{}
+	if cfg.TimelockConfig != nil {
+		defs := []cld_ops.Definition{genericReport.Def}
+		inputs := []any{genericReport.Input}
+
+		mcmsConfig := mcmsops.ProposalGenerateInput{
+			ChainSelector:      cfg.SuiChainSelector,
+			Defs:               defs,
+			Inputs:             inputs,
+			MmcsPackageID:      state[cfg.SuiChainSelector].MCMSPackageID,
+			McmsStateObjID:     state[cfg.SuiChainSelector].MCMSStateObjectID,
+			TimelockObjID:      state[cfg.SuiChainSelector].MCMSTimelockObjectID,
+			AccountObjID:       state[cfg.SuiChainSelector].MCMSAccountStateObjectID,
+			RegistryObjID:      state[cfg.SuiChainSelector].MCMSRegistryObjectID,
+			DeployerStateObjID: state[cfg.SuiChainSelector].MCMSDeployerStateObjectID,
+			TimelockConfig:     *cfg.TimelockConfig,
+		}
+
+		result, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, mcmsConfig)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate MCMS proposal: %w", err)
+		}
+		mcmsProposal = result.Output
+	}
+
+	return cldf.ChangesetOutput{
+		Reports:               []operations.Report[any, any]{genericReport},
+		MCMSTimelockProposals: []mcms.TimelockProposal{mcmsProposal},
+	}, nil
 }
 
 func buildCurseSubjects(cfg CurseUncurseChainsConfig) ([][]byte, error) {

--- a/deployment/ops/registry/op_registry.go
+++ b/deployment/ops/registry/op_registry.go
@@ -2,6 +2,7 @@ package opregistry
 
 import (
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
 	ccipops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip"
 	burnminttokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_burn_mint_token_pool"
 	lockreleasetokenpoolops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_lock_release_token_pool"
@@ -10,6 +11,7 @@ import (
 	onrampops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_onramp"
 	routerops "github.com/smartcontractkit/chainlink-sui/deployment/ops/ccip_router"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
+	rmnops "github.com/smartcontractkit/chainlink-sui/deployment/ops/rmn"
 )
 
 // Exports every operation available so they can be registered to be used in dynamic changesets
@@ -29,6 +31,9 @@ var AllOperations = func() []cld_ops.Operation[any, any, any] {
 	operations = append(operations, lockreleasetokenpoolops.AllOperationsLockReleaseTP...)
 	operations = append(operations, burnminttokenpoolops.AllOperationsBurnMintTP...)
 	operations = append(operations, managedtokenpoolops.AllOperationsManagedTP...)
+
+	// RMN Operations
+	operations = append(operations, rmnops.AllOperationsRMN...)
 	// Add more operation slices here as needed:
 	// operations = append(operations, anotherops.AllOperations...)
 

--- a/deployment/ops/rmn/op_registry.go
+++ b/deployment/ops/rmn/op_registry.go
@@ -1,0 +1,8 @@
+package rmn
+
+import cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+var AllOperationsRMN = []cld_ops.Operation[any, any, any]{
+	*CurseChainOp.AsUntyped(),
+	*UncurseChainOp.AsUntyped(),
+}


### PR DESCRIPTION
# Summary
Curse/Uncurse operations had support for MCMS, but changeset didn't. This PR adds the missing support.

# Testing
Ran pipeline using this branch in CLD. Generated proposal successfully 