### PR TITLE
MCMS Sui entrypoint encoder unmapped callbacks

### DIFF
--- a/bindings/mcms_encoder.go
+++ b/bindings/mcms_encoder.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-sui/bindings/bind"
 	module_fee_quoter "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/fee_quoter"
+	module_receiver_registry "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/receiver_registry"
 	module_rmn_remote "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/rmn_remote"
 	module_state_object "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/state_object"
 	module_token_admin_registry "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip/token_admin_registry"
@@ -21,6 +22,7 @@ import (
 	module_lock_release_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/lock_release_token_pool"
 	module_managed_token_pool "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/ccip_token_pools/managed_token_pool"
 	module_managed_token "github.com/smartcontractkit/chainlink-sui/bindings/generated/ccip/managed_token/managed_token"
+	"github.com/smartcontractkit/chainlink-sui/codec"
 )
 
 var SuiAddressLength = 32
@@ -53,15 +55,15 @@ func overrideCall(call *bind.EncodedCall, module, function string) *bind.Encoded
 // MCMS SDK will call this to encode the entrypoint call
 // Data is the raw BCS encoded bytes of the final function call
 func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *transaction.Argument, target, module, function, stateObjID string, data []byte, typeArgs []string) (*bind.EncodedCall, error) {
-	clock := bind.Object{Id: "0x6"}
-	stateObj := bind.Object{Id: stateObjID}
-	registryObj := bind.Object{Id: e.registryObjID}
-	deployerStateObj := bind.Object{Id: e.deployerStateObjID}
+	clock := codec.Object{Id: "0x6"}
+	stateObj := codec.Object{Id: stateObjID}
+	registryObj := codec.Object{Id: e.registryObjID}
+	deployerStateObj := codec.Object{Id: e.deployerStateObjID}
 
 	encodeWithCCIPObjectRefAndState := func() (*bind.EncodedCall, error) {
 		// Deserialize the ccip object ref (always the first 32 bytes)
 		ccipRefBytes := deserializeFirst32Bytes(data)
-		ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
+		ccipRef := codec.Object{Id: toHexString(ccipRefBytes)}
 
 		offramp, err := module_offramp.NewOfframp(target, nil)
 		if err != nil {
@@ -128,34 +130,34 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		switch function {
 		case "update_prices_with_owner_cap":
 			ccipRefBytes := deserializeFirst32Bytes(data)
-			ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
+			ccipRef := codec.Object{Id: toHexString(ccipRefBytes)}
 			if ccipRef.Id != stateObj.Id {
 				return nil, fmt.Errorf("ccip ref (%s) does not match state object (%s)", ccipRef.Id, stateObj.Id)
 			}
 
 			return feeQuoter.Encoder().McmsUpdatePricesWithOwnerCapWithArgs(ccipRef, registryObj, clock, executingCallbackParams)
 		case "apply_fee_token_updates":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return feeQuoter.Encoder().McmsApplyFeeTokenUpdatesWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "apply_dest_chain_config_updates":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return feeQuoter.Encoder().McmsApplyDestChainConfigUpdatesWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "apply_token_transfer_fee_config_updates":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return feeQuoter.Encoder().McmsApplyTokenTransferFeeConfigUpdatesWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "apply_premium_multiplier_wei_per_eth_updates":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return feeQuoter.Encoder().McmsApplyPremiumMultiplierWeiPerEthUpdatesWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "new_fee_quoter_cap_and_transfer":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return feeQuoter.Encoder().McmsNewFeeQuoterCapAndTransferWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "destroy_fee_quoter_cap":
 			deserializer := bcs.NewDeserializer(data)
 			deserializer.ReadFixedBytes(SuiAddressLength)
 			deserializer.ReadFixedBytes(SuiAddressLength)
 			capBytes := deserializer.ReadFixedBytes(SuiAddressLength)
-			ccipRef := bind.Object{Id: stateObjID}
-			c := bind.Object{Id: toHexString(capBytes)}
+			ccipRef := codec.Object{Id: stateObjID}
+			c := codec.Object{Id: toHexString(capBytes)}
 			return feeQuoter.Encoder().McmsDestroyFeeQuoterCapWithArgs(ccipRef, registryObj, executingCallbackParams, c)
 		default:
 			return nil, fmt.Errorf("unsupported fee_quoter MCMS function: %q", function)
@@ -174,26 +176,61 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			return moduleStateObj.Encoder().McmsAddAllowedModulesWithArgs(registryObj, executingCallbackParams)
 		case "remove_allowed_modules":
 			return moduleStateObj.Encoder().McmsRemoveAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "execute_ownership_transfer":
+			return moduleStateObj.Encoder().McmsExecuteOwnershipTransferWithArgs(stateObj, registryObj, deployerStateObj, executingCallbackParams)
+		case "transfer_ownership":
+			return moduleStateObj.Encoder().McmsTransferOwnershipWithArgs(stateObj, registryObj, executingCallbackParams)
+		case "add_package_id":
+			return moduleStateObj.Encoder().McmsAddPackageIdWithArgs(stateObj, registryObj, executingCallbackParams)
+		case "remove_package_id":
+			return moduleStateObj.Encoder().McmsRemovePackageIdWithArgs(stateObj, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported state_object MCMS function: %q", function)
+		}
+
+	// RECEIVER REGISTRY
+	case "receiver_registry":
+		receiverRegistry, err := module_receiver_registry.NewReceiverRegistry(target, nil)
+		if err != nil {
+			return nil, err
+		}
+		switch function {
+		case "unregister_receiver":
+			return receiverRegistry.Encoder().McmsUnregisterReceiverWithArgs(stateObj, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported receiver_registry MCMS function: %q", function)
 		}
 
 	// OFFRAMP
 	case "offramp":
+		offramp, err := module_offramp.NewOfframp(target, nil)
+		if err != nil {
+			return nil, err
+		}
 		switch function {
 		case "set_dynamic_config",
 			"apply_source_chain_config_updates",
 			"set_ocr3_config",
-			"transfer_ownership",
-			"execute_ownership_transfer":
+			"transfer_ownership":
 			return encodeWithCCIPObjectRefAndState()
+		case "execute_ownership_transfer":
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return offramp.Encoder().McmsExecuteOwnershipTransferWithArgs(ccipRef, stateObj, registryObj, deployerStateObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return offramp.Encoder().McmsAddAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return offramp.Encoder().McmsRemoveAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "add_package_id":
+			return offramp.Encoder().McmsAddPackageIdWithArgs(stateObj, registryObj, executingCallbackParams)
+		case "remove_package_id":
+			return offramp.Encoder().McmsRemovePackageIdWithArgs(stateObj, registryObj, executingCallbackParams)
 		case "accept_ownership":
-			offramp, err := module_offramp.NewOfframp(target, nil)
-			if err != nil {
-				return nil, err
-			}
-			ccipObjectRef := bind.Object{Id: stateObjID} // For accept_ownership, the state object is the CCIP object ref
-			stateObj := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipObjectRef := codec.Object{Id: stateObjID} // For accept_ownership, the state object is the CCIP object ref
+			acceptStateObj := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 
-			return offramp.Encoder().McmsAcceptOwnershipWithArgs(ccipObjectRef, stateObj, registryObj, executingCallbackParams)
+			return offramp.Encoder().McmsAcceptOwnershipWithArgs(ccipObjectRef, acceptStateObj, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported offramp MCMS function: %q", function)
 		}
 
 	// ONRAMP
@@ -204,21 +241,27 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		}
 		switch function {
 		case "accept_ownership":
-			onramp, err := module_onramp.NewOnramp(target, nil)
-			if err != nil {
-				return nil, err
-			}
-			ccipObjectRef := bind.Object{Id: stateObjID} // For accept_ownership, the state object is the CCIP object ref
-			stateObj := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipObjectRef := codec.Object{Id: stateObjID} // For accept_ownership, the state object is the CCIP object ref
+			acceptStateObj := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 
-			return onramp.Encoder().McmsAcceptOwnershipWithArgs(ccipObjectRef, stateObj, registryObj, executingCallbackParams)
+			return onramp.Encoder().McmsAcceptOwnershipWithArgs(ccipObjectRef, acceptStateObj, registryObj, executingCallbackParams)
 
 		case "set_dynamic_config",
 			"apply_dest_chain_config_updates",
 			"apply_allowlist_updates",
-			"transfer_ownership",
-			"execute_ownership_transfer":
+			"transfer_ownership":
 			return encodeWithCCIPObjectRefAndState()
+		case "execute_ownership_transfer":
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return onramp.Encoder().McmsExecuteOwnershipTransferWithArgs(ccipRef, stateObj, registryObj, deployerStateObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return onramp.Encoder().McmsAddAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return onramp.Encoder().McmsRemoveAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "add_package_id":
+			return onramp.Encoder().McmsAddPackageIdWithArgs(stateObj, registryObj, executingCallbackParams)
+		case "remove_package_id":
+			return onramp.Encoder().McmsRemovePackageIdWithArgs(stateObj, registryObj, executingCallbackParams)
 		case "withdraw_fee_tokens":
 			deserializer := bcs.NewDeserializer(data)
 			ccipRefBytes := deserializer.ReadFixedBytes(SuiAddressLength)
@@ -226,14 +269,16 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			deserializer.ReadFixedBytes(SuiAddressLength) // skip owner cap, we don't need it
 			feeTokenMetadata := deserializer.ReadFixedBytes(SuiAddressLength)
 
-			coinMetadata := bind.Object{Id: toHexString(feeTokenMetadata)}
-			ccipRef := bind.Object{Id: toHexString(ccipRefBytes)}
+			coinMetadata := codec.Object{Id: toHexString(feeTokenMetadata)}
+			ccipRef := codec.Object{Id: toHexString(ccipRefBytes)}
 
 			if toHexString(state) != stateObj.Id {
 				return nil, fmt.Errorf("state (%s) does not match state object (%s)", toHexString(state), stateObj.Id)
 			}
 
 			return onramp.Encoder().McmsWithdrawFeeTokensWithArgs(typeArgs, ccipRef, stateObj, registryObj, coinMetadata, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported onramp MCMS function: %q", function)
 		}
 
 	// ROUTER
@@ -245,6 +290,18 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		switch function {
 		case "accept_ownership":
 			return router.Encoder().McmsAcceptOwnershipWithArgs(stateObj, registryObj, executingCallbackParams)
+		case "transfer_ownership":
+			return router.Encoder().McmsTransferOwnershipWithArgs(stateObj, registryObj, executingCallbackParams)
+		case "execute_ownership_transfer":
+			return router.Encoder().McmsExecuteOwnershipTransferWithArgs(stateObj, registryObj, deployerStateObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return router.Encoder().McmsAddAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return router.Encoder().McmsRemoveAllowedModulesWithArgs(registryObj, executingCallbackParams)
+		case "set_on_ramps":
+			return router.Encoder().McmsSetOnRampsWithArgs(stateObj, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported router MCMS function: %q", function)
 		}
 
 	// BURN MINT TOKEN POOL
@@ -268,6 +325,15 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		case "set_chain_rate_limiter_configs",
 			"set_chain_rate_limiter_config":
 			return encodeDefaultWithTypeArgsAndClock()
+		case "destroy_token_pool":
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return burnMintTokenPool.Encoder().McmsDestroyTokenPoolWithArgs(typeArgs, ccipRef, stateObj, registryObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return burnMintTokenPool.Encoder().McmsAddAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return burnMintTokenPool.Encoder().McmsRemoveAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported burn_mint_token_pool MCMS function: %q", function)
 		}
 
 	// LOCK RELEASE TOKEN POOL
@@ -292,6 +358,27 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		case "set_chain_rate_limiter_configs",
 			"set_chain_rate_limiter_config":
 			return encodeDefaultWithTypeArgsAndClock()
+		case "destroy_rebalancer_cap":
+			return lockReleaseTokenPool.Encoder().McmsDestroyRebalancerCapWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
+		case "withdraw_liquidity":
+			return lockReleaseTokenPool.Encoder().McmsWithdrawLiquidityWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
+		case "provide_liquidity":
+			deserializer := bcs.NewDeserializer(data)
+			deserializer.ReadFixedBytes(SuiAddressLength) // skip state, already known
+			deserializer.ReadFixedBytes(SuiAddressLength) // skip rebalancer cap, resolved on-chain
+			coinBytes := deserializer.ReadFixedBytes(SuiAddressLength)
+			coinObj := codec.Object{Id: toHexString(coinBytes)}
+
+			return lockReleaseTokenPool.Encoder().McmsProvideLiquidityWithArgs(typeArgs, stateObj, registryObj, coinObj, executingCallbackParams)
+		case "destroy_token_pool":
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return lockReleaseTokenPool.Encoder().McmsDestroyTokenPoolWithArgs(typeArgs, ccipRef, stateObj, registryObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return lockReleaseTokenPool.Encoder().McmsAddAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return lockReleaseTokenPool.Encoder().McmsRemoveAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported lock_release_token_pool MCMS function: %q", function)
 		}
 
 	// MANAGED TOKEN POOL
@@ -316,6 +403,15 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		case "set_chain_rate_limiter_configs",
 			"set_chain_rate_limiter_config":
 			return encodeDefaultWithTypeArgsAndClock()
+		case "destroy_token_pool":
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			return managedTokenPool.Encoder().McmsDestroyTokenPoolWithArgs(typeArgs, ccipRef, stateObj, registryObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return managedTokenPool.Encoder().McmsAddAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return managedTokenPool.Encoder().McmsRemoveAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported managed_token_pool MCMS function: %q", function)
 		}
 
 	// RMN REMOTE
@@ -324,7 +420,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		if err != nil {
 			return nil, err
 		}
-		ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+		ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 		switch function {
 		case "curse", "curse_multiple":
 			entrypointCall, err := rmnRemote.Encoder().McmsCurseMultipleWithArgs(ccipRef, registryObj, executingCallbackParams)
@@ -362,8 +458,8 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			deserializer.ReadFixedBytes(SuiAddressLength)
 			fastRegBytes := deserializer.ReadFixedBytes(SuiAddressLength)
 			curserCapBytes := deserializer.ReadFixedBytes(SuiAddressLength)
-			fastReg := bind.Object{Id: toHexString(fastRegBytes)}
-			curserCap := bind.Object{Id: toHexString(curserCapBytes)}
+			fastReg := codec.Object{Id: toHexString(fastRegBytes)}
+			curserCap := codec.Object{Id: toHexString(curserCapBytes)}
 			entrypointCall, err := rmnRemote.Encoder().McmsRegisterCurserCapWithArgs(ccipRef, registryObj, fastReg, executingCallbackParams, curserCap)
 			if err != nil {
 				return nil, err
@@ -374,7 +470,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			deserializer.ReadFixedBytes(SuiAddressLength)
 			deserializer.ReadFixedBytes(SuiAddressLength)
 			fastRegBytes := deserializer.ReadFixedBytes(SuiAddressLength)
-			fastReg := bind.Object{Id: toHexString(fastRegBytes)}
+			fastReg := codec.Object{Id: toHexString(fastRegBytes)}
 			entrypointCall, err := rmnRemote.Encoder().McmsMintAndRegisterCurserCapWithArgs(ccipRef, registryObj, fastReg, executingCallbackParams)
 			if err != nil {
 				return nil, err
@@ -386,6 +482,8 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			return rmnRemote.Encoder().McmsRegisterCurserCapIdsWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "deregister_curser_cap_ids":
 			return rmnRemote.Encoder().McmsDeregisterCurserCapIdsWithArgs(ccipRef, registryObj, executingCallbackParams)
+		case "set_config":
+			return rmnRemote.Encoder().McmsSetConfigWithArgs(ccipRef, registryObj, executingCallbackParams)
 		default:
 			return nil, fmt.Errorf("unsupported rmn_remote MCMS function: %q", function)
 		}
@@ -398,7 +496,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		}
 		switch function {
 		case "initialize_local_decimals":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return tokenAdminRegistry.Encoder().McmsInitializeLocalDecimalsWithArgs(
 				ccipRef,
 				registryObj,
@@ -407,7 +505,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		case "backfill_local_decimals", "register_pool", "unregister_pool":
 			deserializer := bcs.NewDeserializer(data)
 			deserializer.ReadFixedBytes(SuiAddressLength)
-			ccipRef := bind.Object{Id: toHexString(deserializer.ReadFixedBytes(SuiAddressLength))}
+			ccipRef := codec.Object{Id: toHexString(deserializer.ReadFixedBytes(SuiAddressLength))}
 			switch function {
 			case "backfill_local_decimals":
 				return tokenAdminRegistry.Encoder().McmsBackfillLocalDecimalsWithArgs(
@@ -429,10 +527,10 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 				)
 			}
 		case "transfer_admin_role":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return tokenAdminRegistry.Encoder().McmsTransferAdminRoleWithArgs(ccipRef, registryObj, executingCallbackParams)
 		case "accept_admin_role":
-			ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+			ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 			return tokenAdminRegistry.Encoder().McmsAcceptAdminRoleWithArgs(ccipRef, registryObj, executingCallbackParams)
 		default:
 			return nil, fmt.Errorf("unsupported token_admin_registry MCMS function: %q", function)
@@ -444,7 +542,7 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 		if err != nil {
 			return nil, err
 		}
-		ccipRef := bind.Object{Id: toHexString(deserializeFirst32Bytes(data))}
+		ccipRef := codec.Object{Id: toHexString(deserializeFirst32Bytes(data))}
 		switch function {
 		case "block_version":
 			return upgradeRegistry.Encoder().McmsBlockVersionWithArgs(ccipRef, registryObj, executingCallbackParams)
@@ -475,13 +573,14 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			"set_unlimited_mint_allowances",
 			"blocklist",
 			"unblocklist",
-			"pause":
+			"pause",
+			"unpause":
 			deserializer := bcs.NewDeserializer(data)
 			state := deserializer.ReadFixedBytes(SuiAddressLength)
 			deserializer.ReadFixedBytes(SuiAddressLength) // skip owner cap, we don't need it
 			denyList := deserializer.ReadFixedBytes(SuiAddressLength)
 
-			denyListObj := bind.Object{Id: toHexString(denyList)}
+			denyListObj := codec.Object{Id: toHexString(denyList)}
 
 			if toHexString(state) != stateObj.Id {
 				return nil, fmt.Errorf("state (%s) does not match state object (%s)", toHexString(state), stateObj.Id)
@@ -492,27 +591,20 @@ func (e *CCIPEntrypointArgEncoder) EncodeEntryPointArg(executingCallbackParams *
 			}
 
 			return overrideCall(entrypointCall, module, function), nil
+		case "destroy_managed_token":
+			return managedToken.Encoder().McmsDestroyManagedTokenWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
+		case "transfer_ownership":
+			return managedToken.Encoder().McmsTransferOwnershipWithArgs(typeArgs, stateObj, registryObj, executingCallbackParams)
+		case "execute_ownership_transfer":
+			return managedToken.Encoder().McmsExecuteOwnershipTransferWithArgs(typeArgs, stateObj, registryObj, deployerStateObj, executingCallbackParams)
+		case "add_allowed_modules":
+			return managedToken.Encoder().McmsAddAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		case "remove_allowed_modules":
+			return managedToken.Encoder().McmsRemoveAllowedModulesWithArgs(typeArgs, registryObj, executingCallbackParams)
+		default:
+			return nil, fmt.Errorf("unsupported managed_token MCMS function: %q", function)
 		}
 	}
 
-	// FALLBACK CASE: Use Fee Quoter as it has the most common function signatures
-	// Fallback to fee quoter for any unhandled module/function
-	// This works because most mcms functions have the same signature
-	// state: &State, registry: &Registry, executing_callback_params: &ExecutingCallbackParams
-	// If a function has a different signature, it should be handled explicitly above
-	feeQuoter, err := module_fee_quoter.NewFeeQuoter(target, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	entryPointCall, err := feeQuoter.Encoder().McmsApplyFeeTokenUpdatesWithArgs(
-		stateObj,
-		registryObj,
-		executingCallbackParams,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mcms_entrypoint call: %w", err)
-	}
-
-	return overrideCall(entryPointCall, module, function), nil
+	return nil, fmt.Errorf("unsupported MCMS entrypoint callback: module=%q function=%q", module, function)
 }

--- a/bindings/mcms_encoder_test.go
+++ b/bindings/mcms_encoder_test.go
@@ -250,12 +250,13 @@ func TestEncodeEntryPointArg_FeeQuoter(t *testing.T) {
 
 func TestEncodeEntryPointArg_Offramp(t *testing.T) {
 	encoder := &CCIPEntrypointArgEncoder{
-		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+		registryObjID:      "0x1234567890123456789012345678901234567890123456789012345678901234",
+		deployerStateObjID: "0x8888888888888888888888888888888888888888888888888888888888888888",
 	}
 
 	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
 	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
-	ccipRefID := "0x8888888888888888888888888888888888888888888888888888888888888888"
+	ccipRefID := "0x7777777777777777777777777777777777777777777777777777777777777777"
 	executingCallbackParams := &transaction.Argument{}
 
 	testCases := []string{
@@ -263,7 +264,6 @@ func TestEncodeEntryPointArg_Offramp(t *testing.T) {
 		"apply_source_chain_config_updates",
 		"set_ocr3_config",
 		"transfer_ownership",
-		"execute_ownership_transfer",
 	}
 
 	for _, fn := range testCases {
@@ -294,11 +294,87 @@ func TestEncodeEntryPointArg_Offramp(t *testing.T) {
 			assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
 		})
 	}
+
+	t.Run("execute_ownership_transfer", func(t *testing.T) {
+		data := serializeAddress(ccipRefID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"offramp",
+			"execute_ownership_transfer",
+			stateObjID,
+			data,
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "offramp", result.Module.ModuleName)
+		assert.Equal(t, "mcms_execute_ownership_transfer", result.Function)
+
+		require.Len(t, result.CallArgs, 5, "Expected 5 arguments: ccipRef, state, registry, deployer_state, executingCallbackParams")
+
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+
+		deployerStateFromResult, err := extractObjectID(result.CallArgs[3])
+		require.NoError(t, err, "Failed to extract deployer state object ID")
+		assert.Equal(t, encoder.deployerStateObjID, deployerStateFromResult, "Deployer state should match deployerStateObjID")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"offramp",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "offramp", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
+		})
+	}
+
+	addRemovePackageIDTestCases := []string{"add_package_id", "remove_package_id"}
+	for _, fn := range addRemovePackageIDTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"offramp",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "offramp", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
+		})
+	}
 }
 
 func TestEncodeEntryPointArg_Onramp(t *testing.T) {
 	encoder := &CCIPEntrypointArgEncoder{
-		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+		registryObjID:      "0x1234567890123456789012345678901234567890123456789012345678901234",
+		deployerStateObjID: "0x5555555555555555555555555555555555555555555555555555555555555555",
 	}
 
 	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
@@ -352,7 +428,6 @@ func TestEncodeEntryPointArg_Onramp(t *testing.T) {
 		"apply_dest_chain_config_updates",
 		"apply_allowlist_updates",
 		"transfer_ownership",
-		"execute_ownership_transfer",
 	}
 
 	for _, fn := range ccipTestCases {
@@ -383,11 +458,87 @@ func TestEncodeEntryPointArg_Onramp(t *testing.T) {
 			assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
 		})
 	}
+
+	t.Run("execute_ownership_transfer", func(t *testing.T) {
+		data := serializeAddress(ccipRefID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"onramp",
+			"execute_ownership_transfer",
+			stateObjID,
+			data,
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "onramp", result.Module.ModuleName)
+		assert.Equal(t, "mcms_execute_ownership_transfer", result.Function)
+
+		require.Len(t, result.CallArgs, 5, "Expected 5 arguments: ccipRef, state, registry, deployer_state, executingCallbackParams")
+
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+
+		deployerStateFromResult, err := extractObjectID(result.CallArgs[3])
+		require.NoError(t, err, "Failed to extract deployer state object ID")
+		assert.Equal(t, encoder.deployerStateObjID, deployerStateFromResult, "Deployer state should match deployerStateObjID")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"onramp",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "onramp", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
+		})
+	}
+
+	addRemovePackageIDTestCases := []string{"add_package_id", "remove_package_id"}
+	for _, fn := range addRemovePackageIDTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"onramp",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "onramp", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
+		})
+	}
 }
 
 func TestEncodeEntryPointArg_Router(t *testing.T) {
 	encoder := &CCIPEntrypointArgEncoder{
-		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+		registryObjID:      "0x1234567890123456789012345678901234567890123456789012345678901234",
+		deployerStateObjID: "0x8888888888888888888888888888888888888888888888888888888888888888",
 	}
 
 	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
@@ -419,6 +570,93 @@ func TestEncodeEntryPointArg_Router(t *testing.T) {
 		stateFromResult, err := extractObjectID(result.CallArgs[0])
 		require.NoError(t, err, "Failed to extract state object ID")
 		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+	})
+
+	t.Run("transfer_ownership", func(t *testing.T) {
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"router",
+			"transfer_ownership",
+			stateObjID,
+			[]byte{},
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "router", result.Module.ModuleName)
+		assert.Equal(t, "mcms_transfer_ownership", result.Function)
+		require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+		stateFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
+	})
+
+	t.Run("execute_ownership_transfer", func(t *testing.T) {
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"router",
+			"execute_ownership_transfer",
+			stateObjID,
+			[]byte{},
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "router", result.Module.ModuleName)
+		assert.Equal(t, "mcms_execute_ownership_transfer", result.Function)
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, registry, deployer_state, executingCallbackParams")
+
+		deployerStateFromResult, err := extractObjectID(result.CallArgs[2])
+		require.NoError(t, err, "Failed to extract deployer state object ID")
+		assert.Equal(t, encoder.deployerStateObjID, deployerStateFromResult, "Deployer state should match deployerStateObjID")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"router",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "router", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
+		})
+	}
+
+	t.Run("set_on_ramps", func(t *testing.T) {
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"router",
+			"set_on_ramps",
+			stateObjID,
+			[]byte{},
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "router", result.Module.ModuleName)
+		assert.Equal(t, "mcms_set_on_ramps", result.Function)
+		require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+		stateFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
 	})
 }
 
