### PR TITLE
fix(deployment): remove json tag to properly untype input

### DIFF
--- a/deployment/ops/mcms/op_set_config.go
+++ b/deployment/ops/mcms/op_set_config.go
@@ -18,16 +18,16 @@ import (
 )
 
 type MCMSSetConfigInput struct {
-	ChainSelector uint64 `json:"chainSelector"`
+	ChainSelector uint64 `yaml:"chainSelector"`
 	// MCMS related
-	McmsPackageID string `json:"mcmsPackageID"`
-	OwnerCap      string `json:"ownerCap"`
-	McmsObjectID  string `json:"mcmsObjectID"`
+	McmsPackageID string `yaml:"mcmsPackageID"`
+	OwnerCap      string `yaml:"ownerCap"`
+	McmsObjectID  string `yaml:"mcmsObjectID"`
 	// Timelock related
-	Role suisdk.TimelockRole `json:"role"`
+	Role suisdk.TimelockRole `yaml:"role"`
 	// Config related
-	Config    types.Config `json:"config"`
-	ClearRoot bool         `json:"clearRoot"`
+	Config    types.Config `yaml:"config"`
+	ClearRoot bool         `yaml:"clearRoot"`
 }
 
 var SetConfigMCMSOp = cld_ops.NewOperation(

--- a/deployment/ops/mcms/seq_configure.go
+++ b/deployment/ops/mcms/seq_configure.go
@@ -14,17 +14,17 @@ import (
 
 // ConfigureMCMSSeqInput defines the input for configuring MCMS
 type ConfigureMCMSSeqInput struct {
-	ChainSelector               uint64 `json:"chainSelector" yaml:"chainSelector"`
-	PackageId                   string `json:"packageId" yaml:"packageId"`
-	McmsAccountOwnerCapObjectId string `json:"mcmsAccountOwnerCapObjectId" yaml:"mcmsAccountOwnerCapObjectId"`
-	McmsAccountStateObjectId    string `json:"mcmsAccountStateObjectId" yaml:"mcmsAccountStateObjectId"`
-	McmsMultisigStateObjectId   string `json:"mcmsMultisigStateObjectId" yaml:"mcmsMultisigStateObjectId"`
+	ChainSelector               uint64 `yaml:"chainSelector"`
+	PackageId                   string `yaml:"packageId"`
+	McmsAccountOwnerCapObjectId string `yaml:"mcmsAccountOwnerCapObjectId"`
+	McmsAccountStateObjectId    string `yaml:"mcmsAccountStateObjectId"`
+	McmsMultisigStateObjectId   string `yaml:"mcmsMultisigStateObjectId"`
 
 	// Optional configs for each timelock role
 	// If nil, the role will not be configured
-	Bypasser  *types.Config `json:"bypasser,omitempty" yaml:"bypasser,omitempty"`
-	Proposer  *types.Config `json:"proposer,omitempty" yaml:"proposer,omitempty"`
-	Canceller *types.Config `json:"canceller,omitempty" yaml:"canceller,omitempty"`
+	Bypasser  *types.Config `yaml:"bypasser,omitempty"`
+	Proposer  *types.Config `yaml:"proposer,omitempty"`
+	Canceller *types.Config `yaml:"canceller,omitempty"`
 }
 
 type ConfigureMCMSSeqOutput struct {


### PR DESCRIPTION
# Summary
JSON tag was making the inputs get unmarshalled as `map[string]interface{}` instead of the untyped as golang any. So asserting back was failing.
# Testing
tested locally running the pipeline 👍 