### PR TITLE
set real versions for replaced modules

### DIFF
--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260624154507-ea7ff77a0ddb
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
 	github.com/smartcontractkit/chainlink-deployments-framework v0.109.1-0.20260604174622-e26b8cddfa0a
-	github.com/smartcontractkit/chainlink-sui v0.0.0
+	github.com/smartcontractkit/chainlink-sui v0.0.0-20260713213943-b588203d6679
 	github.com/smartcontractkit/mcms v0.45.2-0.20260604181544-da0bd7da623d
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.53.0

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260625091148-e5618f5682ee
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260713194119-2689c5708c8b
 	github.com/smartcontractkit/chainlink-deployments-framework v0.111.1-0.20260612191326-e31c0ae4cd54
-	github.com/smartcontractkit/chainlink-sui v0.0.0
-	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-00010101000000-000000000000
+	github.com/smartcontractkit/chainlink-sui v0.0.0-20260713213943-b588203d6679
+	github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260713213943-b588203d6679
 	github.com/smartcontractkit/mcms v0.48.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -8,7 +8,7 @@ replace github.com/smartcontractkit/chainlink-sui => ../
 
 replace github.com/smartcontractkit/chainlink-sui/deployment => ../deployment
 
-require github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-00010101000000-000000000000
+require github.com/smartcontractkit/chainlink-sui/deployment v0.0.0-20260713213943-b588203d6679
 
 require (
 	filippo.io/edwards25519 v1.1.1 // indirect


### PR DESCRIPTION
Using `v0.0.0` and relying on the local replace causes cascading effects on all importers, requiring them to use explicit replaces to even be able to use the tooling. We should just set real versions instead. This is a strict improvement, even when the version is stale (and that happens at each importer regardless).