@@ -552,6 +790,54 @@ func TestEncodeEntryPointArg_BurnMintTokenPool(t *testing.T) {
 			stateFromResult, err := extractObjectID(result.CallArgs[0])
 			require.NoError(t, err, "Failed to extract state object ID")
 			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
+		})
+	}
+
+	t.Run("destroy_token_pool", func(t *testing.T) {
+		ccipRefID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		data := serializeAddress(ccipRefID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"burn_mint_token_pool",
+			"destroy_token_pool",
+			stateObjID,
+			data,
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "burn_mint_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_destroy_token_pool", result.Function)
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ccipRef, state, registry, executingCallbackParams")
+
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"burn_mint_token_pool",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "burn_mint_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
 		})
 	}
 }
@@ -689,6 +975,111 @@ func TestEncodeEntryPointArg_LockReleaseTokenPool(t *testing.T) {
 			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
 		})
 	}
+
+	noDataTestCases := []string{"destroy_rebalancer_cap", "withdraw_liquidity"}
+	for _, fn := range noDataTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"lock_release_token_pool",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
+		})
+	}
+
+	t.Run("provide_liquidity", func(t *testing.T) {
+		rebalancerCapID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		coinID := "0x6666666666666666666666666666666666666666666666666666666666666666"
+		data := serializeAddresses(stateObjID, rebalancerCapID, coinID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"lock_release_token_pool",
+			"provide_liquidity",
+			stateObjID,
+			data,
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_provide_liquidity", result.Function)
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, registry, coin, executingCallbackParams")
+
+		stateFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract state object ID")
+		assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
+
+		coinFromResult, err := extractObjectID(result.CallArgs[2])
+		require.NoError(t, err, "Failed to extract coin object ID")
+		assert.Equal(t, coinID, coinFromResult, "Coin should match the third address in data")
+	})
+
+	t.Run("destroy_token_pool", func(t *testing.T) {
+		ccipRefID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		data := serializeAddress(ccipRefID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"lock_release_token_pool",
+			"destroy_token_pool",
+			stateObjID,
+			data,
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_destroy_token_pool", result.Function)
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ccipRef, state, registry, executingCallbackParams")
+
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"lock_release_token_pool",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "lock_release_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
+		})
+	}
 }
 
 func TestEncodeEntryPointArg_ManagedTokenPool(t *testing.T) {
@@ -823,11 +1214,60 @@ func TestEncodeEntryPointArg_ManagedTokenPool(t *testing.T) {
 			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID (from BCS data)")
 		})
 	}
