### PR TITLE
fix fastcurse and mcmsreader

### DIFF
--- a/deployment/adapters/fastcurse.go
+++ b/deployment/adapters/fastcurse.go
@@ -45,6 +45,8 @@ func NewCurseAdapter() *CurseAdapter {
 }
 
 // Initialize populates the adapter's state fields from the on-chain state for the given selector.
+// Chain metadata is resolved via LoadOnchainStatesui, which prefers datastore address refs
+// (address_refs.json) and falls back to the legacy address book (addresses.json).
 func (c *CurseAdapter) Initialize(e cldf.Environment, selector uint64) error {
 	stateMap, err := deployment.LoadOnchainStatesui(e)
 	if err != nil {

--- a/deployment/adapters/mcmsreader.go
+++ b/deployment/adapters/mcmsreader.go
@@ -2,10 +2,12 @@ package adapters
 
 import (
 	"fmt"
+	"strings"
 
 	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 
+	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	mcms_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -13,13 +15,17 @@ import (
 	suideploy "github.com/smartcontractkit/chainlink-sui/deployment"
 )
 
-const fastCurseQualifier = "RMNMCMS"
+const (
+	fastCurseQualifier       = "RMNMCMS"
+	devenvFastCurseQualifier = "fastcurse-devenv-curse"
+)
 
 type MCMSReader struct{}
 
 // mcmsFieldsFromInput loads the on-chain state and selects the correct
 // MCMSStateFields (normal or fastcurse) based on the Qualifier in the input.
-// A Qualifier value of "RMNMCMS" (fastCurseQualifier) selects the fastcurse MCMS instance.
+// Fast-curse qualifiers (RMNMCMS, UltraFastCurse, fastcurse-devenv-curse) select
+// the fastcurse MCMS instance used for CurserCap curse execution.
 func mcmsFieldsFromInput(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (suideploy.MCMSStateFields, error) {
 	stateMap, err := suideploy.LoadOnchainStatesui(e)
 	if err != nil {
@@ -29,7 +35,16 @@ func mcmsFieldsFromInput(e cldf.Environment, chainSelector uint64, input mcms_ut
 	if !ok {
 		return suideploy.MCMSStateFields{}, fmt.Errorf("sui chain %d not found in state", chainSelector)
 	}
-	return state.MCMSState(input.Qualifier == fastCurseQualifier), nil
+	return state.MCMSState(isFastCurseMCMSQualifier(input.Qualifier)), nil
+}
+
+func isFastCurseMCMSQualifier(qualifier string) bool {
+	switch strings.TrimSpace(qualifier) {
+	case fastCurseQualifier, cciputils.UltraFastCurseMCMSQualifier, devenvFastCurseQualifier:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *MCMSReader) GetChainMetadata(e cldf.Environment, chainSelector uint64, input mcms_utils.Input) (mcmstypes.ChainMetadata, error) {

--- a/deployment/adapters/mcmsreader_test.go
+++ b/deployment/adapters/mcmsreader_test.go
@@ -37,6 +37,52 @@ const (
 	testSlowMcmsDeployer  = "0x0909090909090909090909090909090909090909090909090909090909090909"
 )
 
+func TestMCMSReader_FastCurseQualifiers_SelectFastMCMS(t *testing.T) {
+	t.Parallel()
+
+	selector := cselectors.SUI_TESTNET.Selector
+	ab := cldf.NewMemoryAddressBook()
+	require.NoError(t, ab.Save(selector, testMcmsReaderCCIPPackageID, cldf.NewTypeAndVersion(deployment.SuiCCIPType, deployment.Version1_0_0)))
+	require.NoError(t, ab.Save(selector, testMcmsReaderCCIPObjectRef, cldf.NewTypeAndVersion(deployment.SuiCCIPObjectRefType, deployment.Version1_0_0)))
+	require.NoError(t, deployment.StoreMCMSInAddressBook(ab, selector, mcmsops.DeployMCMSSeqOutput{
+		PackageId: testFastMcmsPackageID,
+		Objects: mcmsops.DeployMCMSObjects{
+			McmsMultisigStateObjectId:   testFastMcmsState,
+			McmsRegistryObjectId:        testFastMcmsRegistry,
+			McmsAccountStateObjectId:    testFastMcmsAccount,
+			McmsAccountOwnerCapObjectId: testFastMcmsOwnerCap,
+			TimelockObjectId:            testFastMcmsTimelock,
+			McmsDeployerStateObjectId:   testFastMcmsDeployer,
+		},
+	}, deployment.MCMSInstanceFastCurse))
+
+	env := cldf.Environment{
+		ExistingAddresses: ab,
+		BlockChains: cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
+			selector: cldfsui.Chain{ChainMetadata: cldfsui.ChainMetadata{Selector: selector}},
+		}),
+	}
+
+	reader := &adapters.MCMSReader{}
+	for _, qualifier := range []string{"RMNMCMS", "UltraFastCurse", "fastcurse-devenv-curse"} {
+		t.Run(qualifier, func(t *testing.T) {
+			t.Parallel()
+			input := ccipmcms.Input{
+				Qualifier:      qualifier,
+				TimelockAction: mcmstypes.TimelockActionBypass,
+			}
+
+			timelockRef, err := reader.GetTimelockRef(env, selector, input)
+			require.NoError(t, err)
+			require.Equal(t, testFastMcmsTimelock, timelockRef.Address)
+
+			mcmsRef, err := reader.GetMCMSRef(env, selector, input)
+			require.NoError(t, err)
+			require.Equal(t, testFastMcmsState, mcmsRef.Address)
+		})
+	}
+}
+
 func TestMCMSReader_RMNMCMSQualifier_SelectsFastMCMS(t *testing.T) {
 	t.Parallel()
 

--- a/deployment/lanes/adapter.go
+++ b/deployment/lanes/adapter.go
@@ -13,8 +13,9 @@ import (
 var suiFamilySelector = [4]byte{0xc4, 0xe0, 0x59, 0x53}
 
 // SuiAdapter implements laneapi.LaneAdapter for Sui CCIP 1.6.0 lanes.
-// Package IDs are resolved from addresses.json via LoadOnchainStatesui; the ds
-// parameter is unused. ConnectChains must run inside WithConnectChainsEnvironment.
+// Package IDs are resolved via LoadOnchainStatesui (datastore address refs first,
+// legacy addresses.json fallback); the ds parameter is unused.
+// ConnectChains must run inside WithConnectChainsEnvironment.
 type SuiAdapter struct{}
 
 func (a *SuiAdapter) GetOnRampAddress(_ datastore.DataStore, chainSelector uint64) ([]byte, error) {

--- a/deployment/lanes/env.go
+++ b/deployment/lanes/env.go
@@ -9,7 +9,8 @@ import (
 
 // connectChainsEnv carries the active CLDF environment while ConnectChains runs.
 // LaneAdapter address getters only receive datastore.DataStore, not Environment, so
-// Sui resolves package IDs from addresses.json via LoadOnchainStatesui using this scope.
+// Sui resolves package IDs from LoadOnchainStatesui (datastore address refs first,
+// legacy addresses.json fallback) using this scope.
 //
 // CLD must invoke ConnectChains inside WithConnectChainsEnvironment. Other chain
 // families are unaffected.
@@ -20,7 +21,7 @@ var connectChainsEnv struct {
 }
 
 // WithConnectChainsEnvironment runs fn while SuiAdapter address getters can read
-// ExistingAddresses from the given environment.
+// chain metadata from the given environment.
 func WithConnectChainsEnvironment(e cldf.Environment, fn func() error) error {
 	connectChainsEnv.mu.Lock()
 	connectChainsEnv.env = e

--- a/deployment/state.go
+++ b/deployment/state.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -413,19 +412,17 @@ func (s CCIPChainState) GenerateView(e *cldf.Environment, selector uint64, chain
 	return chainView, g.Wait()
 }
 
-// LoadOnchainStatesui loads chain state for sui chains from env
+// LoadOnchainStatesui loads chain state for Sui chains from env.
+// Address metadata is read from env.DataStore (address_refs.json) when refs exist
+// for a chain; otherwise it falls back to env.ExistingAddresses (addresses.json).
 func LoadOnchainStatesui(env cldf.Environment) (map[uint64]CCIPChainState, error) {
 	rawChains := env.BlockChains.SuiChains()
 	suiChains := make(map[uint64]CCIPChainState)
 
 	for chainSelector := range rawChains {
-		addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+		addresses, err := addressesForSuiChain(env, chainSelector)
 		if err != nil {
-			// Chain not found in address book, initialize empty state
-			if !errors.Is(err, cldf.ErrChainNotFound) {
-				return nil, fmt.Errorf("failed to get addresses for chain %d: %w", chainSelector, err)
-			}
-			addresses = make(map[string]cldf.TypeAndVersion)
+			return nil, err
 		}
 
 		chainState, err := loadsuiChainStateFromAddresses(addresses)

--- a/deployment/state_sources.go
+++ b/deployment/state_sources.go
@@ -1,0 +1,78 @@
+package deployment
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	fdatastore "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+// addressesForSuiChain loads address/type metadata for one Sui chain.
+// It prefers env.DataStore address refs (address_refs.json) when present and
+// falls back to env.ExistingAddresses (addresses.json).
+func addressesForSuiChain(env cldf.Environment, chainSelector uint64) (map[string]cldf.TypeAndVersion, error) {
+	if addresses, ok, err := addressesForSuiChainFromDatastore(env, chainSelector); err != nil {
+		return nil, err
+	} else if ok {
+		return addresses, nil
+	}
+	return addressesForSuiChainFromAddressBook(env, chainSelector)
+}
+
+func addressesForSuiChainFromDatastore(env cldf.Environment, chainSelector uint64) (map[string]cldf.TypeAndVersion, bool, error) {
+	if env.DataStore == nil {
+		return nil, false, nil
+	}
+	refs := env.DataStore.Addresses().Filter(fdatastore.AddressRefByChainSelector(chainSelector))
+	if len(refs) == 0 {
+		return nil, false, nil
+	}
+	addresses := make(map[string]cldf.TypeAndVersion, len(refs))
+	for _, ref := range refs {
+		tv, err := typeAndVersionFromDatastoreRef(ref)
+		if err != nil {
+			return nil, false, fmt.Errorf("datastore ref %s chain %d: %w", ref.Address, chainSelector, err)
+		}
+		addresses[ref.Address] = tv
+	}
+	return addresses, true, nil
+}
+
+func addressesForSuiChainFromAddressBook(env cldf.Environment, chainSelector uint64) (map[string]cldf.TypeAndVersion, error) {
+	addresses, err := env.ExistingAddresses.AddressesForChain(chainSelector)
+	if err != nil {
+		if errors.Is(err, cldf.ErrChainNotFound) {
+			return make(map[string]cldf.TypeAndVersion), nil
+		}
+		return nil, fmt.Errorf("failed to get addresses for chain %d: %w", chainSelector, err)
+	}
+	return addresses, nil
+}
+
+func typeAndVersionFromDatastoreRef(ref fdatastore.AddressRef) (cldf.TypeAndVersion, error) {
+	if strings.TrimSpace(string(ref.Type)) == "" {
+		return cldf.TypeAndVersion{}, fmt.Errorf("contract type is empty")
+	}
+	version := Version1_0_0
+	if ref.Version != nil {
+		version = *ref.Version
+	}
+	tv := cldf.NewTypeAndVersion(cldf.ContractType(ref.Type), version)
+	for _, label := range datastoreRefLabels(ref) {
+		tv.Labels.Add(label)
+	}
+	return tv, nil
+}
+
+func datastoreRefLabels(ref fdatastore.AddressRef) []string {
+	if !ref.Labels.IsEmpty() {
+		return ref.Labels.List()
+	}
+	qualifier := strings.TrimSpace(ref.Qualifier)
+	if qualifier == MCMSFastCurseLabel {
+		return []string{MCMSFastCurseLabel}
+	}
+	return nil
+}

--- a/deployment/state_sources_test.go
+++ b/deployment/state_sources_test.go
@@ -1,0 +1,134 @@
+package deployment
+
+import (
+	"testing"
+
+	cselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
+	fdatastore "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOnchainStatesui_prefersDatastoreOverAddressBook(t *testing.T) {
+	t.Parallel()
+
+	selector := cselectors.SUI_TESTNET.Selector
+	dsCCIP := "0xdatastore-ccip-package"
+	abCCIP := "0xaddressbook-ccip-package"
+	objectRef := "0xccip-object-ref"
+
+	ds := fdatastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Upsert(fdatastore.AddressRef{
+		ChainSelector: selector,
+		Address:       dsCCIP,
+		Type:          fdatastore.ContractType(SuiCCIPType),
+		Version:       &Version1_0_0,
+	}))
+	require.NoError(t, ds.Addresses().Upsert(fdatastore.AddressRef{
+		ChainSelector: selector,
+		Address:       objectRef,
+		Type:          fdatastore.ContractType(SuiCCIPObjectRefType),
+		Version:       &Version1_0_0,
+	}))
+
+	ab := cldf.NewMemoryAddressBook()
+	require.NoError(t, ab.Save(selector, abCCIP, cldf.NewTypeAndVersion(SuiCCIPType, Version1_0_0)))
+
+	got, err := LoadOnchainStatesui(cldf.Environment{
+		DataStore:         ds.Seal(),
+		ExistingAddresses: ab,
+		BlockChains: chain.NewBlockChains(map[uint64]chain.BlockChain{
+			selector: sui.Chain{},
+		}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, dsCCIP, got[selector].CCIPAddress)
+	require.Equal(t, objectRef, got[selector].CCIPObjectRef)
+}
+
+func TestLoadOnchainStatesui_fallsBackToAddressBookWhenDatastoreEmpty(t *testing.T) {
+	t.Parallel()
+
+	selector := cselectors.SUI_TESTNET.Selector
+	abCCIP := "0xaddressbook-ccip-package"
+
+	ab := cldf.NewMemoryAddressBook()
+	require.NoError(t, ab.Save(selector, abCCIP, cldf.NewTypeAndVersion(SuiCCIPType, Version1_0_0)))
+
+	got, err := LoadOnchainStatesui(cldf.Environment{
+		DataStore:         fdatastore.NewMemoryDataStore().Seal(),
+		ExistingAddresses: ab,
+		BlockChains: chain.NewBlockChains(map[uint64]chain.BlockChain{
+			selector: sui.Chain{},
+		}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, abCCIP, got[selector].CCIPAddress)
+}
+
+func TestLoadOnchainStatesui_fromDatastore_fastcurseLabels(t *testing.T) {
+	t.Parallel()
+
+	selector := cselectors.SUI_TESTNET.Selector
+
+	ds := fdatastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Upsert(fdatastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0xslow_package",
+		Type:          fdatastore.ContractType(SuiMcmsPackageIDType),
+		Version:       &Version1_0_0,
+	}))
+	require.NoError(t, ds.Addresses().Upsert(fdatastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0xfast_package",
+		Type:          fdatastore.ContractType(SuiMcmsPackageIDType),
+		Version:       &Version1_0_0,
+		Qualifier:     MCMSFastCurseLabel,
+		Labels:        fdatastore.NewLabelSet(MCMSFastCurseLabel),
+	}))
+
+	got, err := LoadOnchainStatesui(cldf.Environment{
+		DataStore: ds.Seal(),
+		BlockChains: chain.NewBlockChains(map[uint64]chain.BlockChain{
+			selector: sui.Chain{},
+		}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xslow_package", got[selector].MCMSPackageID)
+	require.Equal(t, "0xfast_package", got[selector].FastCurseMCMSPackageID)
+}
+
+func TestLoadOnchainStatesui_fromDatastore_fastcurseQualifierFallback(t *testing.T) {
+	t.Parallel()
+
+	selector := cselectors.SUI_TESTNET.Selector
+
+	ds := fdatastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Upsert(fdatastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0xfast_package",
+		Type:          fdatastore.ContractType(SuiMcmsPackageIDType),
+		Version:       &Version1_0_0,
+		Qualifier:     MCMSFastCurseLabel,
+	}))
+
+	got, err := LoadOnchainStatesui(cldf.Environment{
+		DataStore: ds.Seal(),
+		BlockChains: chain.NewBlockChains(map[uint64]chain.BlockChain{
+			selector: sui.Chain{},
+		}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xfast_package", got[selector].FastCurseMCMSPackageID)
+}
+
+func TestDatastoreRefLabels_ignoresAddressTypeQualifier(t *testing.T) {
+	t.Parallel()
+
+	labels := datastoreRefLabels(fdatastore.AddressRef{
+		Qualifier: "0x5ef4b483da6644c84aa78eae4f51a9bfb1fb4554d5134ac98892e931fcbdd6bf-SuiCCIP",
+	})
+	require.Empty(t, labels)
+}


### PR DESCRIPTION
this PR:
1. in fastcurse, load Sui addresses from datastore (address_refs) first. if failed, load Sui addresses from address book
2. route MCMS qualifier: UltraFastCurse, RMNMCMS, and fastcurse-devenv-curse to fast MCMS. other qualifiers will be routed to slow MCMS