### PR TITLE
(feature) Update events DB records to enable total ordering

### DIFF
--- a/relayer/chainreader/database/database.go
+++ b/relayer/chainreader/database/database.go
@@ -62,15 +62,15 @@ type EventRecord struct {
 	EventHandle         string
 	// TxIndex is the position of the transaction within its checkpoint, as returned by the node.
 	// Together with (block_height, event_offset) it provides a total order across all events.
-	TxIndex     uint64
-	EventOffset uint64
-	TxDigest    string
-	BlockVersion        uint64
-	BlockHeight         string
-	BlockHash           []byte
-	BlockTimestamp      uint64
-	Data                map[string]any
-	IsSynthetic         bool
+	TxIndex        uint64
+	EventOffset    uint64
+	TxDigest       string
+	BlockVersion   uint64
+	BlockHeight    string
+	BlockHash      []byte
+	BlockTimestamp uint64
+	Data           map[string]any
+	IsSynthetic    bool
 }
 
 func (store *DBStore) InsertEvents(ctx context.Context, records []EventRecord) error {

--- a/relayer/chainreader/database/database.go
+++ b/relayer/chainreader/database/database.go
@@ -60,8 +60,11 @@ func (store *DBStore) EnsureSchema(ctx context.Context) error {
 type EventRecord struct {
 	EventAccountAddress string
 	EventHandle         string
-	EventOffset         uint64
-	TxDigest            string
+	// TxIndex is the position of the transaction within its checkpoint, as returned by the node.
+	// Together with (block_height, event_offset) it provides a total order across all events.
+	TxIndex     uint64
+	EventOffset uint64
+	TxDigest    string
 	BlockVersion        uint64
 	BlockHeight         string
 	BlockHash           []byte
@@ -92,6 +95,7 @@ func (store *DBStore) InsertEvents(ctx context.Context, records []EventRecord) e
 			record.BlockTimestamp,
 			data,
 			record.IsSynthetic,
+			record.TxIndex,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert event (handle: %s, offset: %d): %w", record.EventHandle, record.EventOffset, err)
@@ -122,16 +126,16 @@ func (store *DBStore) QueryEvents(ctx context.Context, eventAccountAddress, even
 		}
 	}
 
+	direction := "DESC" // default to descending order if no sort is provided
 	if len(limitAndSort.SortBy) > 0 {
-		direction := "ASC"
+		direction = "ASC"
 		if sortDir, ok := limitAndSort.SortBy[0].(query.SortBySequence); ok && sortDir.GetDirection() == query.Desc {
 			direction = "DESC"
 		}
-		baseSQL += " ORDER BY (block_height::BIGINT, event_offset) " + direction
-	} else {
-		// default to descending order if no sort is provided
-		baseSQL += " ORDER BY (block_height::BIGINT, event_offset) DESC"
 	}
+	// (block_height, tx_idx, event_offset) totally orders events as returned by the node:
+	// checkpoint, then transaction position within the checkpoint, then event position within the tx.
+	baseSQL += fmt.Sprintf(" ORDER BY block_height::BIGINT %s, tx_idx %s, event_offset %s", direction, direction, direction)
 
 	limit := limitAndSort.Limit.Count
 	if limit > MaxEventsQueryLimit {
@@ -155,7 +159,7 @@ func (store *DBStore) QueryEvents(ctx context.Context, eventAccountAddress, even
 	for rows.Next() {
 		var record EventRecord
 		var dataBytes []byte
-		err := rows.Scan(&record.EventAccountAddress, &record.EventHandle, &record.EventOffset, &record.BlockVersion, &record.BlockHeight, &record.BlockHash, &record.BlockTimestamp, &record.TxDigest, &dataBytes)
+		err := rows.Scan(&record.EventAccountAddress, &record.EventHandle, &record.TxIndex, &record.EventOffset, &record.BlockVersion, &record.BlockHeight, &record.BlockHash, &record.BlockTimestamp, &record.TxDigest, &dataBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan event record: %w", err)
 		}

--- a/relayer/chainreader/database/database_queries.go
+++ b/relayer/chainreader/database/database_queries.go
@@ -20,6 +20,7 @@ const (
 		UNIQUE (event_account_address, event_handle, tx_digest, event_offset)
 	);
     ALTER TABLE sui.events ADD COLUMN IF NOT EXISTS is_synthetic BOOLEAN DEFAULT FALSE;
+    ALTER TABLE sui.events ADD COLUMN IF NOT EXISTS tx_idx BIGINT NOT NULL DEFAULT 0;
     `
 
 	CreateTransmitterCursorsTable = `
@@ -34,6 +35,7 @@ const (
 	CREATE INDEX IF NOT EXISTS idx_events_offset ON sui.events(event_account_address, event_handle, event_offset);
 	CREATE INDEX IF NOT EXISTS idx_events_data_gin ON sui.events USING gin(data);
 	CREATE INDEX IF NOT EXISTS idx_events_account_handle_id ON sui.events(event_account_address, event_handle, id DESC);
+	CREATE INDEX IF NOT EXISTS idx_events_order ON sui.events(event_account_address, event_handle, (block_height::BIGINT), tx_idx, event_offset);
 	`
 
 	InsertEvent = `
@@ -47,13 +49,14 @@ const (
 		block_hash,
 		block_timestamp,
 		data,
-		is_synthetic
-	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		is_synthetic,
+		tx_idx
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	ON CONFLICT DO NOTHING;
     `
 
 	QueryEventsBase = `
-	SELECT event_account_address, event_handle, event_offset, block_version, block_height, block_hash, block_timestamp, tx_digest, data
+	SELECT event_account_address, event_handle, tx_idx, event_offset, block_version, block_height, block_hash, block_timestamp, tx_digest, data
 	FROM sui.events
 	WHERE event_account_address = $1 AND event_handle = $2
     `

--- a/relayer/chainreader/indexer/chain_poller.go
+++ b/relayer/chainreader/indexer/chain_poller.go
@@ -475,7 +475,7 @@ func (cp *ChainPoller) filterEvents(meta CheckpointMeta, transactions []*suirpcv
 		selectorMap[key] = sel
 	}
 
-	for _, tx := range transactions {
+	for txIdx, tx := range transactions {
 		txDigest := tx.GetDigest()
 		if txDigest == "" {
 			continue
@@ -500,6 +500,7 @@ func (cp *ChainPoller) filterEvents(meta CheckpointMeta, transactions []*suirpcv
 					item := CheckpointEventItem{
 						Event:      event,
 						TxDigest:   txDigest,
+						TxIndex:    uint32(txIdx),
 						EventIndex: uint32(eventIdx),
 					}
 					batch.Events = append(batch.Events, item)

--- a/relayer/chainreader/indexer/chain_poller.go
+++ b/relayer/chainreader/indexer/chain_poller.go
@@ -730,8 +730,8 @@ func (cp *ChainPoller) filterEvents(meta CheckpointMeta, transactions []*suirpcv
 	}
 
 	for txIdx, tx := range transactions {
-    cp.logger.Debugw("Processing transaction for event filtering", "transaction", tx.GetDigest())
-    
+		cp.logger.Debugw("Processing transaction for event filtering", "transaction", tx.GetDigest())
+
 		txDigest := tx.GetDigest()
 		if txDigest == "" {
 			cp.logger.Warnf("Transaction digest is empty, skipping")

--- a/relayer/chainreader/indexer/checkpoint_batch.go
+++ b/relayer/chainreader/indexer/checkpoint_batch.go
@@ -13,6 +13,7 @@ type CheckpointMeta struct {
 type CheckpointEventItem struct {
 	Event      *suirpcv2.Event
 	TxDigest   string
+	TxIndex    uint32 // position of the transaction within the checkpoint, as returned by the node
 	EventIndex uint32 // position within tx events list (for offset stability)
 }
 

--- a/relayer/chainreader/indexer/events_indexer.go
+++ b/relayer/chainreader/indexer/events_indexer.go
@@ -242,6 +242,7 @@ func (eIndexer *EventsIndexer) processEventsForHandle(
 		record := database.EventRecord{
 			EventAccountAddress: packageID,
 			EventHandle:         handle,
+			TxIndex:             uint64(item.TxIndex),
 			EventOffset:         uint64(item.EventIndex),
 			TxDigest:            txDigestHex,
 			BlockVersion:        0,

--- a/relayer/chainreader/indexer/transactions_indexer.go
+++ b/relayer/chainreader/indexer/transactions_indexer.go
@@ -271,12 +271,12 @@ func (tIndexer *TransactionsIndexer) ProcessCheckpointTransactions(ctx context.C
 
 	var records []database.EventRecord
 
-	for _, tx := range batch.Transactions {
+	for txIdx, tx := range batch.Transactions {
 		if !tIndexer.shouldProcessTransaction(tx, transmitterSet) {
 			continue
 		}
 
-		record, err := tIndexer.processFailedTransaction(ctx, tx, eventHandle, eventAccountAddress, latestOfframpPackageId, batch.Checkpoint)
+		record, err := tIndexer.processFailedTransaction(ctx, tx, uint64(txIdx), eventHandle, eventAccountAddress, latestOfframpPackageId, batch.Checkpoint)
 		if err != nil {
 			tIndexer.logger.Errorw("Failed to process failed transaction",
 				"txDigest", tx.GetDigest(),
@@ -340,6 +340,7 @@ func (tIndexer *TransactionsIndexer) shouldProcessTransaction(tx *suirpcv2.Execu
 func (tIndexer *TransactionsIndexer) processFailedTransaction(
 	ctx context.Context,
 	tx *suirpcv2.ExecutedTransaction,
+	txIdx uint64,
 	eventHandle string,
 	eventAccountAddress string,
 	latestOfframpPackageID string,
@@ -505,7 +506,8 @@ func (tIndexer *TransactionsIndexer) processFailedTransaction(
 	record := database.EventRecord{
 		EventAccountAddress: eventAccountAddress,
 		EventHandle:         eventHandle,
-		EventOffset:         0, // Synthetic events have offset 0
+		TxIndex:             txIdx, // position of the failed tx within the checkpoint
+		EventOffset:         0,     // Synthetic events have offset 0
 		TxDigest:            txDigestHex,
 		BlockVersion:        0,
 		BlockHeight:         strconv.FormatUint(checkpoint.SequenceNumber, 10),


### PR DESCRIPTION
## Describe your changes

* Add a `tx_idx` to `sui.events` and populate it during event indexing / ingestion flow.
* Update DB queries to always use a composite ORDER BY which includes the newly added `tx_idx`.


## Issue ticket number and link

> ..


## Describe highly relevant files or code snippets that are critical in the review

> ..


## Are there other PRs that should be merged first?

> ..
