### PR TITLE
nonevm-5255: check for errors before memory allocation

### DIFF
--- a/relayer/codec/decoder.go
+++ b/relayer/codec/decoder.go
@@ -32,6 +32,13 @@ const (
 
 	// Response parsing constants
 	maxByteValue = 255
+
+	// proofWireBytes is the fixed on-wire size of each merkle proof element.
+	proofWireBytes = 32
+
+	// tokenTransferMinWireBytes is the minimum BCS size of Any2SuiTokenTransfer:
+	// uleb128(0) source pool + 32 dest token + 4 dest gas + uleb128(0) extra data + 32 amount.
+	tokenTransferMinWireBytes = 70
 )
 
 // DecodeSuiJsonValue decodes Sui JSON response data into the provided target.
@@ -465,8 +472,9 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 	if err := deserializer.Error(); err != nil {
 		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
 	}
-	if int(tokenAmountsLen) > deserializer.Remaining() {
-		return nil, fmt.Errorf("failed to deserialize execution report: token_amounts length %d exceeds remaining %d bytes", tokenAmountsLen, deserializer.Remaining())
+	remaining := deserializer.Remaining()
+	if remaining < 0 || uint64(tokenAmountsLen)*tokenTransferMinWireBytes > uint64(remaining) {
+		return nil, fmt.Errorf("failed to deserialize execution report: token_amounts length %d exceeds remaining %d bytes", tokenAmountsLen, remaining)
 	}
 	tokenAmounts := make([]Any2SuiTokenTransfer, tokenAmountsLen)
 
@@ -517,13 +525,14 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 	if err := deserializer.Error(); err != nil {
 		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
 	}
-	if int(proofsLen) > deserializer.Remaining() {
-		return nil, fmt.Errorf("failed to deserialize execution report: proofs length %d exceeds remaining %d bytes", proofsLen, deserializer.Remaining())
+	remaining = deserializer.Remaining()
+	if remaining < 0 || uint64(proofsLen)*proofWireBytes > uint64(remaining) {
+		return nil, fmt.Errorf("failed to deserialize execution report: proofs length %d exceeds remaining %d bytes", proofsLen, remaining)
 	}
 	proofs := make([][]byte, proofsLen)
 
 	for i := range proofsLen {
-		proofs[i] = deserializer.ReadFixedBytes(32)
+		proofs[i] = deserializer.ReadFixedBytes(proofWireBytes)
 	}
 
 	if err := deserializer.Error(); err != nil {

--- a/relayer/codec/decoder.go
+++ b/relayer/codec/decoder.go
@@ -577,7 +577,7 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 	// 9. Read proofs (vector<vector<u8>>)
 	proofsLen := deserializer.Uleb128()
 	if err := deserializer.Error(); err != nil {
-		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
+		return nil, fmt.Errorf("failed to deserialize proofs length: %w", err)
 	}
 	remaining = deserializer.Remaining()
 	if remaining < 0 || uint64(proofsLen)*proofWireBytes > uint64(remaining) {

--- a/relayer/codec/decoder.go
+++ b/relayer/codec/decoder.go
@@ -430,15 +430,36 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	// 1. Read source_chain_selector (u64)
 	sourceChainSelector := deserializer.U64()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize sourceChainSelector: %w", err)
+	}
 
 	// 2. Read message header
 	messageID := make([]byte, 32)
 	deserializer.ReadFixedBytesInto(messageID)
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize messageID: %w", err)
+	}
 
 	headerSourceChain := deserializer.U64()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize headerSourceChain: %w", err)
+	}
+
 	destChainSelector := deserializer.U64()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize destChainSelector: %w", err)
+	}
+
 	sequenceNumber := deserializer.U64()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize sequenceNumber: %w", err)
+	}
+
 	nonce := deserializer.U64()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize nonce: %w", err)
+	}
 
 	if sourceChainSelector != headerSourceChain {
 		return nil, fmt.Errorf("source chain selector mismatch: %d != %d", sourceChainSelector, headerSourceChain)
@@ -454,18 +475,33 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	// 3. Read sender (vector<u8>)
 	sender := deserializer.ReadBytes()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize sender: %w", err)
+	}
 
 	// 4. Read data (vector<u8>)
 	msgData := deserializer.ReadBytes()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize data: %w", err)
+	}
 
 	// 5. Read receiver (address)
 	receiver := deserializer.ReadFixedBytes(32)
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize receiver: %w", err)
+	}
 
 	// 6. Read gas_limit (u256)
 	gasLimit := deserializer.U256()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize gas_limit: %w", err)
+	}
 
 	tokenReceiver := [32]byte{}
 	deserializer.ReadFixedBytesInto(tokenReceiver[:])
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize tokenReceiver: %w", err)
+	}
 
 	// 7. Read token_amounts vector
 	tokenAmountsLen := deserializer.Uleb128()
