### PR TITLE
Add fastcurse MCMS to address book

### DIFF
--- a/deployment/adapters/mcmsreader.go
+++ b/deployment/adapters/mcmsreader.go
@@ -15,19 +15,31 @@ import (
 
 type MCMSReader struct{}
 
+// mcmsFieldsFromInput loads the on-chain state and selects the correct
+// MCMSStateFields (normal or fastcurse) based on the Qualifier in the input.
+// A Qualifier value of "fastcurse" selects the fastcurse MCMS instance.
+func mcmsFieldsFromInput(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (suideploy.MCMSStateFields, error) {
+	stateMap, err := suideploy.LoadOnchainStatesui(e)
+	if err != nil {
+		return suideploy.MCMSStateFields{}, fmt.Errorf("failed to load sui onchain state: %w", err)
+	}
+	state, ok := stateMap[chainSelector]
+	if !ok {
+		return suideploy.MCMSStateFields{}, fmt.Errorf("sui chain %d not found in state", chainSelector)
+	}
+	// TODO: Check what are Qualifier value options
+	return state.MCMSState(input.Qualifier == suideploy.MCMSFastCurseLabel), nil
+}
+
 func (r *MCMSReader) GetChainMetadata(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (mcmstypes.ChainMetadata, error) {
 	chain, ok := e.BlockChains.SuiChains()[chainSelector]
 	if !ok {
 		return mcmstypes.ChainMetadata{}, fmt.Errorf("sui chain with selector %d not found", chainSelector)
 	}
 
-	stateMap, err := suideploy.LoadOnchainStatesui(e)
+	mcmsFields, err := mcmsFieldsFromInput(e, chainSelector, input)
 	if err != nil {
-		return mcmstypes.ChainMetadata{}, fmt.Errorf("failed to load sui onchain state: %w", err)
-	}
-	state, ok := stateMap[chainSelector]
-	if !ok {
-		return mcmstypes.ChainMetadata{}, fmt.Errorf("sui chain %d not found in state", chainSelector)
+		return mcmstypes.ChainMetadata{}, err
 	}
 
 	role, err := timelockRoleFromAction(input.TimelockAction)
@@ -35,54 +47,46 @@ func (r *MCMSReader) GetChainMetadata(e cldf.Environment, chainSelector uint64, 
 		return mcmstypes.ChainMetadata{}, fmt.Errorf("failed to get role from action: %w", err)
 	}
 
-	inspector, err := suisdk.NewInspector(chain.Client, chain.Signer, state.MCMSPackageID, role)
+	inspector, err := suisdk.NewInspector(chain.Client, chain.Signer, mcmsFields.PackageID, role)
 	if err != nil {
 		return mcmstypes.ChainMetadata{}, fmt.Errorf("failed to create sui mcms inspector for chain %d: %w", chainSelector, err)
 	}
 
-	opCount, err := inspector.GetOpCount(e.GetContext(), state.MCMSStateObjectID)
+	opCount, err := inspector.GetOpCount(e.GetContext(), mcmsFields.StateObjectID)
 	if err != nil {
-		return mcmstypes.ChainMetadata{}, fmt.Errorf("failed to get opCount for MCMS at %s on chain %d: %w", state.MCMSStateObjectID, chainSelector, err)
+		return mcmstypes.ChainMetadata{}, fmt.Errorf("failed to get opCount for MCMS at %s on chain %d: %w", mcmsFields.StateObjectID, chainSelector, err)
 	}
 
 	return suisdk.NewChainMetadata(
 		opCount,
 		role,
-		state.MCMSPackageID,
-		state.MCMSStateObjectID,
-		state.MCMSAccountStateObjectID,
-		state.MCMSRegistryObjectID,
-		state.MCMSTimelockObjectID,
-		state.MCMSDeployerStateObjectID,
+		mcmsFields.PackageID,
+		mcmsFields.StateObjectID,
+		mcmsFields.AccountStateObjectID,
+		mcmsFields.RegistryObjectID,
+		mcmsFields.TimelockObjectID,
+		mcmsFields.DeployerStateObjectID,
 	)
 }
 
 func (r *MCMSReader) GetTimelockRef(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (datastore.AddressRef, error) {
-	stateMap, err := suideploy.LoadOnchainStatesui(e)
+	mcmsFields, err := mcmsFieldsFromInput(e, chainSelector, input)
 	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("failed to load sui onchain state: %w", err)
-	}
-	state, ok := stateMap[chainSelector]
-	if !ok {
-		return datastore.AddressRef{}, fmt.Errorf("sui chain %d not found in state", chainSelector)
+		return datastore.AddressRef{}, err
 	}
 	return datastore.AddressRef{
-		Address:       state.MCMSTimelockObjectID,
+		Address:       mcmsFields.TimelockObjectID,
 		ChainSelector: chainSelector,
 	}, nil
 }
 
 func (r *MCMSReader) GetMCMSRef(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (datastore.AddressRef, error) {
-	stateMap, err := suideploy.LoadOnchainStatesui(e)
+	mcmsFields, err := mcmsFieldsFromInput(e, chainSelector, input)
 	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("failed to load sui onchain state: %w", err)
-	}
-	state, ok := stateMap[chainSelector]
-	if !ok {
-		return datastore.AddressRef{}, fmt.Errorf("sui chain %d not found in state", chainSelector)
+		return datastore.AddressRef{}, err
 	}
 	return datastore.AddressRef{
-		Address:       state.MCMSStateObjectID,
+		Address:       mcmsFields.StateObjectID,
 		ChainSelector: chainSelector,
 	}, nil
 }

--- a/deployment/adapters/mcmsreader.go
+++ b/deployment/adapters/mcmsreader.go
@@ -13,6 +13,8 @@ import (
 	suideploy "github.com/smartcontractkit/chainlink-sui/deployment"
 )
 
+const fastCurseQualifier = "RMNTimelockQualifier"
+
 type MCMSReader struct{}
 
 // mcmsFieldsFromInput loads the on-chain state and selects the correct
@@ -27,8 +29,7 @@ func mcmsFieldsFromInput(e cldf.Environment, chainSelector uint64, input mcms_ut
 	if !ok {
 		return suideploy.MCMSStateFields{}, fmt.Errorf("sui chain %d not found in state", chainSelector)
 	}
-	// TODO: Check what are Qualifier value options
-	return state.MCMSState(input.Qualifier == suideploy.MCMSFastCurseLabel), nil
+	return state.MCMSState(input.Qualifier == fastCurseQualifier), nil
 }
 
 func (r *MCMSReader) GetChainMetadata(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (mcmstypes.ChainMetadata, error) {

--- a/deployment/changesets/cs_curse_uncurse.go
+++ b/deployment/changesets/cs_curse_uncurse.go
@@ -31,6 +31,9 @@ type CurseUncurseChainsConfig struct {
 	IsGlobalCurse      bool                  `yaml:"isGlobalCurse"`
 	DestChainSelectors []uint64              `yaml:"destChainSelectors"`
 	TimelockConfig     *utils.TimelockConfig `yaml:"timelockConfig,omitempty"`
+	// IsFastCurse selects the fastcurse MCMS instance when generating a timelock
+	// proposal. Has no effect when TimelockConfig is nil.
+	IsFastCurse bool `yaml:"isFastCurse,omitempty"`
 }
 
 var _ cldf.ChangeSetV2[CurseUncurseChainsConfig] = CurseUncurseChains{}
@@ -125,16 +128,17 @@ func (c CurseUncurseChains) Apply(e cldf.Environment, cfg CurseUncurseChainsConf
 		defs := []cld_ops.Definition{genericReport.Def}
 		inputs := []any{genericReport.Input}
 
+		mcmsState := state[cfg.SuiChainSelector].MCMSState(cfg.IsFastCurse)
 		mcmsConfig := mcmsops.ProposalGenerateInput{
 			ChainSelector:      cfg.SuiChainSelector,
 			Defs:               defs,
 			Inputs:             inputs,
-			MmcsPackageID:      state[cfg.SuiChainSelector].MCMSPackageID,
-			McmsStateObjID:     state[cfg.SuiChainSelector].MCMSStateObjectID,
-			TimelockObjID:      state[cfg.SuiChainSelector].MCMSTimelockObjectID,
-			AccountObjID:       state[cfg.SuiChainSelector].MCMSAccountStateObjectID,
-			RegistryObjID:      state[cfg.SuiChainSelector].MCMSRegistryObjectID,
-			DeployerStateObjID: state[cfg.SuiChainSelector].MCMSDeployerStateObjectID,
+			MmcsPackageID:      mcmsState.PackageID,
+			McmsStateObjID:     mcmsState.StateObjectID,
+			TimelockObjID:      mcmsState.TimelockObjectID,
+			AccountObjID:       mcmsState.AccountStateObjectID,
+			RegistryObjID:      mcmsState.RegistryObjectID,
+			DeployerStateObjID: mcmsState.DeployerStateObjectID,
 			TimelockConfig:     *cfg.TimelockConfig,
 		}
 

--- a/deployment/changesets/cs_deploy_sui_chain.go
+++ b/deployment/changesets/cs_deploy_sui_chain.go
@@ -76,7 +76,7 @@ func (d DeploySuiChain) Apply(e cldf.Environment, config DeploySuiChainConfig) (
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy MCMS for Sui chain %d: %w", config.SuiChainSelector, err)
 		}
 
-		err = storeMCMSInAddressBook(ab, config.SuiChainSelector, mcmsReport.Output)
+		err = storeMCMSInAddressBook(ab, config.SuiChainSelector, mcmsReport.Output, false)
 		if err != nil {
 			return cldf.ChangesetOutput{}, fmt.Errorf("failed to store MCMS in address book for Sui chain %d: %w", config.SuiChainSelector, err)
 		}

--- a/deployment/changesets/cs_mcms_accept_ownership_self.go
+++ b/deployment/changesets/cs_mcms_accept_ownership_self.go
@@ -9,21 +9,46 @@ import (
 	cld_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
 	sui_ops "github.com/smartcontractkit/chainlink-sui/deployment/ops"
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 )
 
-var _ cldf.ChangeSetV2[mcmsops.AcceptMCMSOwnershipSeqInput] = AcceptMCMSOwnership{}
+var _ cldf.ChangeSetV2[AcceptMCMSOwnershipConfig] = AcceptMCMSOwnership{}
+
+// AcceptMCMSOwnershipConfig identifies an MCMS deployment whose ownership
+// transfer proposal should be (re-)generated. When IsFastCurse is true the
+// fastcurse MCMS instance is targeted; otherwise the normal instance is used.
+type AcceptMCMSOwnershipConfig struct {
+	ChainSelector uint64
+	IsFastCurse   bool
+}
 
 type AcceptMCMSOwnership struct{}
 
 // VerifyPreconditions implements deployment.ChangeSetV2.
-func (a AcceptMCMSOwnership) VerifyPreconditions(e cldf.Environment, config mcmsops.AcceptMCMSOwnershipSeqInput) error {
+func (a AcceptMCMSOwnership) VerifyPreconditions(e cldf.Environment, config AcceptMCMSOwnershipConfig) error {
 	return nil
 }
 
 // Apply implements deployment.ChangeSetV2.
-func (a AcceptMCMSOwnership) Apply(e cldf.Environment, config mcmsops.AcceptMCMSOwnershipSeqInput) (cldf.ChangesetOutput, error) {
+func (a AcceptMCMSOwnership) Apply(e cldf.Environment, config AcceptMCMSOwnershipConfig) (cldf.ChangesetOutput, error) {
+	suiState, err := deployment.LoadOnchainStatesui(e)
+	if err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load sui onchain state: %w", err)
+	}
+
+	mcmsFields := suiState[config.ChainSelector].MCMSState(config.IsFastCurse)
+
+	seqInput := mcmsops.AcceptMCMSOwnershipSeqInput{
+		ChainSelector:             config.ChainSelector,
+		PackageId:                 mcmsFields.PackageID,
+		McmsMultisigStateObjectId: mcmsFields.StateObjectID,
+		TimelockObjectId:          mcmsFields.TimelockObjectID,
+		McmsAccountStateObjectId:  mcmsFields.AccountStateObjectID,
+		McmsRegistryObjectId:      mcmsFields.RegistryObjectID,
+		McmsDeployerStateObjectId: mcmsFields.DeployerStateObjectID,
+	}
 	suiChains := e.BlockChains.SuiChains()
 	suiChain := suiChains[config.ChainSelector]
 	deps := sui_ops.OpTxDeps{
@@ -40,7 +65,7 @@ func (a AcceptMCMSOwnership) Apply(e cldf.Environment, config mcmsops.AcceptMCMS
 	}
 
 	// Run AcceptMCMSOwnership Sequence
-	acceptReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.AcceptMCMSOwnershipSequence, deps, config)
+	acceptReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.AcceptMCMSOwnershipSequence, deps, seqInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to generate accept ownership proposal for Sui chain %d: %w", config.ChainSelector, err)
 	}

--- a/deployment/changesets/cs_mcms_configure.go
+++ b/deployment/changesets/cs_mcms_configure.go
@@ -18,6 +18,7 @@ import (
 type ConfigureMCMSConfig struct {
 	mcmsops.ConfigureMCMSSeqInput
 	TimelockConfig *utils.TimelockConfig // If nil, configuration will be executed directly
+	IsFastCurse    bool                  // If true, the fastcurse MCMS instance is configured
 }
 
 var _ cldf.ChangeSetV2[ConfigureMCMSConfig] = ConfigureMCMS{}
@@ -42,6 +43,8 @@ func (c ConfigureMCMS) Apply(e cldf.Environment, config ConfigureMCMSConfig) (cl
 	suiChains := e.BlockChains.SuiChains()
 
 	suiChain := suiChains[config.ChainSelector]
+
+	mcmsState := state[config.ChainSelector].MCMSState(config.IsFastCurse)
 
 	deps := sui_ops.OpTxDeps{
 		Client: suiChain.Client,
@@ -83,12 +86,12 @@ func (c ConfigureMCMS) Apply(e cldf.Environment, config ConfigureMCMSConfig) (cl
 			ChainSelector:      config.ChainSelector,
 			Defs:               defs,
 			Inputs:             inputs,
-			MmcsPackageID:      state[config.ChainSelector].MCMSPackageID,
-			McmsStateObjID:     state[config.ChainSelector].MCMSStateObjectID,
-			TimelockObjID:      state[config.ChainSelector].MCMSTimelockObjectID,
-			AccountObjID:       state[config.ChainSelector].MCMSAccountStateObjectID,
-			RegistryObjID:      state[config.ChainSelector].MCMSRegistryObjectID,
-			DeployerStateObjID: state[config.ChainSelector].MCMSDeployerStateObjectID,
+			MmcsPackageID:      mcmsState.PackageID,
+			McmsStateObjID:     mcmsState.StateObjectID,
+			TimelockObjID:      mcmsState.TimelockObjectID,
+			AccountObjID:       mcmsState.AccountStateObjectID,
+			RegistryObjID:      mcmsState.RegistryObjectID,
+			DeployerStateObjID: mcmsState.DeployerStateObjectID,
 			TimelockConfig:     *config.TimelockConfig,
 		}
 

--- a/deployment/changesets/cs_mcms_deploy.go
+++ b/deployment/changesets/cs_mcms_deploy.go
@@ -13,12 +13,21 @@ import (
 	mcmsops "github.com/smartcontractkit/chainlink-sui/deployment/ops/mcms"
 )
 
-var _ cldf.ChangeSetV2[mcmsops.DeployMCMSSeqInput] = DeployMCMS{}
+var _ cldf.ChangeSetV2[DeployMCMSConfig] = DeployMCMS{}
+
+// DeployMCMSConfig wraps DeployMCMSSeqInput and adds the IsFastCurse flag.
+// When IsFastCurse is true all address-book entries are stored with the
+// "fastcurse" label so that LoadOnchainStatesui can distinguish the two
+// MCMS instances deployed on the same chain.
+type DeployMCMSConfig struct {
+	mcmsops.DeployMCMSSeqInput
+	IsFastCurse bool
+}
 
 type DeployMCMS struct{}
 
 // Apply implements deployment.ChangeSetV2.
-func (d DeployMCMS) Apply(e cldf.Environment, config mcmsops.DeployMCMSSeqInput) (cldf.ChangesetOutput, error) {
+func (d DeployMCMS) Apply(e cldf.Environment, config DeployMCMSConfig) (cldf.ChangesetOutput, error) {
 	ab := cldf.NewMemoryAddressBook()
 	seqReports := make([]cld_ops.Report[any, any], 0)
 
@@ -40,12 +49,12 @@ func (d DeployMCMS) Apply(e cldf.Environment, config mcmsops.DeployMCMSSeqInput)
 	}
 
 	// Run DeployMCMS Sequence
-	mcmsReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, config)
+	mcmsReport, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.DeployMCMSSequence, deps, config.DeployMCMSSeqInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to deploy MCMS for Sui chain %d: %w", config.ChainSelector, err)
 	}
 
-	err = storeMCMSInAddressBook(ab, config.ChainSelector, mcmsReport.Output)
+	err = storeMCMSInAddressBook(ab, config.ChainSelector, mcmsReport.Output, config.IsFastCurse)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to store MCMS in address book for Sui chain %d: %w", config.ChainSelector, err)
 	}
@@ -58,55 +67,63 @@ func (d DeployMCMS) Apply(e cldf.Environment, config mcmsops.DeployMCMSSeqInput)
 }
 
 // VerifyPreconditions implements deployment.ChangeSetV2.
-func (d DeployMCMS) VerifyPreconditions(e cldf.Environment, config mcmsops.DeployMCMSSeqInput) error {
+func (d DeployMCMS) VerifyPreconditions(e cldf.Environment, config DeployMCMSConfig) error {
 	return nil
 }
 
-func storeMCMSInAddressBook(ab *cldf.AddressBookMap, chainSelector uint64, mcmsReport mcmsops.DeployMCMSSeqOutput) error {
+func storeMCMSInAddressBook(ab *cldf.AddressBookMap, chainSelector uint64, mcmsReport mcmsops.DeployMCMSSeqOutput, isFastCurse bool) error {
+	// addLabel optionally stamps the "fastcurse" label on a TypeAndVersion.
+	addLabel := func(tv cldf.TypeAndVersion) cldf.TypeAndVersion {
+		if isFastCurse {
+			tv.Labels.Add(deployment.MCMSFastCurseLabel)
+		}
+		return tv
+	}
+
 	// save MCMS address to the addressbook
-	typeAndVersionMCMS := cldf.NewTypeAndVersion(deployment.SuiMcmsPackageIDType, deployment.Version1_0_0)
+	typeAndVersionMCMS := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsPackageIDType, deployment.Version1_0_0))
 	err := ab.Save(chainSelector, mcmsReport.PackageId, typeAndVersionMCMS)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS address %s for Sui chain %d: %w", mcmsReport.PackageId, chainSelector, err)
 	}
 
 	// save MCMS MultisigState object ID to the addressbook
-	typeAndVersionMCMSObject := cldf.NewTypeAndVersion(deployment.SuiMcmsObjectIDType, deployment.Version1_0_0)
+	typeAndVersionMCMSObject := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsObjectIDType, deployment.Version1_0_0))
 	err = ab.Save(chainSelector, mcmsReport.Objects.McmsMultisigStateObjectId, typeAndVersionMCMSObject)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS MultisigState object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsMultisigStateObjectId, chainSelector, err)
 	}
 
 	// save MCMS Registry object ID to the addressbook
-	typeAndVersionMCMSRegistry := cldf.NewTypeAndVersion(deployment.SuiMcmsRegistryObjectIDType, deployment.Version1_0_0)
+	typeAndVersionMCMSRegistry := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsRegistryObjectIDType, deployment.Version1_0_0))
 	err = ab.Save(chainSelector, mcmsReport.Objects.McmsRegistryObjectId, typeAndVersionMCMSRegistry)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS Registry object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsRegistryObjectId, chainSelector, err)
 	}
 
 	// save MCMS AccountState object ID to the addressbook