+
+	t.Run("destroy_token_pool", func(t *testing.T) {
+		ccipRefID := "0x7777777777777777777777777777777777777777777777777777777777777777"
+		data := serializeAddress(ccipRefID)
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"managed_token_pool",
+			"destroy_token_pool",
+			stateObjID,
+			data,
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "managed_token_pool", result.Module.ModuleName)
+		assert.Equal(t, "mcms_destroy_token_pool", result.Function)
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ccipRef, state, registry, executingCallbackParams")
+
+		ccipRefFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err, "Failed to extract ccipRef object ID")
+		assert.Equal(t, ccipRefID, ccipRefFromResult, "CcipRef should match ccipRefID (from BCS data)")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"managed_token_pool",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "managed_token_pool", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
+		})
+	}
 }
 
 func TestEncodeEntryPointArg_ManagedToken(t *testing.T) {
 	encoder := &CCIPEntrypointArgEncoder{
-		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+		registryObjID:      "0x1234567890123456789012345678901234567890123456789012345678901234",
+		deployerStateObjID: "0x8888888888888888888888888888888888888888888888888888888888888888",
 	}
 
 	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
@@ -894,6 +1334,7 @@ func TestEncodeEntryPointArg_ManagedToken(t *testing.T) {
 		"blocklist",
 		"unblocklist",
 		"pause",
+		"unpause",
 	}
 
 	for _, fn := range denyListTestCases {
@@ -925,11 +1366,83 @@ func TestEncodeEntryPointArg_ManagedToken(t *testing.T) {
 			assert.Equal(t, toHexString(createAddress(denyListID)), denyListFromResult, "DenyList should match deserialized value from data")
 		})
 	}