@@ -480,12 +516,27 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	for i := range tokenAmountsLen {
 		sourcePoolAddr := deserializer.ReadBytes()
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize sourcePoolAddr: %w", err)
+		}
 
 		destToken := deserializer.ReadFixedBytes(32)
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize destToken: %w", err)
+		}
 
 		destGas := deserializer.U32()
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize destGas: %w", err)
+		}
 		extraData := deserializer.ReadBytes()
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize extraData: %w", err)
+		}
 		amount := deserializer.U256()
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize amount: %w", err)
+		}
 
 		tokenAmounts[i] = Any2SuiTokenTransfer{
 			SourcePoolAddress: sourcePoolAddr,
@@ -518,6 +569,9 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	for i := range offchainDataLen {
 		offchainData[i] = deserializer.ReadBytes()
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize offchainData at index %d: %w", i, err)
+		}
 	}
 
 	// 9. Read proofs (vector<vector<u8>>)
@@ -533,6 +587,9 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	for i := range proofsLen {
 		proofs[i] = deserializer.ReadFixedBytes(proofWireBytes)
+		if err := deserializer.Error(); err != nil {
+			return nil, fmt.Errorf("failed to deserialize proof at index %d: %w", i, err)
+		}
 	}
 
 	if err := deserializer.Error(); err != nil {

--- a/relayer/codec/decoder.go
+++ b/relayer/codec/decoder.go
@@ -560,7 +560,7 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 	// 8. Read offchain_token_data (vector<vector<u8>>)
 	offchainDataLen := deserializer.Uleb128()
 	if err := deserializer.Error(); err != nil {
-		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
+		return nil, fmt.Errorf("failed to deserialize offchain_token_data length: %w", err)
 	}
 	if int(offchainDataLen) > deserializer.Remaining() {
 		return nil, fmt.Errorf("failed to deserialize execution report: offchain_token_data length %d exceeds remaining %d bytes", offchainDataLen, deserializer.Remaining())

--- a/relayer/codec/decoder.go
+++ b/relayer/codec/decoder.go
@@ -462,6 +462,12 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	// 7. Read token_amounts vector
 	tokenAmountsLen := deserializer.Uleb128()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
+	}
+	if int(tokenAmountsLen) > deserializer.Remaining() {
+		return nil, fmt.Errorf("failed to deserialize execution report: token_amounts length %d exceeds remaining %d bytes", tokenAmountsLen, deserializer.Remaining())
+	}
 	tokenAmounts := make([]Any2SuiTokenTransfer, tokenAmountsLen)
 
 	for i := range tokenAmountsLen {
@@ -494,6 +500,12 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	// 8. Read offchain_token_data (vector<vector<u8>>)
 	offchainDataLen := deserializer.Uleb128()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
+	}
+	if int(offchainDataLen) > deserializer.Remaining() {
+		return nil, fmt.Errorf("failed to deserialize execution report: offchain_token_data length %d exceeds remaining %d bytes", offchainDataLen, deserializer.Remaining())
+	}
 	offchainData := make([][]byte, offchainDataLen)
 
 	for i := range offchainDataLen {
@@ -502,6 +514,12 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 
 	// 9. Read proofs (vector<vector<u8>>)
 	proofsLen := deserializer.Uleb128()
+	if err := deserializer.Error(); err != nil {
+		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
+	}
+	if int(proofsLen) > deserializer.Remaining() {
+		return nil, fmt.Errorf("failed to deserialize execution report: proofs length %d exceeds remaining %d bytes", proofsLen, deserializer.Remaining())
+	}
 	proofs := make([][]byte, proofsLen)
 
 	for i := range proofsLen {

--- a/relayer/codec/decoder.go
+++ b/relayer/codec/decoder.go
@@ -506,7 +506,7 @@ func DeserializeExecutionReport(data []byte) (*ExecutionReport, error) {
 	// 7. Read token_amounts vector
 	tokenAmountsLen := deserializer.Uleb128()
 	if err := deserializer.Error(); err != nil {
-		return nil, fmt.Errorf("failed to deserialize execution report: %w", err)
+		return nil, fmt.Errorf("failed to deserialize token_amounts length: %w", err)
 	}
 	remaining := deserializer.Remaining()
 	if remaining < 0 || uint64(tokenAmountsLen)*tokenTransferMinWireBytes > uint64(remaining) {

--- a/relayer/codec/decoder_test.go
+++ b/relayer/codec/decoder_test.go
@@ -2697,6 +2697,61 @@ func TestCustomReportDeserializer(t *testing.T) {
 	})
 }
 
+func TestDeserializeExecutionReport_RejectsOversizedVectorLength(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal valid prefix up to token_amounts length, then inject a
+	// ULEB128 encoding of 0xFFFFFFFF. Without the bounds check this would
+	// trigger a ~343 GB allocation and a fatal OOM.
+	var buf []byte
+
+	u64 := func(v uint64) {
+		b := make([]byte, 8)
+		b[0] = byte(v)
+		b[1] = byte(v >> 8)
+		b[2] = byte(v >> 16)
+		b[3] = byte(v >> 24)
+		b[4] = byte(v >> 32)
+		b[5] = byte(v >> 40)
+		b[6] = byte(v >> 48)
+		b[7] = byte(v >> 56)
+		buf = append(buf, b...)
+	}
+	fixed32 := func() { buf = append(buf, make([]byte, 32)...) }
+	uleb := func(v uint32) {
+		for {
+			b := byte(v & 0x7f)
+			v >>= 7
+			if v != 0 {
+				b |= 0x80
+			}
+			buf = append(buf, b)
+			if v == 0 {
+				break
+			}
+		}
+	}
+
+	u64(1)       // sourceChainSelector
+	fixed32()    // messageID
+	u64(1)       // headerSourceChain (must match sourceChainSelector)
+	u64(2)       // destChainSelector
+	u64(3)       // sequenceNumber
+	u64(4)       // nonce
+	uleb(0)      // sender length (empty)
+	uleb(0)      // data length (empty)
+	fixed32()    // receiver
+	fixed32()    // gasLimit (u256)
+	fixed32()    // tokenReceiver
+	uleb(0xFFFFFFFF) // token_amounts length -- the malicious value
+
+	report, err := DeserializeExecutionReport(buf)
+	require.Nil(t, report)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token_amounts length")
+	require.Contains(t, err.Error(), "exceeds remaining")
+}
+
 func TestDeserializeExecutionReportFromPure(t *testing.T) {
 	t.Parallel()
 

--- a/relayer/codec/decoder_test.go
+++ b/relayer/codec/decoder_test.go
@@ -2752,6 +2752,114 @@ func TestDeserializeExecutionReport_RejectsOversizedVectorLength(t *testing.T) {
 	require.Contains(t, err.Error(), "exceeds remaining")
 }
 
+func TestDeserializeExecutionReport_RejectsTokenAmountsLengthExceedingWireBudget(t *testing.T) {
+	t.Parallel()
+
+	var buf []byte
+
+	u64 := func(v uint64) {
+		b := make([]byte, 8)
+		b[0] = byte(v)
+		b[1] = byte(v >> 8)
+		b[2] = byte(v >> 16)
+		b[3] = byte(v >> 24)
+		b[4] = byte(v >> 32)
+		b[5] = byte(v >> 40)
+		b[6] = byte(v >> 48)
+		b[7] = byte(v >> 56)
+		buf = append(buf, b...)
+	}
+	fixed32 := func() { buf = append(buf, make([]byte, 32)...) }
+	uleb := func(v uint32) {
+		for {
+			b := byte(v & 0x7f)
+			v >>= 7
+			if v != 0 {
+				b |= 0x80
+			}
+			buf = append(buf, b)
+			if v == 0 {
+				break
+			}
+		}
+	}
+
+	u64(1)    // sourceChainSelector
+	fixed32() // messageID
+	u64(1)    // headerSourceChain
+	u64(2)    // destChainSelector
+	u64(3)    // sequenceNumber
+	u64(4)    // nonce
+	uleb(0)   // sender
+	uleb(0)   // data
+	fixed32() // receiver
+	fixed32() // gasLimit
+	fixed32() // tokenReceiver
+	uleb(100) // token_amounts length: 100 elements need 7000 bytes
+	buf = append(buf, make([]byte, 100)...) // only 100 bytes remain on the wire
+
+	report, err := DeserializeExecutionReport(buf)
+	require.Nil(t, report)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token_amounts length")
+	require.Contains(t, err.Error(), "exceeds remaining")
+}
+
+func TestDeserializeExecutionReport_RejectsProofsLengthExceedingWireBudget(t *testing.T) {
+	t.Parallel()
+
+	var buf []byte
+
+	u64 := func(v uint64) {
+		b := make([]byte, 8)
+		b[0] = byte(v)
+		b[1] = byte(v >> 8)
+		b[2] = byte(v >> 16)
+		b[3] = byte(v >> 24)
+		b[4] = byte(v >> 32)
+		b[5] = byte(v >> 40)
+		b[6] = byte(v >> 48)
+		b[7] = byte(v >> 56)
+		buf = append(buf, b...)
+	}
+	fixed32 := func() { buf = append(buf, make([]byte, 32)...) }
+	uleb := func(v uint32) {
+		for {
+			b := byte(v & 0x7f)
+			v >>= 7
+			if v != 0 {
+				b |= 0x80
+			}
+			buf = append(buf, b)
+			if v == 0 {
+				break
+			}
+		}
+	}
+
+	u64(1)    // sourceChainSelector
+	fixed32() // messageID
+	u64(1)    // headerSourceChain
+	u64(2)    // destChainSelector
+	u64(3)    // sequenceNumber
+	u64(4)    // nonce
+	uleb(0)   // sender
+	uleb(0)   // data
+	fixed32() // receiver
+	fixed32() // gasLimit
+	fixed32() // tokenReceiver
+	uleb(0)   // token_amounts
+	uleb(0)   // offchain_token_data
+	uleb(10)  // proofs length: 10 elements need 320 bytes
+	buf = append(buf, make([]byte, 100)...) // only 100 bytes remain on the wire
+
+	report, err := DeserializeExecutionReport(buf)
+	require.Nil(t, report)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "proofs length")
+	require.Contains(t, err.Error(), "exceeds remaining")
+}
+
 func TestDeserializeExecutionReportFromPure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
mirroring https://github.com/smartcontractkit/chainlink-aptos/pull/479