-	typeAndVersionMCMSAccountState := cldf.NewTypeAndVersion(deployment.SuiMcmsAccountStateObjectIDType, deployment.Version1_0_0)
+	typeAndVersionMCMSAccountState := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsAccountStateObjectIDType, deployment.Version1_0_0))
 	err = ab.Save(chainSelector, mcmsReport.Objects.McmsAccountStateObjectId, typeAndVersionMCMSAccountState)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS AccountState object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsAccountStateObjectId, chainSelector, err)
 	}
 
 	// save MCMS AccountOwnerCap object ID to the addressbook
-	typeAndVersionMCMSAccountOwnerCap := cldf.NewTypeAndVersion(deployment.SuiMcmsAccountOwnerCapObjectIDType, deployment.Version1_0_0)
+	typeAndVersionMCMSAccountOwnerCap := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsAccountOwnerCapObjectIDType, deployment.Version1_0_0))
 	err = ab.Save(chainSelector, mcmsReport.Objects.McmsAccountOwnerCapObjectId, typeAndVersionMCMSAccountOwnerCap)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS AccountOwnerCap object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsAccountOwnerCapObjectId, chainSelector, err)
 	}
 
 	// save MCMS Timelock object ID to the addressbook
-	typeAndVersionMCMSTimelock := cldf.NewTypeAndVersion(deployment.SuiMcmsTimelockObjectIDType, deployment.Version1_0_0)
+	typeAndVersionMCMSTimelock := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsTimelockObjectIDType, deployment.Version1_0_0))
 	err = ab.Save(chainSelector, mcmsReport.Objects.TimelockObjectId, typeAndVersionMCMSTimelock)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS Timelock object ID %s for Sui chain %d: %w", mcmsReport.Objects.TimelockObjectId, chainSelector, err)
 	}
 
 	// save MCMS Deployer State object ID to the addressbook