+
+	stateArgTestCases := []string{"destroy_managed_token", "transfer_ownership"}
+	for _, fn := range stateArgTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"managed_token",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "managed_token", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: state, registry, executingCallbackParams")
+
+			stateFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err, "Failed to extract state object ID")
+			assert.Equal(t, stateObjID, stateFromResult, "State should match stateObjID")
+		})
+	}
+
+	t.Run("execute_ownership_transfer", func(t *testing.T) {
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"managed_token",
+			"execute_ownership_transfer",
+			stateObjID,
+			[]byte{},
+			[]string{"0x1::sui::SUI"},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "managed_token", result.Module.ModuleName)
+		assert.Equal(t, "mcms_execute_ownership_transfer", result.Function)
+		require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: state, registry, deployer_state, executingCallbackParams")
+
+		deployerStateFromResult, err := extractObjectID(result.CallArgs[2])
+		require.NoError(t, err, "Failed to extract deployer state object ID")
+		assert.Equal(t, encoder.deployerStateObjID, deployerStateFromResult, "Deployer state should match deployerStateObjID")
+	})
+
+	addRemoveModulesTestCases := []string{"add_allowed_modules", "remove_allowed_modules"}
+	for _, fn := range addRemoveModulesTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"managed_token",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{"0x1::sui::SUI"},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "managed_token", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.TypeArgs, 1, "Expected 1 type argument")
+			require.Len(t, result.CallArgs, 2, "Expected 2 arguments: registry, executingCallbackParams")
+		})
+	}
 }
 
 func TestEncodeEntryPointArg_StateObject(t *testing.T) {
 	encoder := &CCIPEntrypointArgEncoder{
-		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+		registryObjID:      "0x1234567890123456789012345678901234567890123456789012345678901234",
+		deployerStateObjID: "0x8888888888888888888888888888888888888888888888888888888888888888",
 	}
 
 	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
@@ -968,6 +1481,85 @@ func TestEncodeEntryPointArg_StateObject(t *testing.T) {
 			assert.Equal(t, encoder.registryObjID, registryFromResult, "First arg should be the registry object")
 		})
 	}
