### PR TITLE
Enhancement: add relayer rescan / replay command

### DIFF
--- a/documentation/relayer/configuration.md
+++ b/documentation/relayer/configuration.md
@@ -219,6 +219,7 @@ PollingIntervalSecs = 2
 SyncTimeoutSecs = 60
 ChannelBufferSize = 16
 BackfillCheckpointCount = 100
+ReplayCheckpointCount = 100         # checkpoints re-scanned per Replay request (0 = to latest)
 # StartCheckpointSequence = 12345   # optional; overrides backfill when set
 ```
 
@@ -227,8 +228,9 @@ BackfillCheckpointCount = 100
 | `PollingIntervalSecs` | uint64 | `2` | How often live polling checks for new checkpoints |
 | `SyncTimeoutSecs` | uint64 | `60` | Timeout for processing a single checkpoint |
 | `ChannelBufferSize` | uint64 | `16` | Buffer size of the events/transactions channels |
-| `BackfillCheckpointCount` | uint64 | `100` | Start at `latest - N`; also the rewind span used when a new selector triggers a rescan |
+| `BackfillCheckpointCount` | uint64 | `100` | Start at `latest - N` |
 | `StartCheckpointSequence` | uint64 | _unset_ | Explicit starting checkpoint sequence (overrides backfill) |
+| `ReplayCheckpointCount` | uint64 | `100` | Checkpoints re-scanned per `Replay` request, starting at the requested checkpoint; an explicit `0` re-scans to the latest checkpoint |
 
 > **Note**: In the relayer's own TOML the chain block is keyed `[[Sui]]` with `[[Sui.Nodes]]`, `[Sui.ChainPoller]`, `[Sui.TransactionManager]`, etc. The `[[Chains]]` form used elsewhere in this document is illustrative.
 

--- a/documentation/relayer/event-indexing.md
+++ b/documentation/relayer/event-indexing.md
@@ -157,9 +157,11 @@ Selectors are registered with the `EventsIndexer` (and therefore become visible 
 
 `AddEventSelector` is idempotent, so re-binding never creates duplicates.
 
-### Rescans on new selectors
+### Replay (rescanning checkpoints)
 
-A selector can only be registered once its contract is discovered and bound. By then the poller may have already processed — and, lacking the selector, discarded — checkpoints that carried matching events. To recover them, registering a new selector triggers `RescanRecent`, which rewinds the poller's in-memory `lastProcessed` cursor so those recent checkpoints are re-scanned. The rewind span is the configured backfill window (`BackfillCheckpointCount`, default `100`); re-inserts are idempotent.
+The core node can request a replay via the relayer's `Replay(ctx, fromBlock, args)` command, where `fromBlock` is a checkpoint sequence number in decimal. The relayer forwards it to the poller's `RescanFrom`, which re-enqueues a window of `ReplayCheckpointCount` checkpoints (default `100`; an explicit `0` re-scans all the way to the latest checkpoint) starting at the requested checkpoint, capped at the chain tip. Re-inserts are idempotent, so replaying already-indexed checkpoints is safe.
+
+A replay request is rejected with an error when the requested checkpoint is ahead of the chain tip or has been pruned from the RPC provider's history (the error names the lowest available checkpoint so the request can be retried from there).
 
 ## Backfill & start sequence
 
@@ -190,8 +192,9 @@ type ChainPollerConfig struct {
 | `PollingIntervalSecs` | `2` | How often live polling checks for new checkpoints |
 | `SyncTimeoutSecs` | `60` | Timeout for processing a single checkpoint |
 | `ChannelBufferSize` | `16` | Buffer size of the events/transactions channels |
-| `BackfillCheckpointCount` | `100` | Backfill window (start at `latest - N`) and rescan rewind span |
+| `BackfillCheckpointCount` | `100` | Backfill window (start at `latest - N`) |
 | `StartCheckpointSequence` | _unset_ | Explicit start sequence (overrides backfill) |
+| `ReplayCheckpointCount` | `100` | Checkpoints re-scanned per Replay request, starting at the requested checkpoint; an explicit `0` re-scans to the latest checkpoint |
 
 > The legacy `[Sui.ChainReader] EventsIndexer.*` / `TransactionsIndexer.*` polling settings no longer drive checkpoint fetching — the single ChainPoller does. See [Configuration](./configuration.md).
 
@@ -236,7 +239,7 @@ On `Close`, the poller's context is cancelled, which closes the channels; the co
 | Symptom | Likely cause | What to check |
 |---------|--------------|---------------|
 | Events for a contract never appear | Selector never registered | Confirm the contract was bound and `AddEventSelector` ran; check the "Registered event selector" log line |
-| Events around bind time are missing | Poller advanced past them before the selector existed | Confirm a rescan fired (`Rewinding poller to re-scan...`); increase `BackfillCheckpointCount` |
+| Events around bind time are missing | Poller advanced past them before the selector existed | Trigger a `Replay` from a checkpoint before the bind; increase `BackfillCheckpointCount` |
 | Indexer lags the chain | `PollingInterval` too high or node slow on `GetCheckpointData` | Lower `PollingIntervalSecs`; check node gRPC latency and the indexer client's connection pool |
 | `checkpoint not found` warnings | The poller reached a checkpoint not yet produced | Benign at the chain tip; the poller retries on the next tick |
 | No synthetic failure events | Transmitters/OffRamp not yet known | Confirm OffRamp is bound and a `ConfigSet` event has been indexed |

--- a/relayer/chainreader/indexer/chain_poller.go
+++ b/relayer/chainreader/indexer/chain_poller.go
@@ -36,8 +36,9 @@ const (
 	minStalledTicksBeforeRetry = 2
 	// chunkQueueSizeMultiplier sizes the chunk queue relative to the worker count.
 	chunkQueueSizeMultiplier = 4
-	// defaultRescanRewindCheckpoints is how far RescanRecent rewinds when no explicit backfill window is set.
-	defaultRescanRewindCheckpoints uint64 = 100
+	// defaultRescanCheckpointCount is how many checkpoints RescanFrom covers when the config does
+	// not set ReplayCheckpointCount.
+	defaultRescanCheckpointCount uint64 = 100
 	// minStartSequence is a value used as a fallback to avoid using 0 and doing a full chain rescan
 	// when the required configs are missing and the RPC node used is a full archive node
 	minStartSequence uint64 = 299_000_000
@@ -49,9 +50,9 @@ type ChainPollerAPI interface {
 	Start(ctx context.Context) error
 	EventsChannel() <-chan CheckpointEventsBatch
 	TransactionsChannel() <-chan CheckpointTransactionsBatch
-	// RescanRecent rewinds the poller so recently-processed checkpoints are re-scanned (used when a new
-	// event selector is registered after the poller has already advanced past the events it matches).
-	RescanRecent()
+	// RescanFrom re-enqueues a bounded window of checkpoints starting at fromSeq so
+	// already-processed checkpoints are re-scanned (triggered by the relayer's Replay command).
+	RescanFrom(ctx context.Context, fromSeq uint64) error
 	Close() error
 }
 
@@ -96,6 +97,14 @@ func WithCursorStore(store CheckpointCursorStore, id string) PollerOption {
 	}
 }
 
+// WithRescanCheckpointCount sets how many checkpoints RescanFrom covers per replay request.
+// Zero means the rescan extends to the latest checkpoint.
+func WithRescanCheckpointCount(count uint64) PollerOption {
+	return func(cp *ChainPoller) {
+		cp.rescanCount = count
+	}
+}
+
 // ChainPoller implements checkpoint-based polling for the Sui chain.
 // It fetches checkpoints concurrently in bounded chunks, reorders the results via a sequencer,
 // and sends events and transactions strictly in checkpoint order over channels to the indexers.
@@ -113,6 +122,7 @@ type ChainPoller struct {
 	chunkSize       int
 	maxPending      int // reorder-buffer capacity: workers * chunkSize
 	maxStalledTicks int
+	rescanCount     uint64 // checkpoints covered per RescanFrom request; 0 rescans to the latest
 
 	sequencer   *checkpointSequencer
 	chunkCh     chan chunkRange
@@ -154,6 +164,7 @@ func NewChainPoller(
 		workers:          defaultMaxConcurrentWorkers,
 		chunkSize:        defaultCatchupChunkSize,
 		maxStalledTicks:  defaultMaxStalledTicksBeforeSkip,
+		rescanCount:      defaultRescanCheckpointCount,
 	}
 
 	for _, opt := range opts {
@@ -511,34 +522,52 @@ func (cp *ChainPoller) getLatestCheckpointSequence(ctx context.Context) (uint64,
 	return seq, nil
 }
 
-// RescanRecent enqueues the most recent N checkpoints for re-scanning. Results below the
-// sequencer watermark bypass ordering and are re-emitted directly; inserts are idempotent.
-func (cp *ChainPoller) RescanRecent() {
-	latestCheckpoint, err := cp.getLatestCheckpointSequence(context.Background())
+// RescanFrom enqueues up to rescanCount checkpoints starting at fromSeq (capped at the chain tip;
+// a zero rescanCount rescans all the way to the tip) for re-scanning. Results below the sequencer
+// watermark bypass ordering and are re-emitted directly; inserts are idempotent. It rejects a
+// fromSeq the provider has already pruned or that is ahead of the chain tip.
+func (cp *ChainPoller) RescanFrom(ctx context.Context, fromSeq uint64) error {
+	latestCheckpoint, err := cp.getLatestCheckpointSequence(ctx)
 	if err != nil {
-		cp.logger.Errorw("Failed to get latest checkpoint", "error", err)
-		return
+		return fmt.Errorf("failed to get latest checkpoint: %w", err)
 	}
 
-	startSeq := uint64(0)
-	if latestCheckpoint > defaultRescanRewindCheckpoints {
-		startSeq = latestCheckpoint - defaultRescanRewindCheckpoints
+	if fromSeq > latestCheckpoint {
+		return fmt.Errorf("rescan start checkpoint %d is ahead of the latest checkpoint %d", fromSeq, latestCheckpoint)
 	}
 
-	for from := startSeq; from <= latestCheckpoint; {
-		end := min(from+cp.chunkSpan()-1, latestCheckpoint)
+	if lowest := cp.providerLowestAvailable(ctx); lowest > fromSeq {
+		return fmt.Errorf(
+			"rescan start checkpoint %d is no longer available from the RPC provider (pruned; lowest available is %d)",
+			fromSeq, lowest,
+		)
+	}
+
+	// Rescanning can be done upto the current latest checkpoint unless
+	// the `rescanCount` config value is set. This clause allows for the TOML
+	// configs to explicitly set the behavior of setting `PollerReplayCheckpointCount`
+	// to 0 to allow for rescanning upto latest.
+	endSeq := latestCheckpoint
+	if cp.rescanCount != 0 {
+		endSeq = min(fromSeq+cp.rescanCount-1, latestCheckpoint)
+	}
+
+	cp.logger.Infow("Rescanning checkpoints", "fromSequence", fromSeq, "toSequence", endSeq)
+
+	for from := fromSeq; from <= endSeq; {
+		end := min(from+cp.chunkSpan()-1, endSeq)
 		select {
 		case cp.chunkCh <- chunkRange{start: from, end: end}:
 			from = end + 1
 		default:
-			cp.logger.Warnw(
-				"Chunk queue full, dropping remainder of rescan range",
-				"droppedFrom", from,
-				"droppedTo", latestCheckpoint,
+			return fmt.Errorf(
+				"chunk queue full: enqueued rescan of [%d, %d], dropped [%d, %d]; retry replay for the dropped range",
+				fromSeq, from-1, from, endSeq,
 			)
-			return
 		}
 	}
+
+	return nil
 }
 
 // catchUp processes checkpoints from startSeq to endSeq (inclusive).
@@ -646,7 +675,7 @@ func (cp *ChainPoller) processCheckpoint(ctx context.Context, seq uint64) error 
 	// Skip the fetch when the result is already buffered awaiting emission — a duplicate
 	// submit would be dropped anyway, so re-fetching (e.g. from a stall retry overlapping an
 	// in-flight chunk) is wasted RPC. Below-watermark sequences are still fetched so
-	// RescanRecent can re-emit them.
+	// RescanFrom can re-emit them.
 	if cp.sequencer.isPending(seq) {
 		cp.logger.Debugw("Checkpoint already buffered, skipping fetch", "sequence", seq)
 		return nil

--- a/relayer/chainreader/indexer/chain_poller_concurrent_test.go
+++ b/relayer/chainreader/indexer/chain_poller_concurrent_test.go
@@ -364,9 +364,9 @@ func TestPollerRescanRecentReEmitsBelowWatermark(t *testing.T) {
 		return len(firstOccurrences(collected())) == 160-150+1
 	}, 10*time.Second, 10*time.Millisecond)
 
-	// Rescan rewinds 100 checkpoints behind the latest (160 → 60) and re-enqueues them; results
-	// below the watermark bypass ordering and are re-emitted directly.
-	cp.RescanRecent()
+	// Rescan re-enqueues [60, 159] (default window of 100 checkpoints from the requested start);
+	// results below the watermark bypass ordering and are re-emitted directly.
+	require.NoError(t, cp.RescanFrom(context.Background(), 60))
 
 	require.Eventually(t, func() bool {
 		return mockClient.processed(60) >= 1 && mockClient.processed(155) >= 2

--- a/relayer/chainreader/indexer/indexer.go
+++ b/relayer/chainreader/indexer/indexer.go
@@ -55,10 +55,10 @@ type IndexerApi interface {
 	Close() error
 	GetEventIndexer() EventsIndexerApi
 	GetTransactionIndexer() TransactionsIndexerApi
-	// RescanRecentCheckpoints rewinds the ChainPoller so recently-processed checkpoints are re-scanned.
-	// The ChainReader calls this after a Bind registers new event selectors, so events the poller already
-	// processed and discarded (before the selector existed) are picked up on a second pass.
-	RescanRecentCheckpoints()
+	// RescanFromCheckpoint rewinds the ChainPoller so a bounded window of checkpoints starting at
+	// fromSeq is re-scanned. The relayer calls this when the core node requests a Replay, so events
+	// and transactions the poller already processed (or missed) are picked up on a second pass.
+	RescanFromCheckpoint(ctx context.Context, fromSeq uint64) error
 }
 
 // Params holds the dependencies needed to construct a fully-wired Indexer via NewIndexer.
@@ -73,6 +73,9 @@ type Params struct {
 	// PollerChunkSize is the number of checkpoints per catch-up chunk; non-positive values use
 	// the ChainPoller default.
 	PollerChunkSize int
+	// PollerReplayCheckpointCount is how many checkpoints a Replay request re-scans, starting from
+	// the requested checkpoint; zero re-scans all the way to the latest checkpoint.
+	PollerReplayCheckpointCount uint64
 	// EventSelectors optionally seeds the EventsIndexer. Selectors are normally registered later
 	// when the ChainReader binds contracts, so this is usually left nil/empty.
 	EventSelectors []*sui.EventFilterByMoveEventModule
@@ -107,6 +110,7 @@ func NewIndexer(p Params) *Indexer {
 		eventsIndexer.GetEventSelectors,
 		WithWorkerPool(p.PollerWorkers, p.PollerChunkSize),
 		WithCursorStore(dbStore, checkpointCursorID),
+		WithRescanCheckpointCount(p.PollerReplayCheckpointCount),
 	)
 
 	idx := NewIndexerFromComponents(p.Logger, chainPoller, eventsIndexer, txnIndexer)
@@ -276,11 +280,12 @@ func (i *Indexer) GetTransactionIndexer() TransactionsIndexerApi {
 	return i.transactionIndexer
 }
 
-// RescanRecentCheckpoints rewinds the ChainPoller so recently-processed checkpoints are re-scanned. See
-// the IndexerApi docs: the ChainReader calls this after a Bind registers new event selectors.
-func (i *Indexer) RescanRecentCheckpoints() {
+// RescanFromCheckpoint rewinds the ChainPoller so a bounded window of checkpoints starting at
+// fromSeq is re-scanned. See the IndexerApi docs: the relayer calls this when the core node
+// requests a Replay.
+func (i *Indexer) RescanFromCheckpoint(ctx context.Context, fromSeq uint64) error {
 	if i.chainPoller == nil {
-		return
+		return errors.New("chain poller not configured")
 	}
-	i.chainPoller.RescanRecent()
+	return i.chainPoller.RescanFrom(ctx, fromSeq)
 }

--- a/relayer/chainreader/reader/chainreader.go
+++ b/relayer/chainreader/reader/chainreader.go
@@ -259,8 +259,6 @@ func (s *suiChainReader) registerConfiguredEventSelectors(ctx context.Context, b
 	s.logger.Infow("Registering configured event selectors at bind",
 		"contract", binding.Name, "address", binding.Address, "eventCount", len(moduleConfig.Events))
 
-	selectorsBefore := len(evIndexer.GetEventSelectors())
-
 	for eventKey, eventConfig := range moduleConfig.Events {
 		if eventConfig == nil {
 			continue
@@ -306,13 +304,6 @@ func (s *suiChainReader) registerConfiguredEventSelectors(ctx context.Context, b
 			"package", binding.Address,
 			"module", module,
 			"event", event)
-	}
-
-	// If this bind registered any new selectors, the poller may have already advanced past the
-	// checkpoints carrying their events (selectors register only after the contract is discovered/bound).
-	// Rewind it once to re-scan those checkpoints with the new selectors; re-inserts are idempotent.
-	if len(evIndexer.GetEventSelectors()) > selectorsBefore {
-		s.indexer.RescanRecentCheckpoints()
 	}
 }
 

--- a/relayer/config/chain_config.go
+++ b/relayer/config/chain_config.go
@@ -26,6 +26,7 @@ const (
 	DefaultChainPollerBackfillCheckpointCount = uint64(100)
 	DefaultChainPollerMaxConcurrentWorkers    = uint64(8)
 	DefaultChainPollerCatchupChunkSize        = uint64(12)
+	DefaultChainPollerReplayCheckpointCount   = uint64(100)
 
 	DefaultReaperPollSecs           = uint64(10)
 	DefaultTransactionRetentionSecs = uint64(10)

--- a/relayer/config/toml_config.go
+++ b/relayer/config/toml_config.go
@@ -212,6 +212,10 @@ type ChainPollerConfig struct {
 	MaxConcurrentWorkers *uint64
 	// CatchupChunkSize is the number of checkpoints per catch-up chunk handed to a worker.
 	CatchupChunkSize *uint64
+	// ReplayCheckpointCount is how many checkpoints a Replay request re-scans, starting from the
+	// requested checkpoint. An explicit 0 re-scans all the way to the latest checkpoint; the
+	// default only applies when the field is unset.
+	ReplayCheckpointCount *uint64
 }
 
 func (c *ChainPollerConfig) setDefaults() {
@@ -238,6 +242,10 @@ func (c *ChainPollerConfig) setDefaults() {
 	if c.CatchupChunkSize == nil {
 		v := DefaultChainPollerCatchupChunkSize
 		c.CatchupChunkSize = &v
+	}
+	if c.ReplayCheckpointCount == nil {
+		v := DefaultChainPollerReplayCheckpointCount
+		c.ReplayCheckpointCount = &v
 	}
 }
 
@@ -412,6 +420,9 @@ func setFromChainPoller(c, f *ChainPollerConfig) {
 	}
 	if f.CatchupChunkSize != nil {
 		c.CatchupChunkSize = f.CatchupChunkSize
+	}
+	if f.ReplayCheckpointCount != nil {
+		c.ReplayCheckpointCount = f.ReplayCheckpointCount
 	}
 }
 

--- a/relayer/plugin/relayer.go
+++ b/relayer/plugin/relayer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -171,12 +172,13 @@ func NewRelayer(cfg *config.TOMLConfig, lggr logger.Logger, keystore core.Keysto
 	// Create main indexer that constructs and orchestrates the poller + consumer indexers.
 	// A separate client (suiClientIndexers) is used for the poller to avoid rate limiting.
 	indexerInstance := indexer.NewIndexer(indexer.Params{
-		Logger:          loggerInstance,
-		DB:              db,
-		Client:          suiClientIndexers,
-		PollerConfig:    pollerConfig,
-		PollerWorkers:   pollerWorkers,
-		PollerChunkSize: pollerChunkSize,
+		Logger:                      loggerInstance,
+		DB:                          db,
+		Client:                      suiClientIndexers,
+		PollerConfig:                pollerConfig,
+		PollerWorkers:               pollerWorkers,
+		PollerChunkSize:             pollerChunkSize,
+		PollerReplayCheckpointCount: *cfg.ChainPoller.ReplayCheckpointCount,
 	})
 
 	loggerInstance.Infof("Creating retry manager. NumberRetries: %d", *cfg.TransactionManager.MaxTxRetryAttempts)
@@ -369,10 +371,17 @@ func (r *SuiRelayer) NewAutomationProvider(ctx context.Context, rargs types.Rela
 	return nil, errors.New("automation not supported for Sui")
 }
 
-// Replay implements the transaction replay functionality.
-// Currently not supported for Sui.
-func (r *SuiRelayer) Replay(ctx context.Context, chainID string, data map[string]any) error {
-	return errors.New("replay not supported for Sui")
+// Replay re-scans a window of checkpoints starting at the given sequence (ChainPoller's
+// ReplayCheckpointCount, capped at the chain tip; 0 re-scans to the tip) so their events and
+// transactions are re-indexed. fromBlock is a Sui checkpoint sequence number in decimal; args
+// is unused. Re-inserts are idempotent, so replaying already-indexed checkpoints is safe.
+func (r *SuiRelayer) Replay(ctx context.Context, fromBlock string, args map[string]any) error {
+	fromSeq, err := strconv.ParseUint(fromBlock, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid fromBlock %q: expected a Sui checkpoint sequence number: %w", fromBlock, err)
+	}
+
+	return r.indexer.RescanFromCheckpoint(ctx, fromSeq)
 }
 
 // NewCCIPCommitProvider returns a new CCIP commit provider for the given relay and plugin arguments.

--- a/scripts/core.config.toml
+++ b/scripts/core.config.toml
@@ -59,7 +59,8 @@ SyncTimeoutSecs = 3
 PollingIntervalSecs = 2      # how often live polling checks for new checkpoints
 SyncTimeoutSecs = 60         # timeout for processing a single checkpoint
 ChannelBufferSize = 16       # buffer size of the events/transactions channels
-BackfillCheckpointCount = 100 # start at (latest - N); also the rewind span on rescan
+BackfillCheckpointCount = 100 # start at (latest - N)
+ReplayCheckpointCount = 100   # checkpoints re-scanned per Replay request, starting at the requested checkpoint (0 = to latest)
 # StartCheckpointSequence = 12345 # optional; explicit start checkpoint (overrides backfill)
 
 


### PR DESCRIPTION
core ref: 84d0186177a9da8de4b754700989c8bcf6a0cdac

---

## Describe your changes

* Removes the `RescanRecent` indexer method previously trigged by contract binds
* Implements the plugin `Replay` method to allow for rescanning specific checkpoints. This currently works by rescanning a a set number of checkpoints starting from the checkpoint # specified in the `Replay` call params. 
    * **Important** - if the `ReplayCheckpointCount` config is set to 0. Replays will be from the specified checkpoint until the latest checkpoint. This scenario would be avoided and is only kept for flexibility. The currently default is set to 100, leaving the `ReplayCheckpointCount` value nil will use the default. Otherwise, using a small value such as 5 is sufficient.


## Issue ticket number and link

> ..


## Describe highly relevant files or code snippets that are critical in the review

> ..


## Are there other PRs that should be merged first?

> ..