-	typeAndVersionMCMSDeployer := cldf.NewTypeAndVersion(deployment.SuiMcmsDeployerObjectIDType, deployment.Version1_0_0)
+	typeAndVersionMCMSDeployer := addLabel(cldf.NewTypeAndVersion(deployment.SuiMcmsDeployerObjectIDType, deployment.Version1_0_0))
 	err = ab.Save(chainSelector, mcmsReport.Objects.McmsDeployerStateObjectId, typeAndVersionMCMSDeployer)
 	if err != nil {
 		return fmt.Errorf("failed to save MCMS Deployer object ID %s for Sui chain %d: %w", mcmsReport.Objects.McmsDeployerStateObjectId, chainSelector, err)

--- a/deployment/changesets/cs_mcms_execute_ownership_transfer.go
+++ b/deployment/changesets/cs_mcms_execute_ownership_transfer.go
@@ -29,6 +29,10 @@ type MCMSExecuteTransferOwnership struct{}
 type MCMSExecuteTransferOwnershipInput struct {
 	ChainSelector uint64 `json:"chainSelector" yaml:"chainSelector"`
 
+	// IsFastCurse selects the fastcurse MCMS instance as the ownership target.
+	// When false (default) the normal MCMS instance is used.
+	IsFastCurse bool `json:"isFastCurse,omitempty" yaml:"isFastCurse,omitempty"`
+
 	// Type of contracts to execute the transfer on
 	MCMS                            bool   `json:"mcms,omitempty" yaml:"mcms,omitempty"`
 	StateObject                     bool   `json:"state_object,omitempty" yaml:"state_object,omitempty"`
@@ -50,6 +54,7 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 	}
 
 	state := suiState[config.ChainSelector]
+	mcmsFields := state.MCMSState(config.IsFastCurse)
 
 	suiChains := e.BlockChains.SuiChains()
 
@@ -72,10 +77,10 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 	// Populate the input fields
 	if config.MCMS {
 		input.MCMS = &mcmsops.MCMSExecuteTransferOwnershipInput{
-			McmsPackageID:    state.MCMSPackageID,
-			OwnerCap:         state.MCMSAccountOwnerCapObjectID,
-			AccountObjectID:  state.MCMSAccountStateObjectID,
-			RegistryObjectID: state.MCMSRegistryObjectID,
+			McmsPackageID:    mcmsFields.PackageID,
+			OwnerCap:         mcmsFields.AccountOwnerCapObjectID,
+			AccountObjectID:  mcmsFields.AccountStateObjectID,
+			RegistryObjectID: mcmsFields.RegistryObjectID,
 		}
 	}
 
@@ -84,8 +89,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			CCIPPackageId:         state.CCIPAddress,
 			OwnerCapObjectId:      state.CCIPOwnerCapObjectId,
 			CCIPObjectRefObjectId: state.CCIPObjectRef,
-			RegistryObjectId:      state.MCMSRegistryObjectID,
-			To:                    state.MCMSPackageID,
+			RegistryObjectId:      mcmsFields.RegistryObjectID,
+			To:                    mcmsFields.PackageID,
 		}
 	}
 