+
+	stateArgTestCases := []string{"transfer_ownership", "add_package_id", "remove_package_id"}
+	for _, fn := range stateArgTestCases {
+		t.Run(fn, func(t *testing.T) {
+			result, err := encoder.EncodeEntryPointArg(
+				executingCallbackParams,
+				target,
+				"state_object",
+				fn,
+				stateObjID,
+				[]byte{},
+				[]string{},
+			)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "state_object", result.Module.ModuleName)
+			assert.Equal(t, "mcms_"+fn, result.Function)
+			require.Len(t, result.CallArgs, 3, "Expected 3 arguments: ref, registry, executingCallbackParams")
+
+			refFromResult, err := extractObjectID(result.CallArgs[0])
+			require.NoError(t, err)
+			assert.Equal(t, stateObjID, refFromResult, "First arg should be the CCIPObjectRef/state object")
+		})
+	}
+
+	t.Run("execute_ownership_transfer", func(t *testing.T) {
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"state_object",
+			"execute_ownership_transfer",
+			stateObjID,
+			[]byte{},
+			[]string{},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "state_object", result.Module.ModuleName)
+		assert.Equal(t, "mcms_execute_ownership_transfer", result.Function)
+		require.Len(t, result.CallArgs, 4, "Expected 4 arguments: ref, registry, deployer_state, executingCallbackParams")
+
+		deployerStateFromResult, err := extractObjectID(result.CallArgs[2])
+		require.NoError(t, err, "Failed to extract deployer state object ID")
+		assert.Equal(t, encoder.deployerStateObjID, deployerStateFromResult, "Deployer state should match deployerStateObjID")
+	})
+}
+
+func TestEncodeEntryPointArg_ReceiverRegistry(t *testing.T) {
+	encoder := &CCIPEntrypointArgEncoder{
+		registryObjID: "0x1234567890123456789012345678901234567890123456789012345678901234",
+	}
+
+	target := "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
+	executingCallbackParams := &transaction.Argument{}
+
+	t.Run("unregister_receiver", func(t *testing.T) {
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"receiver_registry",
+			"unregister_receiver",
+			stateObjID,
+			[]byte{},
+			[]string{},
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "receiver_registry", result.Module.ModuleName)
+		assert.Equal(t, "mcms_unregister_receiver", result.Function)
+		require.Len(t, result.CallArgs, 3, "Expected 3 arguments: ref, registry, executingCallbackParams")
+
+		refFromResult, err := extractObjectID(result.CallArgs[0])
+		require.NoError(t, err)
+		assert.Equal(t, stateObjID, refFromResult, "First arg should be the CCIPObjectRef")
+	})
 }
 
 func TestEncodeEntryPointArg_UnknownModule(t *testing.T) {
@@ -979,7 +1571,7 @@ func TestEncodeEntryPointArg_UnknownModule(t *testing.T) {
 	stateObjID := "0x9999999999999999999999999999999999999999999999999999999999999999"
 	executingCallbackParams := &transaction.Argument{}
 
-	t.Run("fallback_to_default_encoder", func(t *testing.T) {
+	t.Run("unrecognized_module_and_function_errors", func(t *testing.T) {
 		data := []byte{}
 
 		result, err := encoder.EncodeEntryPointArg(
@@ -992,10 +1584,28 @@ func TestEncodeEntryPointArg_UnknownModule(t *testing.T) {
 			[]string{"0x1::sui::SUI"},
 		)
 
-		require.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.Equal(t, "unknown_module", result.Module.ModuleName)
-		assert.Equal(t, "mcms_unknown_function", result.Function)
+		require.Error(t, err, "unrecognized module/function must not silently fall back to a guessed encoding")
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "unknown_module")
+		assert.Contains(t, err.Error(), "unknown_function")
+	})
+
+	t.Run("known_module_unrecognized_function_errors", func(t *testing.T) {
+		data := []byte{}
+
+		result, err := encoder.EncodeEntryPointArg(
+			executingCallbackParams,
+			target,
+			"router",
+			"unknown_function",
+			stateObjID,
+			data,
+			[]string{},
+		)
+
+		require.Error(t, err, "unrecognized function on a known module must not silently fall back")
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "unknown_function")
 	})
 }
 
@@ -1194,6 +1804,32 @@ func TestEncodeEntryPointArg_RmnRemoteCurserCapCurse(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "mcms_curse_multiple_with_curser_cap", encoded.Function)
 	require.Equal(t, "rmn_remote", encoded.Module.ModuleName)
+}
+
+func TestEncodeEntryPointArg_RmnRemoteSetConfig(t *testing.T) {
+	t.Parallel()
+
+	registryObjID := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	deployerStateObjID := "0x8888888888888888888888888888888888888888888888888888888888888888"
+	encoder := NewCCIPEntrypointArgEncoder(registryObjID, deployerStateObjID)
+
+	ccipRef := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	data := serializeAddress(ccipRef)
+
+	paramsArg := transaction.Argument{}
+	encoded, err := encoder.EncodeEntryPointArg(
+		&paramsArg,
+		ccipRef,
+		"rmn_remote",
+		"set_config",
+		ccipRef,
+		data,
+		nil,
+	)
+	require.NoError(t, err, "rmn_remote.mcms_set_config must be encoded, not explicitly rejected")
+	require.Equal(t, "mcms_set_config", encoded.Function)
+	require.Equal(t, "rmn_remote", encoded.Module.ModuleName)
+	require.Len(t, encoded.CallArgs, 3, "Expected 3 arguments: ccipRef, registry, executingCallbackParams")
 }
 
 func TestEncodeEntryPointArg_RmnRemoteCreateCurserCapAndTransfer(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix `bindings/mcms_encoder.go`'s `CCIPEntrypointArgEncoder` fell through to a hardcoded `fee_quoter::mcms_apply_fee_token_updates` 3-arg shape for any MCMS callback it didn't explicitly handle — wrong for almost anything else (missing type args, missing `CCIPObjectRef`/`Coin<T>`/`DenyList`/`DeployerState`, or an extra unwanted argument).