### PR TITLE
[Feature] Update RPC client to deprecate GetNormalizedModule

### DIFF
--- a/deployment/ops/mcms/op_proposal_generate_test.go
+++ b/deployment/ops/mcms/op_proposal_generate_test.go
@@ -76,6 +76,17 @@ func newTestBundle(t *testing.T, registry *cld_ops.OperationRegistry) cld_ops.Bu
 	)
 }
 
+// Temporarily wrap the mock client from MCMS to mock the GetMoveModuleFunction method
+type proposalGenerateMockClient struct {
+	*mocksui.SuiPTBClient
+}
+
+func (c *proposalGenerateMockClient) GetMoveModuleFunction(
+	_ context.Context, _, _, _ string,
+) (*suirpcv2.FunctionDescriptor, error) {
+	return nil, nil
+}
+
 func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 	t.Parallel()
 
@@ -90,7 +101,7 @@ func TestMCMSDynamicProposalGenerateSeq(t *testing.T) {
 	mockClient := setupProposalGenerateMockClient(t)
 	// Create mock dependencies
 	deps := sui_ops.OpTxDeps{
-		Client: mockClient,
+		Client: &proposalGenerateMockClient{mockClient},
 		Signer: nil, // We don't need a real signer for this test since NoExecute=true
 		GetCallOpts: func() *bind.CallOpts {
 			return &bind.CallOpts{}

--- a/relayer/chainwriter/ptb/offramp/execute.go
+++ b/relayer/chainwriter/ptb/offramp/execute.go
@@ -12,7 +12,6 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/block-vision/sui-go-sdk/models"
 	"github.com/block-vision/sui-go-sdk/transaction"
 	"github.com/mitchellh/mapstructure"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
@@ -227,12 +226,6 @@ func ProcessTokenPools(
 
 		lggr.Debugw("fetched token configs via dev inspect call", "tokenConfig", tokenConfig)
 
-		// Get the move normalized module to dynamically construct the parameters for the token pool call
-		tokenPoolNormalizedModule, err := ptbClient.GetNormalizedModule(ctx, tokenConfig.TokenPoolPackageId, tokenConfig.TokenPoolModule)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get normalized module for token pool: %w", err)
-		}
-
 		tokenPoolCommandResult, err := AppendPTBCommandForTokenPool(
 			ctx,
 			lggr,
@@ -241,7 +234,6 @@ func ProcessTokenPools(
 			callOpts,
 			addressMappings,
 			&tokenConfig,
-			&tokenPoolNormalizedModule,
 			receiverParams,
 		)
 		if err != nil {
@@ -257,12 +249,11 @@ func ProcessTokenPools(
 func AppendPTBCommandForTokenPool(
 	ctx context.Context,
 	lggr logger.Logger,
-	chainClient client.BindingsClient,
+	chainClient client.SuiPTBClient,
 	ptb *transaction.Transaction,
 	callOpts *bind.CallOpts,
 	addressMappings *OffRampAddressMappings,
 	tokenPoolConfigs *module_token_admin_registry.TokenConfig,
-	normalizedModule *models.GetNormalizedMoveModuleResponse,
 	receiverParams *transaction.Argument,
 ) (*transaction.Argument, error) {
 	poolBoundContract, err := bind.NewBoundContract(
@@ -295,16 +286,11 @@ func AppendPTBCommandForTokenPool(
 	}
 
 	// Use the normalized module to populate the paramTypes and paramValues for the bound contract
-	functionSignature, ok := normalizedModule.ExposedFunctions[OfframpTokenPoolFunctionName]
-	if !ok {
-		return nil, fmt.Errorf("missing function signature for token pool function not found in module (%s)", OfframpTokenPoolFunctionName)
+	functionDescriptor, err := chainClient.GetMoveModuleFunction(ctx, tokenPoolConfigs.TokenPoolPackageId, tokenPoolConfigs.TokenPoolModule, OfframpTokenPoolFunctionName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get function descriptor for token pool function: %w", err)
 	}
-
-	funcMap, ok := functionSignature.(map[string]any)
-	if !ok || funcMap == nil {
-		return nil, fmt.Errorf("invalid function signature shape for %q (%T)", OfframpTokenPoolFunctionName, functionSignature)
-	}
-	paramTypes, err := DecodeParameters(lggr, funcMap, "parameters")
+	paramTypes, err := DecodeParametersFromFunctionDescriptor(lggr, functionDescriptor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode parameters for token pool function: %w", err)
 	}
@@ -387,12 +373,6 @@ func ProcessReceivers(
 			return nil, fmt.Errorf("failed to get receiver config in offramp execution: %w", err)
 		}
 
-		receiverNormalizedModule, err := ptbClient.GetNormalizedModule(ctx, receiverPackageId, receiverConfig.ModuleName)
-		if err != nil {
-			// RPC/network error — propagate so the caller can retry later.
-			return nil, fmt.Errorf("failed to get normalized module for receiver: %w", err)
-		}
-
 		receiverCommandResult, err := AppendPTBCommandForReceiver(
 			ctx,
 			lggr,
@@ -404,7 +384,6 @@ func ProcessReceivers(
 			"ccip_receive",
 			addressMappings,
 			message.Header.MessageID,
-			&receiverNormalizedModule,
 			receiverParams,
 			extraArgs,
 		)
@@ -450,7 +429,7 @@ func needsAppDelivery(message ccipocr3.Message, extraArgs map[string]any) bool {
 func AppendPTBCommandForReceiver(
 	ctx context.Context,
 	lggr logger.Logger,
-	chainClient client.BindingsClient,
+	chainClient client.SuiPTBClient,
 	ptb *transaction.Transaction,
 	callOpts *bind.CallOpts,
 	packageId string,
@@ -458,7 +437,6 @@ func AppendPTBCommandForReceiver(
 	functionName string,
 	addressMappings *OffRampAddressMappings,
 	messageID [32]byte,
-	normalizedModule *models.GetNormalizedMoveModuleResponse,
 	receiverParams *transaction.Argument,
 	extraArgs map[string]any,
 ) (*transaction.Argument, error) {
@@ -514,18 +492,13 @@ func AppendPTBCommandForReceiver(
 	}
 
 	// Use the normalized module to populate the paramTypes and paramValues for the bound contract
-	functionSignature, ok := normalizedModule.ExposedFunctions[functionName]
-	if !ok {
-		return nil, fmt.Errorf("%w: function %q not found in module", ErrUnsupportedReceiverABI, functionName)
-	}
-
-	funcMap, err := exposedFunctionSignature(functionName, functionSignature)
+	functionDescriptor, err := chainClient.GetMoveModuleFunction(ctx, packageId, moduleId, functionName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get function descriptor for receiver: %w", err)
 	}
-	paramTypes, err = DecodeParameters(lggr, funcMap, "parameters")
+	paramTypes, err = DecodeParametersFromFunctionDescriptor(lggr, functionDescriptor)
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to decode receiver parameters: %w", ErrUnsupportedReceiverABI, err)
+		return nil, fmt.Errorf("failed to decode parameters for receiver: %w", err)
 	}
 
 	lggr.Debugw("calling receiver", "paramTypes", paramTypes, "paramValues", paramValues)

--- a/relayer/chainwriter/ptb/offramp/execute_test.go
+++ b/relayer/chainwriter/ptb/offramp/execute_test.go
@@ -92,6 +92,9 @@ func (s *stubPTBClient) GetLatestCheckpoint(context.Context) (*suirpcv2.Checkpoi
 func (s *stubPTBClient) GetCheckpointData(context.Context, uint64) (*client.CheckpointData, error) {
 	return nil, nil
 }
+func (s *stubPTBClient) GetMoveModuleFunction(context.Context, string, string, string) (*suirpcv2.FunctionDescriptor, error) {
+	return nil, nil
+}
 func (s *stubPTBClient) GetNormalizedModule(context.Context, string, string) (models.GetNormalizedMoveModuleResponse, error) {
 	return models.GetNormalizedMoveModuleResponse{}, nil
 }

--- a/relayer/chainwriter/ptb/offramp/helpers.go
+++ b/relayer/chainwriter/ptb/offramp/helpers.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	suirpcv2 "github.com/block-vision/sui-go-sdk/pb/sui/rpc/v2"
+
 	module_token_admin_registry "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-sui/relayer/client"
 )
@@ -457,6 +459,152 @@ func DecodeParameters(lggr logger.Logger, function map[string]any, key string) (
 
 		paramTypes = append(paramTypes, formatValueParamType(param.Type))
 	}
+
+	return paramTypes, nil
+}
+
+// datatypeName returns the unqualified name portion (e.g. "TxContext") of a fully qualified
+// datatype name of the form "<address>::<module>::<name>", as returned by
+// OpenSignatureBody.GetTypeName(). If typeName isn't qualified, it is returned unchanged.
+func datatypeName(typeName string) string {
+	idx := strings.LastIndex(typeName, "::")
+	if idx == -1 {
+		return typeName
+	}
+	return typeName[idx+2:]
+}
+
+// datatypeMoveType maps a fully qualified datatype name to the Move type string used by
+// EncodeCallArgsWithGenerics, mirroring structMapToMoveType for the JSON-RPC based decoder.
+func datatypeMoveType(typeName string) string {
+	parts := strings.Split(typeName, "::")
+	if len(parts) != 3 {
+		return "object_id"
+	}
+	address, module, name := parts[0], parts[1], parts[2]
+	return structFieldsToMoveType(address, module, name)
+}
+
+// parseSignatureBodyType computes the Move type string for a single OpenSignatureBody, recursing
+// into vector element types. It mirrors ParseParamType for the gRPC FunctionDescriptor shape.
+func parseSignatureBodyType(body *suirpcv2.OpenSignatureBody) (string, error) {
+	if body == nil {
+		return "", errors.New("nil signature body")
+	}
+
+	switch body.GetType() {
+	case suirpcv2.OpenSignatureBody_ADDRESS:
+		return "object_id", nil
+	case suirpcv2.OpenSignatureBody_BOOL:
+		return "bool", nil
+	case suirpcv2.OpenSignatureBody_U8:
+		return "u8", nil
+	case suirpcv2.OpenSignatureBody_U16:
+		return "u16", nil
+	case suirpcv2.OpenSignatureBody_U32:
+		return "u32", nil
+	case suirpcv2.OpenSignatureBody_U64:
+		return "u64", nil
+	case suirpcv2.OpenSignatureBody_U128:
+		return "u128", nil
+	case suirpcv2.OpenSignatureBody_U256:
+		return "u256", nil
+	case suirpcv2.OpenSignatureBody_VECTOR:
+		elementTypes := body.GetTypeParameterInstantiation()
+		if len(elementTypes) != 1 {
+			return "", fmt.Errorf("vector signature has %d type parameters, expected 1", len(elementTypes))
+		}
+		elementType, err := parseSignatureBodyType(elementTypes[0])
+		if err != nil {
+			return "", err
+		}
+		return "vector<" + elementType + ">", nil
+	case suirpcv2.OpenSignatureBody_DATATYPE:
+		return datatypeMoveType(body.GetTypeName()), nil
+	case suirpcv2.OpenSignatureBody_TYPE_PARAMETER:
+		return "", fmt.Errorf("%w: TypeParameter (generic parameters are not supported)", ErrUnsupportedReceiverABI)
+	default:
+		return "unknown", nil
+	}
+}
+
+// decodeOpenSignature classifies a single function parameter/return signature into the name
+// (used to detect and skip TxContext), the reference kind ("Reference", "MutableReference", or
+// "Vector"), and the underlying Move type string. It mirrors decodeParam for the gRPC
+// FunctionDescriptor shape: a Vector body always takes precedence over the outer reference
+// (matching the JSON-RPC decoder, where a Vector's own wrapper key overrides any enclosing
+// Reference/MutableReference), and a bare (non-Vector) body defaults to "Reference" unless
+// explicitly marked MUTABLE.
+func decodeOpenSignature(sig *suirpcv2.OpenSignature) (name string, reference string, moveType string, err error) {
+	body := sig.GetBody()
+	if body == nil {
+		return "", "", "", errors.New("nil parameter body")
+	}
+
+	if body.GetType() == suirpcv2.OpenSignatureBody_VECTOR {
+		elementTypes := body.GetTypeParameterInstantiation()
+		if len(elementTypes) != 1 {
+			return "", "", "", fmt.Errorf("vector signature has %d type parameters, expected 1", len(elementTypes))
+		}
+		elementType, err := parseSignatureBodyType(elementTypes[0])
+		if err != nil {
+			return "", "", "", err
+		}
+		return datatypeName(elementTypes[0].GetTypeName()), "Vector", elementType, nil
+	}
+
+	moveType, err = parseSignatureBodyType(body)
+	if err != nil {
+		return "", "", "", err
+	}
+	name = datatypeName(body.GetTypeName())
+
+	if sig.GetReference() == suirpcv2.OpenSignature_MUTABLE {
+		return name, "MutableReference", moveType, nil
+	}
+
+	return name, "Reference", moveType, nil
+}
+
+// DecodeParametersFromFunctionDescriptor computes the PTB argument type strings for a Move
+// function's parameters, given its gRPC FunctionDescriptor. It achieves the same purpose as
+// DecodeParameters, but reads from the typed sui.rpc.v2.FunctionDescriptor returned by
+// MovePackageService.GetFunction rather than the untyped JSON-RPC normalized function map.
+func DecodeParametersFromFunctionDescriptor(lggr logger.Logger, functionDescriptor *suirpcv2.FunctionDescriptor) ([]string, error) {
+	if functionDescriptor == nil {
+		lggr.Errorw("function descriptor is nil")
+		return nil, errors.New("function descriptor is nil")
+	}
+
+	parameters := functionDescriptor.GetParameters()
+	lggr.Debugw("Raw parameters", "parameters", parameters)
+
+	paramTypes := make([]string, 0, len(parameters))
+	for i, parameter := range parameters {
+		name, reference, moveType, err := decodeOpenSignature(parameter)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode parameter %d: %w", i, err)
+		}
+
+		if name == "TxContext" {
+			continue
+		}
+
+		switch reference {
+		case "MutableReference":
+			paramTypes = append(paramTypes, "&mut object")
+		case "Vector":
+			paramTypes = append(paramTypes, "vector<"+moveType+">")
+		default:
+			if isPureParamType(moveType) {
+				paramTypes = append(paramTypes, moveType)
+			} else {
+				paramTypes = append(paramTypes, "&object")
+			}
+		}
+	}
+
+	lggr.Debugw("decoded parameter types", "paramTypes", paramTypes)
 
 	return paramTypes, nil
 }

--- a/relayer/chainwriter/ptb/offramp/helpers.go
+++ b/relayer/chainwriter/ptb/offramp/helpers.go
@@ -546,9 +546,9 @@ func decodeOpenSignature(sig *suirpcv2.OpenSignature) (name string, reference st
 		if len(elementTypes) != 1 {
 			return "", "", "", fmt.Errorf("vector signature has %d type parameters, expected 1", len(elementTypes))
 		}
-		elementType, err := parseSignatureBodyType(elementTypes[0])
-		if err != nil {
-			return "", "", "", err
+		elementType, elmErr := parseSignatureBodyType(elementTypes[0])
+		if elmErr != nil {
+			return "", "", "", elmErr
 		}
 		return datatypeName(elementTypes[0].GetTypeName()), "Vector", elementType, nil
 	}

--- a/relayer/chainwriter/ptb/offramp/helpers_test.go
+++ b/relayer/chainwriter/ptb/offramp/helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	suirpcv2 "github.com/block-vision/sui-go-sdk/pb/sui/rpc/v2"
 )
 
 func TestExposedFunctionSignature_InvalidShape(t *testing.T) {
@@ -598,6 +600,204 @@ func TestDecodeParameters_NilValue(t *testing.T) {
 	function := map[string]any{"parameters": nil}
 
 	result, err := DecodeParameters(lggr, function, "parameters")
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// The tests below exercise DecodeParametersFromFunctionDescriptor, the gRPC-based counterpart to
+// DecodeParameters, using suirpcv2.FunctionDescriptor fixtures instead of JSON-RPC-shaped maps.
+// Each case mirrors an equivalent DecodeParameters test above to confirm behavioral parity.
+
+func openSig(reference *suirpcv2.OpenSignature_Reference, body *suirpcv2.OpenSignatureBody) *suirpcv2.OpenSignature {
+	return &suirpcv2.OpenSignature{Reference: reference, Body: body}
+}
+
+func primitiveBody(t suirpcv2.OpenSignatureBody_Type) *suirpcv2.OpenSignatureBody {
+	return &suirpcv2.OpenSignatureBody{Type: AnyPointer(t)}
+}
+
+func datatypeBody(typeName string) *suirpcv2.OpenSignatureBody {
+	return &suirpcv2.OpenSignatureBody{Type: AnyPointer(suirpcv2.OpenSignatureBody_DATATYPE), TypeName: AnyPointer(typeName)}
+}
+
+func vectorBody(element *suirpcv2.OpenSignatureBody) *suirpcv2.OpenSignatureBody {
+	return &suirpcv2.OpenSignatureBody{
+		Type:                       AnyPointer(suirpcv2.OpenSignatureBody_VECTOR),
+		TypeParameterInstantiation: []*suirpcv2.OpenSignatureBody{element},
+	}
+}
+
+func typeParameterBody(position uint32) *suirpcv2.OpenSignatureBody {
+	return &suirpcv2.OpenSignatureBody{Type: AnyPointer(suirpcv2.OpenSignatureBody_TYPE_PARAMETER), TypeParameter: AnyPointer(position)}
+}
+
+func TestDecodeParametersFromFunctionDescriptor_NilDescriptor(t *testing.T) {
+	lggr := logger.Test(t)
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_EmptyParameters(t *testing.T) {
+	lggr := logger.Test(t)
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, &suirpcv2.FunctionDescriptor{})
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_StringParam(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(nil, datatypeBody("0x1::string::String")),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.NoError(t, err)
+	assert.Equal(t, []string{moveStringType}, result)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_VectorAsciiString(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(nil, vectorBody(datatypeBody("0x1::ascii::String"))),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vector<" + moveASCIIStringType + ">"}, result)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_NestedVectorU8(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(nil, vectorBody(vectorBody(primitiveBody(suirpcv2.OpenSignatureBody_U8)))),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vector<vector<u8>>"}, result)
+}
+
+// TestDecodeParametersFromFunctionDescriptor_ComplexSignature mirrors
+// TestDecodeParameters_ComplexSignature using the gRPC FunctionDescriptor shape.
+func TestDecodeParametersFromFunctionDescriptor_ComplexSignature(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			// &CCIPObjectRef (object reference)
+			openSig(AnyPointer(suirpcv2.OpenSignature_IMMUTABLE), datatypeBody("0xccip::state_object::CCIPObjectRef")),
+			// address primitive (Move Address)
+			openSig(nil, primitiveBody(suirpcv2.OpenSignatureBody_ADDRESS)),
+			// vector<u8>
+			openSig(nil, vectorBody(primitiveBody(suirpcv2.OpenSignatureBody_U8))),
+			// vector<SomeStruct> (vector of object-like structs)
+			openSig(nil, vectorBody(datatypeBody("0xpool::burn_mint::BurnMintTokenPoolState"))),
+			// 0x1::string::String by value
+			openSig(nil, datatypeBody("0x1::string::String")),
+			// vector<0x1::string::String>
+			openSig(nil, vectorBody(datatypeBody("0x1::string::String"))),
+			// bool
+			openSig(nil, primitiveBody(suirpcv2.OpenSignatureBody_BOOL)),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.NoError(t, err)
+
+	expected := []string{
+		"&object",
+		"&object",
+		"vector<u8>",
+		"vector<object_id>",
+		moveStringType,
+		"vector<" + moveStringType + ">",
+		"bool",
+	}
+	assert.Equal(t, expected, result)
+}
+
+// TestDecodeParametersFromFunctionDescriptor_ValidDummyReceiverSignature mirrors
+// TestDecodeParameters_ValidDummyReceiverSignature using the gRPC FunctionDescriptor shape.
+func TestDecodeParametersFromFunctionDescriptor_ValidDummyReceiverSignature(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(nil, vectorBody(primitiveBody(suirpcv2.OpenSignatureBody_U8))),
+			openSig(AnyPointer(suirpcv2.OpenSignature_IMMUTABLE), datatypeBody("0xccip::state_object::CCIPObjectRef")),
+			openSig(nil, datatypeBody("0xccip::client::Any2SuiMessage")),
+			openSig(AnyPointer(suirpcv2.OpenSignature_IMMUTABLE), datatypeBody("0x2::clock::Clock")),
+			openSig(AnyPointer(suirpcv2.OpenSignature_MUTABLE), datatypeBody("0xreceiver::dummy_receiver::CCIPReceiverState")),
+			openSig(AnyPointer(suirpcv2.OpenSignature_MUTABLE), datatypeBody("0x2::tx_context::TxContext")),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.NoError(t, err)
+
+	// TxContext is skipped.
+	expected := []string{
+		"vector<u8>",
+		"&object",
+		"&object",
+		"&object",
+		"&mut object",
+	}
+	assert.Equal(t, expected, result)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_TopLevelTypeParameter_Unsupported(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(nil, typeParameterBody(0)),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrUnsupportedReceiverABI)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_VectorWrappingTypeParameter_Unsupported(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(AnyPointer(suirpcv2.OpenSignature_IMMUTABLE), vectorBody(typeParameterBody(0))),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrUnsupportedReceiverABI)
+}
+
+func TestDecodeParametersFromFunctionDescriptor_NilBody(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fd := &suirpcv2.FunctionDescriptor{
+		Parameters: []*suirpcv2.OpenSignature{
+			openSig(nil, nil),
+		},
+	}
+
+	result, err := DecodeParametersFromFunctionDescriptor(lggr, fd)
 	require.Error(t, err)
 	assert.Nil(t, result)
 }

--- a/relayer/client/grpc_client.go
+++ b/relayer/client/grpc_client.go
@@ -1281,19 +1281,33 @@ func (c *PTBClient) getNormalizedModuleInternal(ctx context.Context, packageId s
 }
 
 func (c *PTBClient) GetCoinMetadata(ctx context.Context, coinType string) (models.CoinMetadataResponse, error) {
-	if c.moveModuleClient == nil {
-		return models.CoinMetadataResponse{}, errors.New("move module client not configured")
-	}
-
 	var result models.CoinMetadataResponse
 	err := c.WithRateLimit(ctx, "GetCoinMetadata", func(ctx context.Context) error {
-		rsp, err := c.moveModuleClient.SuiXGetCoinMetadata(ctx, models.SuiXGetCoinMetadataRequest{
-			CoinType: coinType,
+		stateService, err := c.getStateService(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get state service: %w", err)
+		}
+
+		coinInfoResponse, err := stateService.GetCoinInfo(ctx, &suirpcv2.GetCoinInfoRequest{
+			CoinType: &coinType,
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get coin info: %w", err)
 		}
-		result = rsp
+
+		metadata := coinInfoResponse.GetMetadata()
+		if metadata == nil {
+			return fmt.Errorf("no metadata found for coin type %s", coinType)
+		}
+
+		result = models.CoinMetadataResponse{
+			Id:          metadata.GetId(),
+			Decimals:    int(metadata.GetDecimals()),
+			Name:        metadata.GetName(),
+			Symbol:      metadata.GetSymbol(),
+			IconUrl:     metadata.GetIconUrl(),
+			Description: metadata.GetDescription(),
+		}
 		return nil
 	})
 

--- a/relayer/client/grpc_client.go
+++ b/relayer/client/grpc_client.go
@@ -113,6 +113,7 @@ type SuiPTBClient interface {
 	GetLatestCheckpoint(ctx context.Context) (*suirpcv2.Checkpoint, error)
 	GetCheckpointData(ctx context.Context, checkpointSequenceNumber uint64) (*CheckpointData, error)
 	GetNormalizedModule(ctx context.Context, packageId string, moduleId string) (models.GetNormalizedMoveModuleResponse, error)
+	GetMoveModuleFunction(ctx context.Context, packageId string, moduleId string, functionName string) (*suirpcv2.FunctionDescriptor, error)
 	GetSUIBalance(ctx context.Context, address string) (*suirpcv2.Balance, error)
 	LoadModulePackageIds(ctx context.Context, packageId string, module string) ([]string, error)
 	GetLatestPackageId(ctx context.Context, packageId string, module string) (string, error)
@@ -1278,6 +1279,25 @@ func (c *PTBClient) getNormalizedModuleInternal(ctx context.Context, packageId s
 	c.normalizedModules[packageId][module] = normalizedModule
 
 	return normalizedModule, nil
+}
+
+func (c *PTBClient) GetMoveModuleFunction(ctx context.Context, packageId string, moduleId string, functionName string) (*suirpcv2.FunctionDescriptor, error) {
+	var result *suirpcv2.FunctionDescriptor
+	err := c.WithRateLimit(ctx, "GetMoveModuleFunction", func(ctx context.Context) error {
+		var err error
+		movePkgService, err := c.getMovePackageService(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get move package service: %w", err)
+		}
+		response, err := movePkgService.GetFunction(ctx, &suirpcv2.GetFunctionRequest{
+			PackageId:  &packageId,
+			ModuleName: &moduleId,
+			Name:       &functionName,
+		})
+		result = response.GetFunction()
+		return err
+	})
+	return result, err
 }
 
 func (c *PTBClient) GetCoinMetadata(ctx context.Context, coinType string) (models.CoinMetadataResponse, error) {

--- a/relayer/client/mocks/mock_ptb_client.go
+++ b/relayer/client/mocks/mock_ptb_client.go
@@ -14,8 +14,9 @@ import (
 	signer "github.com/block-vision/sui-go-sdk/signer"
 	transaction "github.com/block-vision/sui-go-sdk/transaction"
 	cache "github.com/patrickmn/go-cache"
-	client "github.com/smartcontractkit/chainlink-sui/relayer/client"
 	"go.uber.org/mock/gomock"
+
+	client "github.com/smartcontractkit/chainlink-sui/relayer/client"
 )
 
 // MockSuiPTBClient is a mock of SuiPTBClient interface.
@@ -556,4 +557,17 @@ func (m *MockSuiPTBClient) SignAndSendTransaction(ctx context.Context, txBytesRa
 func (mr *MockSuiPTBClientMockRecorder) SignAndSendTransaction(ctx, txBytesRaw, signerPublicKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignAndSendTransaction", reflect.TypeOf((*MockSuiPTBClient)(nil).SignAndSendTransaction), ctx, txBytesRaw, signerPublicKey)
+}
+
+func (m *MockSuiPTBClient) GetMoveModuleFunction(ctx context.Context, packageId string, moduleId string, functionName string) (*v2.FunctionDescriptor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMoveModuleFunction", ctx, packageId, moduleId, functionName)
+	ret0, _ := ret[0].(*v2.FunctionDescriptor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockSuiPTBClientMockRecorder) GetMoveModuleFunction(ctx, packageId, moduleId, functionName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMoveModuleFunction", reflect.TypeOf((*MockSuiPTBClient)(nil).GetMoveModuleFunction), ctx, packageId, moduleId, functionName)
 }

--- a/relayer/testutils/fake_client.go
+++ b/relayer/testutils/fake_client.go
@@ -183,3 +183,7 @@ func (c *FakeSuiPTBClient) GetReferenceGasPrice(ctx context.Context) (*big.Int, 
 func (c *FakeSuiPTBClient) GetTokenPoolConfigByPackageAddress(ctx context.Context, accountAddress string, tokenPoolAddress string, ccipPackageAddress string) (module_token_admin_registry.TokenConfig, error) {
 	return module_token_admin_registry.TokenConfig{}, nil
 }
+
+func (c *FakeSuiPTBClient) GetMoveModuleFunction(ctx context.Context, packageId string, moduleId string, functionName string) (*suirpcv2.FunctionDescriptor, error) {
+	return &suirpcv2.FunctionDescriptor{}, nil
+}


### PR DESCRIPTION
## Describe your changes

* Adds a new method `GetMoveModuleFunction` which uses the gRPC services
* Deprecate `GetNormalizedModule` (kept to avoid breakage in `chainlink` repo tests)
* Update Offramp execution helper to extract function params using `FunctionDescriptor` (gRPC response model)

## Issue ticket number and link

> ..


## Describe highly relevant files or code snippets that are critical in the review

> ..


## Are there other PRs that should be merged first?

> ..