@@ -95,8 +100,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			OnRampRefObjectId:   state.CCIPObjectRef,
 			OnRampStateObjectId: state.OnRampStateObjectId,
 			OwnerCapObjectId:    state.OnRampOwnerCapObjectId,
-			RegistryObjectId:    state.MCMSRegistryObjectID,
-			To:                  state.MCMSPackageID,
+			RegistryObjectId:    mcmsFields.RegistryObjectID,
+			To:                  mcmsFields.PackageID,
 		}
 	}
 
@@ -106,8 +111,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			OffRampRefObjectId:   state.CCIPObjectRef,
 			OffRampStateObjectId: state.OffRampStateObjectId,
 			OwnerCapObjectId:     state.OffRampOwnerCapId,
-			RegistryObjectId:     state.MCMSRegistryObjectID,
-			To:                   state.MCMSPackageID,
+			RegistryObjectId:     mcmsFields.RegistryObjectID,
+			To:                   mcmsFields.PackageID,
 		}
 	}
 
@@ -116,8 +121,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			RouterPackageId:     state.CCIPRouterAddress,
 			OwnerCapObjectId:    state.CCIPRouterOwnerCapObjectId,
 			RouterStateObjectId: state.CCIPRouterStateObjectID,
-			RegistryObjectId:    state.MCMSRegistryObjectID,
-			To:                  state.MCMSPackageID,
+			RegistryObjectId:    mcmsFields.RegistryObjectID,
+			To:                  mcmsFields.PackageID,
 		}
 	}
 
@@ -126,8 +131,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 		input.ManagedToken = &managedtokenops.ExecuteOwnershipTransferToMcmsManagedTokenInput{
 			ManagedTokenPackageId: state.CCIPAddress,
 			OwnerCapObjectId:      state.CCIPOwnerCapObjectId,
-			RegistryObjectId:      state.MCMSRegistryObjectID,
-			To:                    state.MCMSPackageID,
+			RegistryObjectId:      mcmsFields.RegistryObjectID,
+			To:                    mcmsFields.PackageID,
 		}
 	}
 
@@ -141,8 +146,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			TypeArgs:                   []string{config.TypeArg},
 			StateObjectId:              poolState.StateObjectId,
 			OwnerCapObjectId:           poolState.OwnerCapObjectId,
-			RegistryObjectId:           state.MCMSRegistryObjectID,
-			To:                         state.MCMSPackageID,
+			RegistryObjectId:           mcmsFields.RegistryObjectID,
+			To:                         mcmsFields.PackageID,
 		}
 	}
 
@@ -156,8 +161,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			TypeArgs:                      []string{config.TypeArg},
 			StateObjectId:                 poolState.StateObjectId,
 			OwnerCapObjectId:              poolState.OwnerCapObjectId,
-			RegistryObjectId:              state.MCMSRegistryObjectID,
-			To:                            state.MCMSPackageID,
+			RegistryObjectId:              mcmsFields.RegistryObjectID,
+			To:                            mcmsFields.PackageID,
 		}
 	}
 
@@ -171,8 +176,8 @@ func (d MCMSExecuteTransferOwnership) Apply(e cldf.Environment, config MCMSExecu
 			TypeArgs:                  []string{config.TypeArg},
 			StateObjectId:             poolState.StateObjectId,
 			OwnerCapObjectId:          poolState.OwnerCapObjectId,
-			RegistryObjectId:          state.MCMSRegistryObjectID,
-			To:                        state.MCMSPackageID,
+			RegistryObjectId:          mcmsFields.RegistryObjectID,
+			To:                        mcmsFields.PackageID,
 		}
 	}
 

--- a/deployment/changesets/cs_mcms_proposal_generate.go
+++ b/deployment/changesets/cs_mcms_proposal_generate.go
@@ -12,25 +12,33 @@ import (
 	"github.com/smartcontractkit/mcms"
 )
 
-var _ cldf.ChangeSetV2[mcmsops.ProposalGenerateInput] = MCMSProposalGenerate{}
+var _ cldf.ChangeSetV2[MCMSProposalGenerateConfig] = MCMSProposalGenerate{}
+
+// MCMSProposalGenerateConfig wraps ProposalGenerateInput and adds IsFastCurse.
+// When MCMS state fields in ProposalGenerateInput are left empty, they are
+// auto-populated from the on-chain address book using the IsFastCurse flag.
+type MCMSProposalGenerateConfig struct {
+	mcmsops.ProposalGenerateInput
+	IsFastCurse bool
+}
 
 type MCMSProposalGenerate struct{}
 
-func (d MCMSProposalGenerate) Apply(e cldf.Environment, config mcmsops.ProposalGenerateInput) (cldf.ChangesetOutput, error) {
+func (d MCMSProposalGenerate) Apply(e cldf.Environment, config MCMSProposalGenerateConfig) (cldf.ChangesetOutput, error) {
 	suiState, err := deployment.LoadOnchainStatesui(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	state := suiState[config.ChainSelector]
+	mcmsState := suiState[config.ChainSelector].MCMSState(config.IsFastCurse)
 
 	// Get necessary MCMS state from onchain AB
 	if config.MmcsPackageID == "" || config.McmsStateObjID == "" || config.TimelockObjID == "" || config.AccountObjID == "" || config.RegistryObjID == "" {
-		config.MmcsPackageID = state.MCMSPackageID
-		config.McmsStateObjID = state.MCMSStateObjectID
-		config.TimelockObjID = state.MCMSTimelockObjectID
-		config.AccountObjID = state.MCMSAccountStateObjectID
-		config.RegistryObjID = state.MCMSRegistryObjectID
+		config.MmcsPackageID = mcmsState.PackageID
+		config.McmsStateObjID = mcmsState.StateObjectID
+		config.TimelockObjID = mcmsState.TimelockObjectID
+		config.AccountObjID = mcmsState.AccountStateObjectID
+		config.RegistryObjID = mcmsState.RegistryObjectID
 	}
 
 	suiChains := e.BlockChains.SuiChains()
@@ -44,7 +52,7 @@ func (d MCMSProposalGenerate) Apply(e cldf.Environment, config mcmsops.ProposalG
 		},
 		SuiRPC: suiChain.URL,
 	}
-	result, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, config)
+	result, err := cld_ops.ExecuteSequence(e.OperationsBundle, mcmsops.MCMSDynamicProposalGenerateSeq, deps, config.ProposalGenerateInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute sequence: %w", err)
 	}
@@ -55,6 +63,6 @@ func (d MCMSProposalGenerate) Apply(e cldf.Environment, config mcmsops.ProposalG
 }
 
 // VerifyPreconditions implements deployment.ChangeSetV2.
-func (d MCMSProposalGenerate) VerifyPreconditions(e cldf.Environment, config mcmsops.ProposalGenerateInput) error {
+func (d MCMSProposalGenerate) VerifyPreconditions(e cldf.Environment, config MCMSProposalGenerateConfig) error {
 	return nil
 }

--- a/deployment/changesets/cs_mcms_proposal_upgrade_package.go
+++ b/deployment/changesets/cs_mcms_proposal_upgrade_package.go
@@ -12,25 +12,33 @@ import (
 	"github.com/smartcontractkit/mcms"
 )
 
-var _ cldf.ChangeSetV2[mcmsops.UpgradeCCIPInput] = MCMSProposalUpgradePackage{}
+var _ cldf.ChangeSetV2[UpgradePackageConfig] = MCMSProposalUpgradePackage{}
+
+// UpgradePackageConfig wraps UpgradeCCIPInput and adds IsFastCurse.
+// When MCMS state fields in UpgradeCCIPInput are left empty, they are
+// auto-populated from the on-chain address book using the IsFastCurse flag.
+type UpgradePackageConfig struct {
+	mcmsops.UpgradeCCIPInput
+	IsFastCurse bool
+}
 
 type MCMSProposalUpgradePackage struct{}
 
-func (d MCMSProposalUpgradePackage) Apply(e cldf.Environment, config mcmsops.UpgradeCCIPInput) (cldf.ChangesetOutput, error) {
+func (d MCMSProposalUpgradePackage) Apply(e cldf.Environment, config UpgradePackageConfig) (cldf.ChangesetOutput, error) {
 	suiState, err := deployment.LoadOnchainStatesui(e)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to load onchain state: %w", err)
 	}
 
-	state := suiState[config.ChainSelector]
+	mcmsState := suiState[config.ChainSelector].MCMSState(config.IsFastCurse)
 
 	// Get necessary MCMS state from onchain AB
 	if config.MmcsPackageID == "" || config.McmsStateObjID == "" || config.TimelockObjID == "" || config.AccountObjID == "" || config.RegistryObjID == "" {
-		config.MmcsPackageID = state.MCMSPackageID
-		config.McmsStateObjID = state.MCMSStateObjectID
-		config.TimelockObjID = state.MCMSTimelockObjectID
-		config.AccountObjID = state.MCMSAccountStateObjectID
-		config.RegistryObjID = state.MCMSRegistryObjectID
+		config.MmcsPackageID = mcmsState.PackageID
+		config.McmsStateObjID = mcmsState.StateObjectID
+		config.TimelockObjID = mcmsState.TimelockObjectID
+		config.AccountObjID = mcmsState.AccountStateObjectID
+		config.RegistryObjID = mcmsState.RegistryObjectID
 	}
 
 	suiChains := e.BlockChains.SuiChains()
@@ -44,7 +52,7 @@ func (d MCMSProposalUpgradePackage) Apply(e cldf.Environment, config mcmsops.Upg
 		},
 		SuiRPC: suiChain.URL,
 	}
-	result, err := cld_ops.ExecuteOperation(e.OperationsBundle, mcmsops.UpgradeCCIPOp, deps, config)
+	result, err := cld_ops.ExecuteOperation(e.OperationsBundle, mcmsops.UpgradeCCIPOp, deps, config.UpgradeCCIPInput)
 	if err != nil {
 		return cldf.ChangesetOutput{}, fmt.Errorf("failed to execute sequence: %w", err)
 	}
@@ -55,6 +63,6 @@ func (d MCMSProposalUpgradePackage) Apply(e cldf.Environment, config mcmsops.Upg
 }
 
 // VerifyPreconditions implements deployment.ChangeSetV2.
-func (d MCMSProposalUpgradePackage) VerifyPreconditions(e cldf.Environment, config mcmsops.UpgradeCCIPInput) error {
+func (d MCMSProposalUpgradePackage) VerifyPreconditions(e cldf.Environment, config UpgradePackageConfig) error {
 	return nil
 }

--- a/deployment/changesets/cs_mcms_user_proposal.go
+++ b/deployment/changesets/cs_mcms_user_proposal.go
@@ -11,6 +11,7 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	mcmsuser "github.com/smartcontractkit/chainlink-sui/bindings/packages/mcms/mcms_user"
+	"github.com/smartcontractkit/chainlink-sui/deployment"
 )
 
 type InvokeMCMSFunctionOneConfig struct {
@@ -21,6 +22,10 @@ type InvokeMCMSFunctionOneConfig struct {
 	AccountObjID       string `json:"accountObjID"`
 	RegistryObjID      string `json:"registryObjID"`
 	DeployerStateObjID string `json:"deployerStateObjID"`
+
+	// IsFastCurse selects the fastcurse MCMS instance for the proposal.
+	// MCMS fields above are auto-populated from state when empty.
+	IsFastCurse bool `json:"isFastCurse,omitempty"`
 
 	// Proposal related
 	Role  suisdk.TimelockRole `json:"role"`
@@ -40,6 +45,20 @@ var _ cldf.ChangeSetV2[InvokeMCMSFunctionOneConfig] = InvokeMCMSFunctionOne{}
 type InvokeMCMSFunctionOne struct{}
 
 func (d InvokeMCMSFunctionOne) Apply(e cldf.Environment, config InvokeMCMSFunctionOneConfig) (cldf.ChangesetOutput, error) {
+	// Auto-populate MCMS fields from on-chain state when not provided.
+	if config.MmcsPackageID == "" || config.McmsStateObjID == "" || config.TimelockObjID == "" || config.AccountObjID == "" || config.RegistryObjID == "" {
+		suiState, err := deployment.LoadOnchainStatesui(e)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to load sui onchain state: %w", err)
+		}
+		mcmsFields := suiState[config.ChainSelector].MCMSState(config.IsFastCurse)
+		config.MmcsPackageID = mcmsFields.PackageID
+		config.McmsStateObjID = mcmsFields.StateObjectID
+		config.TimelockObjID = mcmsFields.TimelockObjectID
+		config.AccountObjID = mcmsFields.AccountStateObjectID
+		config.RegistryObjID = mcmsFields.RegistryObjectID
+		config.DeployerStateObjID = mcmsFields.DeployerStateObjectID
+	}
 	suiChains := e.BlockChains.SuiChains()
 
 	suiChain := suiChains[config.ChainSelector]

--- a/deployment/state.go
+++ b/deployment/state.go
@@ -28,7 +28,8 @@ type SuiChainView struct {
 	ChainSelector uint64 `json:"chainSelector,omitempty"`
 	ChainID       string `json:"chainID,omitempty"`
 
-	MCMSWithTimelock view.MCMSWithTimelockView `json:"mcmsWithTimelock"`
+	MCMSWithTimelock          view.MCMSWithTimelockView `json:"mcmsWithTimelock"`
+	FastCurseMCMSWithTimelock view.MCMSWithTimelockView `json:"fastcurseMcmsWithTimelock,omitempty"`
 
 	CCIP    view.CCIPView               `json:"ccip,omitempty"`
 	OnRamp  map[string]view.OnRampView  `json:"onRamp,omitempty"`
@@ -63,8 +64,22 @@ type ManagedTokenFaucetState struct {
 	UpgradeCapObjectId string
 }
 
+// MCMSLabel is the address book label applied to the fastcurse MCMS instance.
+const MCMSFastCurseLabel = "fastcurse"
+
+// MCMSStateFields holds the seven object IDs that describe one MCMS deployment.
+type MCMSStateFields struct {
+	PackageID               string
+	StateObjectID           string
+	RegistryObjectID        string
+	DeployerStateObjectID   string
+	AccountStateObjectID    string
+	AccountOwnerCapObjectID string
+	TimelockObjectID        string
+}
+
 type CCIPChainState struct {
-	// MCMS related
+	// MCMS related (normal governance instance)
 	MCMSPackageID               string
 	MCMSStateObjectID           string
 	MCMSRegistryObjectID        string
@@ -72,6 +87,15 @@ type CCIPChainState struct {
 	MCMSAccountStateObjectID    string
 	MCMSAccountOwnerCapObjectID string
 	MCMSTimelockObjectID        string
+
+	// FastCurse MCMS related (fastcurse governance instance, stored with label "fastcurse")
+	FastCurseMCMSPackageID               string
+	FastCurseMCMSStateObjectID           string
+	FastCurseMCMSRegistryObjectID        string
+	FastCurseMCMSDeployerStateObjectID   string
+	FastCurseMCMSAccountStateObjectID    string
+	FastCurseMCMSAccountOwnerCapObjectID string
+	FastCurseMCMSTimelockObjectID        string
 
 	// CCIP related
 	CCIPAddress            string
@@ -119,6 +143,32 @@ type CCIPChainState struct {
 	CCIPMockV2PackageId    string
 }
 
+// MCMSState returns the MCMS object IDs for the requested instance.
+// When isFastCurse is true the fastcurse instance fields are returned;
+// otherwise the normal governance instance fields are returned.
+func (s CCIPChainState) MCMSState(isFastCurse bool) MCMSStateFields {
+	if isFastCurse {
+		return MCMSStateFields{
+			PackageID:               s.FastCurseMCMSPackageID,
+			StateObjectID:           s.FastCurseMCMSStateObjectID,
+			RegistryObjectID:        s.FastCurseMCMSRegistryObjectID,
+			DeployerStateObjectID:   s.FastCurseMCMSDeployerStateObjectID,
+			AccountStateObjectID:    s.FastCurseMCMSAccountStateObjectID,
+			AccountOwnerCapObjectID: s.FastCurseMCMSAccountOwnerCapObjectID,
+			TimelockObjectID:        s.FastCurseMCMSTimelockObjectID,
+		}
+	}
+	return MCMSStateFields{
+		PackageID:               s.MCMSPackageID,
+		StateObjectID:           s.MCMSStateObjectID,
+		RegistryObjectID:        s.MCMSRegistryObjectID,
+		DeployerStateObjectID:   s.MCMSDeployerStateObjectID,
+		AccountStateObjectID:    s.MCMSAccountStateObjectID,
+		AccountOwnerCapObjectID: s.MCMSAccountOwnerCapObjectID,
+		TimelockObjectID:        s.MCMSTimelockObjectID,
+	}
+}
+
 func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chainName string) (SuiChainView, error) {
 	lggr := e.Logger
 	chainView := SuiChainView{
@@ -136,7 +186,7 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 	var mu sync.Mutex
 	g, ctxG1 := errgroup.WithContext(ctx)
 
-	// MCMS
+	// Normal MCMS
 	if s.MCMSStateObjectID != "" {
 		g.Go(func() error {
 			mcmsView, err := view.GenerateMCMSWithTimelockView(ctxG1, suiChain, s.MCMSPackageID, s.MCMSStateObjectID, s.MCMSTimelockObjectID, s.MCMSAccountStateObjectID)
@@ -147,6 +197,21 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 			chainView.MCMSWithTimelock = mcmsView
 			mu.Unlock()
 			lggr.Infow("generated MCMS view", "mcmsStateObjectID", s.MCMSStateObjectID, "chain", chainName)
+			return nil
+		})
+	}
+
+	// FastCurse MCMS
+	if s.FastCurseMCMSStateObjectID != "" {
+		g.Go(func() error {
+			mcmsView, err := view.GenerateMCMSWithTimelockView(ctxG1, suiChain, s.FastCurseMCMSPackageID, s.FastCurseMCMSStateObjectID, s.FastCurseMCMSTimelockObjectID, s.FastCurseMCMSAccountStateObjectID)
+			if err != nil {
+				return fmt.Errorf("failed to generate fastcurse mcms view for mcms %s: %w", s.FastCurseMCMSStateObjectID, err)
+			}
+			mu.Lock()
+			chainView.FastCurseMCMSWithTimelock = mcmsView
+			mu.Unlock()
+			lggr.Infow("generated FastCurse MCMS view", "fastCurseMCMSStateObjectID", s.FastCurseMCMSStateObjectID, "chain", chainName)
 			return nil
 		})
 	}
@@ -358,24 +423,54 @@ func loadsuiChainStateFromAddresses(addresses map[string]cldf.TypeAndVersion) (C
 		ManagedTokenPools:   make(map[string]CCIPPoolState),
 	}
 	for addr, typeAndVersion := range addresses {
-		// Parse addresss based on type and label
+		// Determine whether this address belongs to the fastcurse MCMS instance.
+		isFastCurse := typeAndVersion.Labels.Contains(MCMSFastCurseLabel)
+
 		switch typeAndVersion.Type {
 
-		// MCMS related
+		// MCMS related — route to normal or fastcurse fields based on the label.
 		case SuiMcmsPackageIDType:
-			chainState.MCMSPackageID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSPackageID = addr
+			} else {
+				chainState.MCMSPackageID = addr
+			}
 		case SuiMcmsRegistryObjectIDType:
-			chainState.MCMSRegistryObjectID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSRegistryObjectID = addr
+			} else {
+				chainState.MCMSRegistryObjectID = addr
+			}
 		case SuiMcmsObjectIDType:
-			chainState.MCMSStateObjectID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSStateObjectID = addr
+			} else {
+				chainState.MCMSStateObjectID = addr
+			}
 		case SuiMcmsAccountStateObjectIDType:
-			chainState.MCMSAccountStateObjectID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSAccountStateObjectID = addr
+			} else {
+				chainState.MCMSAccountStateObjectID = addr
+			}
 		case SuiMcmsAccountOwnerCapObjectIDType:
-			chainState.MCMSAccountOwnerCapObjectID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSAccountOwnerCapObjectID = addr
+			} else {
+				chainState.MCMSAccountOwnerCapObjectID = addr
+			}
 		case SuiMcmsTimelockObjectIDType:
-			chainState.MCMSTimelockObjectID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSTimelockObjectID = addr
+			} else {
+				chainState.MCMSTimelockObjectID = addr
+			}
 		case SuiMcmsDeployerObjectIDType:
-			chainState.MCMSDeployerStateObjectID = addr
+			if isFastCurse {
+				chainState.FastCurseMCMSDeployerStateObjectID = addr
+			} else {
+				chainState.MCMSDeployerStateObjectID = addr
+			}
 
 		// CCIP Router related
 		case SuiCCIPRouterType:

--- a/integration-tests/deploy/deploy_test.go
+++ b/integration-tests/deploy/deploy_test.go
@@ -92,11 +92,14 @@ func (s *DeployTestSuite) TestDeployAndConfigureSuiChain() {
 func (s *DeployTestSuite) DeployMCMS() {
 	s.T().Log("Phase 1: Deploying MCMS...")
 
-	out, err := changesets.DeployMCMS{}.Apply(s.env, mcmsops.DeployMCMSSeqInput{
-		ChainSelector: SuiChainSelector,
-		Bypasser:      GetMCMSConfig(1),
-		Proposer:      GetMCMSConfig(1),
-		Canceller:     GetMCMSConfig(2),
+	out, err := changesets.DeployMCMS{}.Apply(s.env, changesets.DeployMCMSConfig{
+		DeployMCMSSeqInput: mcmsops.DeployMCMSSeqInput{
+			ChainSelector: SuiChainSelector,
+			Bypasser:      GetMCMSConfig(1),
+			Proposer:      GetMCMSConfig(1),
+			Canceller:     GetMCMSConfig(2),
+		},
+		IsFastCurse: false,
 	})
 	s.Require().NoError(err, "failed to deploy MCMS")
 


### PR DESCRIPTION
- MCMS Changesets accept a `isFastcurse` input to decide wether to use the fastcurse or normal MCMS 
- MCMS type and version of address book can contain a "fastcurse" label to differentiate the instance
- State returns the right instance of MCMS considering "fastcurse" input